### PR TITLE
Set api authentication method bij elke request

### DIFF
--- a/htdocs/API/2.0/api.php
+++ b/htdocs/API/2.0/api.php
@@ -30,6 +30,7 @@ if ($authHeader) {
 
 			// Register uid for this session
 			$_SESSION['_uid'] = $token->data->userId;
+			$_SESSION['_authenticationMethod'] = AuthenticationMethod::cookie_token;
 
 			// Leden
 			if (LoginModel::mag('P_OUDLEDEN_READ') && isset($_GET['cat']) && $_GET['cat'] === 'leden') {


### PR DESCRIPTION
De PHP sessions zijn niet per se persistent bij gebruik van jwt, daarom moet de `AuthenticationMethod` bij elke api request geset worden, net als de user id. 

Bijkomend voordeel is dat leden niet opnieuw hoeven in te loggen om de app weer werkend te krijgen.