### PR TITLE
Consistentie voor inloggen en blijvend inloggen wat betreft lock-ip

### DIFF
--- a/lib/model/security/RememberLoginModel.class.php
+++ b/lib/model/security/RememberLoginModel.class.php
@@ -28,7 +28,7 @@ class RememberLoginModel extends PersistenceModel {
 		$remember->remember_since = getDateTime();
 		$remember->device_name = '';
 		$remember->ip = $_SERVER['REMOTE_ADDR'];
-		$remember->lock_ip = true;
+		$remember->lock_ip = false;
 		return $remember;
 	}
 


### PR DESCRIPTION
Ik denk dat de onduidelijkheden en inlogproblemen hierdoor worden veroorzaakt:
- gewoon inloggen locked ip niet
- blijvend inloggen locked ip wel

Dit is nu gelijkgetrokken naar: ip lock UIT