### PR TITLE
Fix account actions in login controller

### DIFF
--- a/lib/controller/CmsPaginaController.class.php
+++ b/lib/controller/CmsPaginaController.class.php
@@ -105,11 +105,10 @@ class CmsPaginaController extends Controller {
 		}
 		if ($this->model->delete($pagina)) {
 			setMelding('Pagina ' . $naam . ' succesvol verwijderd', 1);
-			redirect(CSR_ROOT);
 		} else {
 			setMelding('Verwijderen mislukt', -1);
-			redirect(CSR_ROOT);
 		}
+		$this->view = new JsonResponse(CSR_ROOT); // redirect
 	}
 
 }

--- a/lib/controller/ForumController.class.php
+++ b/lib/controller/ForumController.class.php
@@ -397,7 +397,7 @@ class ForumController extends Controller {
 			ForumDelenModel::instance()->verwijderForumDeel($deel->forum_id);
 			setMelding('Deelforum verwijderd', 1);
 		}
-		$this->view = new JsonResponse(true);
+		$this->view = new JsonResponse('/forum'); // redirect
 	}
 
 	/**

--- a/lib/controller/LoginController.class.php
+++ b/lib/controller/LoginController.class.php
@@ -16,20 +16,32 @@ class LoginController extends AclController {
 				'logout'			 => 'P_LOGGED_IN',
 				'su'				 => 'P_ADMIN',
 				'endsu'				 => 'P_LOGGED_IN',
+				'verify'			 => 'P_PUBLIC',
 				'pauper'			 => 'P_PUBLIC',
-				'account'			 => 'P_LOGGED_IN',
+				'account'			 => 'P_PUBLIC',
 				'accountaanvragen'	 => 'P_PUBLIC',
+				'accountaanmaken'	 => 'P_ADMIN',
+				'accountbewerken'	 => 'P_LOGGED_IN',
+				'accountverwijderen' => 'P_LOGGED_IN',
 				'wachtwoord'		 => 'P_PUBLIC',
-				'verify'			 => 'P_PUBLIC'
+				'wachtwoordwijzigen' => 'P_LOGGED_IN',
+				'wachtwoordreset'	 => 'P_LOGGED_IN',
+				'wachtwoordvergeten' => 'P_PUBLIC',
 			);
 		} else {
 			$this->acl = array(
 				'login'				 => 'P_PUBLIC',
 				'logout'			 => 'P_LOGGED_IN',
+				'verify'			 => 'P_PUBLIC',
 				'pauper'			 => 'P_PUBLIC',
 				'account'			 => 'P_LOGGED_IN',
+				'accountaanmaken'	 => 'P_ADMIN',
+				'accountbewerken'	 => 'P_LOGGED_IN',
+				'accountverwijderen' => 'P_LOGGED_IN',
 				'wachtwoord'		 => 'P_PUBLIC',
-				'verify'			 => 'P_PUBLIC',
+				'wachtwoordwijzigen' => 'P_LOGGED_IN',
+				'wachtwoordreset'	 => 'P_LOGGED_IN',
+				'wachtwoordvergeten' => 'P_PUBLIC',
 				'loginsessionsdata'	 => 'P_LOGGED_IN',
 				'loginendsession'	 => 'P_LOGGED_IN',
 				'loginlockip'		 => 'P_LOGGED_IN',
@@ -51,11 +63,8 @@ class LoginController extends AclController {
 		if ($this->getMethod() == 'POST') {
 			parent::exit_http($response_code);
 		}
-		require_once 'model/CmsPaginaModel.class.php';
-		require_once 'view/CmsPaginaView.class.php';
-		$body = new CmsPaginaView(CmsPaginaModel::get('accountaanvragen'));
-		$this->view = new CsrLayoutPage($body);
-        $this->view->view();
+		$this->GET_accountaanvragen();
+		$this->view->view();
 		exit;
 	}
 
@@ -132,34 +141,69 @@ class LoginController extends AclController {
 		$this->view = new CsrLayoutPage($body);
 	}
 
-	public function accountaanvragen() {
-		$this->exit_http(403);
+	public function account($uid = null, $action = null) {
+		switch ($action) {
+			case 'aanvragen':
+				return $this->GET_accountaanvragen();
+			case 'aanmaken':
+				return $this->accountaanmaken($uid);
+			case 'verwijderen':
+				return $this->accountverwijderen($uid);
+			case 'bewerken':
+			default:
+				return $this->accountbewerken($uid);
+		}
 	}
 
-	public function account($uid = null, $delete = null) {
-		if ($uid === null OR ! LoginModel::mag('P_ADMIN')) {
-			$uid = LoginModel::getUid();
+	public function GET_accountaanvragen() {
+		require_once 'model/CmsPaginaModel.class.php';
+		require_once 'view/CmsPaginaView.class.php';
+		$body = new CmsPaginaView(CmsPaginaModel::get('accountaanvragen'));
+		$this->view = new CsrLayoutPage($body);
+	}
+
+	public function accountaanmaken($uid = null) {
+		if (!LoginModel::mag('P_ADMIN')) {
+			$this->exit_http(403);
 		}
-		// aanvragen
+		if ($uid == null) {
+			$uid = $this->model->getUid();
+		}
+		if (AccountModel::get($uid)) {
+			setMelding('Account bestaat al', 0);
+		} else {
+			$account = AccountModel::instance()->maakAccount($uid);
+			if ($account) {
+				setMelding('Account succesvol aangemaakt', 1);
+			} else {
+				throw new Exception('Account aanmaken gefaald');
+			}
+		}
+		redirect('/account/' . $uid . '/bewerken');
+	}
+
+	public function accountbewerken($uid = null) {
+		if ($uid == null) {
+			$uid = $this->model->getUid();
+		}
 		if ($uid === 'x999') {
-			return $this->accountaanvragen();
+			$this->GET_accountaanvragen();
+			return;
 		}
-		// bewerken
+		if ($uid !== $this->model->getUid() AND ! LoginModel::mag('P_ADMIN')) {
+			$this->exit_http(403);
+		}
 		if (LoginModel::instance()->getAuthenticationMethod() !== AuthenticationMethod::recent_password_login) {
 			setMelding('U mag geen account wijzigen want u bent niet recent met wachtwoord ingelogd', 2);
 			$this->exit_http(403);
 		}
 		$account = AccountModel::get($uid);
-		if (!$account AND LoginModel::mag('P_ADMIN')) {
-			$account = AccountModel::instance()->maakAccount($uid);
+		if (!$account) {
+			setMelding('Account bestaat niet', -1);
+			$this->exit_http(403);
 		}
-		if ($delete === 'delete' AND LoginModel::mag('P_ADMIN')) {
-			$result = AccountModel::instance()->delete($account);
-			if ($result === 1) {
-				setMelding('Account succesvol verwijderd', 1);
-				redirect('/profiel/' . $uid);
-			}
-			setMelding('Account verwijderen mislukt', -1);
+		if (!AccessModel::mag($account, 'P_LOGGED_IN')) {
+			setMelding('Account mag niet inloggen', 2);
 		}
 		$form = new AccountForm($account);
 		if ($form->validate()) {
@@ -174,91 +218,126 @@ class LoginController extends AclController {
 		$this->view = new CsrLayoutPage($form);
 	}
 
+	public function accountverwijderen($uid = null) {
+		if ($uid == null) {
+			$uid = $this->model->getUid();
+		}
+		if ($uid !== $this->model->getUid() AND ! LoginModel::mag('P_ADMIN')) {
+			$this->exit_http(403);
+		}
+		$account = AccountModel::get($uid);
+		if (!$account) {
+			setMelding('Account bestaat niet', -1);
+		} else {
+			$result = AccountModel::instance()->delete($account);
+			if ($result === 1) {
+				setMelding('Account succesvol verwijderd', 1);
+			} else {
+				setMelding('Account verwijderen mislukt', -1);
+			}
+		}
+		$this->view = new JsonResponse('/profiel/' . $uid); // redirect
+	}
+
 	public function wachtwoord($action = null) {
+		switch ($action) {
+			case 'wijzigen':
+				return $this->wachtwoordwijzigen();
+			case 'reset':
+				return $this->wachtwoordreset();
+			case 'vergeten':
+			default:
+				return $this->wachtwoordvergeten();
+		}
+	}
+
+	public function wachtwoordwijzigen() {
 		$account = LoginModel::getAccount();
-		// wijzigen
-		if ($action !== 'vergeten' AND LoginModel::mag('P_PROFIEL_EDIT')) {
-			$form = new WachtwoordWijzigenForm($account, $action);
-			if ($form->validate()) {
-				// wachtwoord opslaan
-				$pass_plain = $form->findByName('wijzigww')->getValue();
-				AccountModel::instance()->wijzigWachtwoord($account, $pass_plain);
+		// mag inloggen?
+		if (!$account OR ! AccessModel::mag($account, 'P_LOGGED_IN')) {
+			$this->exit_http(403);
+		}
+		$form = new WachtwoordWijzigenForm($account, 'wijzigen');
+		if ($form->validate()) {
+			// wachtwoord opslaan
+			$pass_plain = $form->findByName('wijzigww')->getValue();
+			AccountModel::instance()->wijzigWachtwoord($account, $pass_plain);
+			setMelding('Wachtwoord instellen geslaagd', 1);
+		}
+		$this->view = new CsrLayoutPage($form);
+	}
+
+	public function wachtwoordreset() {
+		$account = LoginModel::getAccount();
+		// mag inloggen met url_token?
+		if (!$account OR ! AccessModel::mag($account, 'P_LOGGED_IN', AuthenticationMethod::getTypeOptions()) OR ! OneTimeTokensModel::instance()->isVerified($account->uid, '/wachtwoord/reset')) {
+			$this->exit_http(403);
+		}
+		$form = new WachtwoordWijzigenForm($account, 'reset', false);
+		if ($form->validate()) {
+			// wachtwoord opslaan
+			$pass_plain = $form->findByName('wijzigww')->getValue();
+			if (AccountModel::instance()->wijzigWachtwoord($account, $pass_plain)) {
 				setMelding('Wachtwoord instellen geslaagd', 1);
 			}
-		}
-		// resetten
-		elseif ($action === 'reset' AND LoginModel::mag('P_PROFIEL_EDIT', AuthenticationMethod::getTypeOptions()) AND OneTimeTokensModel::instance()->isVerified($account->uid, '/wachtwoord/reset')) {
-			$form = new WachtwoordWijzigenForm($account, $action, false);
-			if ($form->validate()) {
-				// wachtwoord opslaan
-				$pass_plain = $form->findByName('wijzigww')->getValue();
-				if (AccountModel::instance()->wijzigWachtwoord($account, $pass_plain)) {
-					setMelding('Wachtwoord instellen geslaagd', 1);
-				}
-				// token verbruikt
-				OneTimeTokensModel::instance()->discardToken($account->uid, '/wachtwoord/reset');
-				// inloggen zonder $authByToken
-				$this->model->login($account->uid, $pass_plain, false);
-				// stuur bevestigingsmail
-				$lidnaam = $account->getProfiel()->getNaam('volledig');
-				require_once 'model/entity/Mail.class.php';
-				$bericht = "Geachte " . $lidnaam .
-						",\n\nU heeft recent uw wachtwoord opnieuw ingesteld. Als u dit niet zelf gedaan heeft dan moet u nu direct uw wachtwoord wijzigen en de PubCie op de hoogte stellen.\n\nMet amicale groet,\nUw PubCie";
-				$mail = new Mail(array($account->email => $lidnaam), '[C.S.R. webstek] Nieuw wachtwoord ingesteld', $bericht);
-				$mail->send();
-				redirect(CSR_ROOT);
+			// token verbruikt
+			// (pas na wachtwoord opslaan om meedere pogingen toe te staan als wachtwoord niet aan eisen voldoet)
+			OneTimeTokensModel::instance()->discardToken($account->uid, '/wachtwoord/reset');
+			// inloggen alsof gebruiker wachtwoord heeft ingevoerd
+			$loggedin = $this->model->login($account->uid, $pass_plain, false);
+			if (!$loggedin) {
+				throw new Exception('Inloggen met nieuw wachtwoord mislukt');
 			}
+			// stuur bevestigingsmail
+			$profiel = $account->getProfiel();
+			require_once 'model/entity/Mail.class.php';
+			$bericht = "Geachte " . $profiel->getNaam('civitas') .
+					",\n\nU heeft recent uw wachtwoord opnieuw ingesteld. Als u dit niet zelf gedaan heeft dan moet u nu direct uw wachtwoord wijzigen en de PubCie op de hoogte stellen.\n\nMet amicale groet,\nUw PubCie";
+			$emailNaam = $profiel->getNaam('volledig');
+			$mail = new Mail(array($account->email => $emailNaam), '[C.S.R. webstek] Nieuw wachtwoord ingesteld', $bericht);
+			$mail->send();
+			redirect(CSR_ROOT);
 		}
-		// vergeten
-		else {
-			$form = new WachtwoordVergetenForm();
-			if ($form->validate()) {
-				// voorkom dat AccessModel ingelogde gebruiker blokkeerd als AuthenticationMethod::token_url niet toegestaan is
-				if (LoginModel::instance()->getAuthenticationMethod() === AuthenticationMethod::url_token) {
-					LoginModel::instance()->login('x999', 'x999', false);
-				}
-				$values = $form->getValues();
-				$account = AccountModel::get($values['user']);
-				// mag wachtwoord wijzigen?
-				if ($account AND AccessModel::mag($account, 'P_PROFIEL_EDIT') AND mb_strtolower($account->email) === mb_strtolower($values['mail'])) {
-					$token = OneTimeTokensModel::instance()->createToken($account->uid, '/wachtwoord/reset');
-					// stuur resetmail
-					$civitasnaam = $account->getProfiel()->getNaam('civitas');
-					// Forceer, want gebruiker is niet ingelogd en krijgt anders 'civitas'
-					// Dit zorgt voor een • in het 'aan' veld van de mail, sommige spamfilters gaan hiervan over hun nek
-					$lidnaam = $account->getProfiel()->getNaam('volledig', true);
-					require_once 'model/entity/Mail.class.php';
-					$bericht = "Geachte " . $civitasnaam .
-							",\n\nU heeft verzocht om uw wachtwoord opnieuw in te stellen. Dit is mogelijk met de onderstaande link tot " . $token[1] .
-							".\n\n[url=" . CSR_ROOT . "/verify/" . $token[0] .
-							"]Wachtwoord instellen[/url].\n\nAls dit niet uw eigen verzoek is kunt u dit bericht negeren.\n\nMet amicale groet,\nUw PubCie";
-					$mail = new Mail(array($account->email => $lidnaam), '[C.S.R. webstek] Wachtwoord vergeten', $bericht);
-					$mail->send();
-					setMelding('Wachtwoord reset email verzonden', 1);
-				} else {
-					setMelding('Lidnummer en/of e-mailadres onjuist', -1);
-				}
+		$this->view = new CsrLayoutPage($form);
+	}
+
+	public function wachtwoordvergeten() {
+		$form = new WachtwoordVergetenForm();
+		if ($form->validate()) {
+			$values = $form->getValues();
+			$account = AccountModel::get($values['user']);
+			// mag wachtwoord reset aanvragen?
+			// (mag ook als na verify($tokenString) niet ingelogd is met wachtwoord en dus AuthenticationMethod::url_token is)
+			if (!$account OR ! AccessModel::mag($account, 'P_LOGGED_IN', AuthenticationMethod::getTypeOptions()) OR mb_strtolower($account->email) !== mb_strtolower($values['mail'])) {
+				setMelding('Lidnummer en/of e-mailadres onjuist', -1);
+			} else {
+				$token = OneTimeTokensModel::instance()->createToken($account->uid, '/wachtwoord/reset');
+				// stuur resetmail
+				$profiel = $account->getProfiel();
+				require_once 'model/entity/Mail.class.php';
+				$bericht = "Geachte " . $profiel->getNaam('civitas') .
+						",\n\nU heeft verzocht om uw wachtwoord opnieuw in te stellen. Dit is mogelijk met de onderstaande link tot " . $token[1] .
+						".\n\n[url=" . CSR_ROOT . "/verify/" . $token[0] .
+						"]Wachtwoord instellen[/url].\n\nAls dit niet uw eigen verzoek is kunt u dit bericht negeren.\n\nMet amicale groet,\nUw PubCie";
+				$emailNaam = $profiel->getNaam('volledig', true); // Forceer, want gebruiker is niet ingelogd en krijgt anders 'civitas'
+				$mail = new Mail(array($account->email => $emailNaam), '[C.S.R. webstek] Wachtwoord vergeten', $bericht);
+				$mail->send();
+				setMelding('Wachtwoord reset email verzonden', 1);
 			}
 		}
 		$this->view = new CsrLayoutPage($form);
 	}
 
 	public function verify($tokenString = null) {
-		$tokenString = filter_var($tokenString, FILTER_SANITIZE_STRING);
 		$form = new VerifyForm($tokenString);
 		if ($form->validate()) {
-			// voorkom dat AccessModel ingelogde gebruiker blokkeerd als AuthenticationMethod::token_url niet toegestaan is
-			if (LoginModel::instance()->getAuthenticationMethod() === AuthenticationMethod::url_token) {
-				LoginModel::instance()->login('x999', 'x999', false);
-			}
 			$uid = $form->findByName('user')->getValue();
 			$account = AccountModel::get($uid);
-			// mag inloggen?
-			if ($account AND AccessModel::mag($account, 'P_LOGGED_IN') AND OneTimeTokensModel::instance()->verifyToken($account->uid, $tokenString)) {
-				// redirect by verifyToken
-			} else {
-				setMelding('Deze link is niet meer geldig', -1);
+			// mag inloggen met url_token?
+			if (!$account OR ! AccessModel::mag($account, 'P_LOGGED_IN', AuthenticationMethod::getTypeOptions()) OR ! OneTimeTokensModel::instance()->verifyToken($account->uid, $tokenString)) {
+				setMelding('Deze link is niet (meer) geldig', -1);
 			}
+			// verifyToken() redirects on success
 		}
 		$this->view = new CsrLayoutPage($form);
 	}

--- a/lib/model/security/AccountModel.class.php
+++ b/lib/model/security/AccountModel.class.php
@@ -44,7 +44,7 @@ class AccountModel extends CachedPersistenceModel {
 		$account->username = $uid;
 		$account->email = $profiel->email;
 		$account->pass_hash = '';
-		$account->pass_since = '';
+		$account->pass_since = getDateTime();
 		$account->failed_login_attempts = 0;
 		$account->perm_role = AccessModel::instance()->getDefaultPermissionRole($profiel->status);
 		$this->create($account);

--- a/lib/templates/profiel/profiel.tpl
+++ b/lib/templates/profiel/profiel.tpl
@@ -14,9 +14,9 @@
 					{/if}
 					{if LoginModel::getUid() === $profiel->uid OR LoginModel::mag('P_ADMIN')}
 						{if AccountModel::existsUid($profiel->uid)}
-							<a href="/account/{$profiel->uid}" class="btn" title="Inloggegevens bewerken">{icon get="key"}</a>
+							<a href="/account/{$profiel->uid}/bewerken" class="btn" title="Inloggegevens bewerken">{icon get="key"}</a>
 						{elseif LoginModel::mag('P_ADMIN')}
-							<a href="/account/{$profiel->uid}" class="btn" title="Account aanmaken">{icon get="key_delete" hover="key_add"}</a>
+							<a href="/account/{$profiel->uid}/aanmaken" class="btn" title="Account aanmaken">{icon get="key_delete" hover="key_add"}</a>
 						{/if}
 						{if LoginModel::mag('P_ADMIN')}
 							<a href="/tools/stats.php?uid={$profiel->uid}" class="btn" title="Toon bezoeklog">{icon get="server_chart"}</a>

--- a/lib/view/LoginView.class.php
+++ b/lib/view/LoginView.class.php
@@ -216,7 +216,7 @@ class WachtwoordWijzigenForm extends Formulier {
 class AccountForm extends Formulier {
 
 	public function __construct(Account $account) {
-		parent::__construct($account, '/account/' . $account->uid, 'Inloggegevens aanpassen');
+		parent::__construct($account, '/account/' . $account->uid . '/bewerken', 'Inloggegevens aanpassen');
 
 		if (LoginModel::mag('P_LEDEN_MOD')) {
 			$roles = array();
@@ -231,7 +231,7 @@ class AccountForm extends Formulier {
 		$fields[] = new WachtwoordWijzigenField('wijzigww', $account, !LoginModel::mag('P_LEDEN_MOD'));
 		$fields['btn'] = new FormDefaultKnoppen('/profiel/' . $account->uid, false, true, true, true);
 
-		$delete = new DeleteKnop($this->action . '/delete');
+		$delete = new DeleteKnop('/account/' . $account->uid . '/verwijderen');
 		$fields['btn']->addKnop($delete, true);
 
 		$this->addFields($fields);

--- a/lib/view/formulier/FormKnoppen.class.php
+++ b/lib/view/formulier/FormKnoppen.class.php
@@ -270,7 +270,7 @@ class CancelKnop extends FormulierKnop {
 
 class DeleteKnop extends FormulierKnop {
 
-	public function __construct($url, $action = 'post confirm ReloadPage', $label = 'Verwijderen', $title = 'Definitief verwijderen', $icon = 'cross') {
+	public function __construct($url, $action = 'post confirm redirect', $label = 'Verwijderen', $title = 'Definitief verwijderen', $icon = 'cross') {
 		parent::__construct($url, $action, $label, $title, $icon);
 	}
 


### PR DESCRIPTION
- [x] Fix: naar /account/<uid>/aanmaken navigeren maakt een account, maar laat alsnog de account aanvragen maken pagina zien,
- [x] Fix: verwijderen van een account laat de account aanvragen pagina zien, terwijl het profiel gewild is.
- [x] Fix: opnieuw wachtwoord vergeten aanvragen na mislukte poging
- [x] Fix: #79
- [x] Fix: #134
- [ ] POST-only CmsPaginaController->verwijderen
- [ ] POST-only ForumController->opheffen
- [ ] POST-only LoginController->accountverwijderen
- [x] Fix: Knopje account aanmaken is stuk,
- [x] Redirect on delete ipv page reload (beter en voorkomt bugs) [enhancement]