### PR TITLE
iOS app banner

### DIFF
--- a/lib/templates/html_head.tpl
+++ b/lib/templates/html_head.tpl
@@ -6,6 +6,7 @@
 <meta name="author" content="PubCie C.S.R. Delft" />
 <meta name="description" content="{Instellingen::get('stek', 'beschrijving')}">
 <meta name="google-site-verification" content="zLTm1NVzZPHx7jiGHBpe4HeH1goQAlJej2Rdc0_qKzE" />
+<meta name="apple-itunes-app" content="app-id=1112148892, app-argument={$smarty.const.CSR_ROOT}{$REQUEST_URI}">
 <meta property="og:url" content="{$smarty.const.CSR_ROOT}{$REQUEST_URI}" />
 <meta property="og:title" content="C.S.R. Delft | {$titel}" />
 <meta property="og:locale" content="nl_nl" />


### PR DESCRIPTION
Deze `<meta>` tag laat een promotie banner zien bovenaan de pagina in de iOS browser.

Meer info: https://developer.apple.com/library/ios/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html