### PR TITLE
Nieuwe manier van icoontjes doen.

### DIFF
--- a/htdocs/assets/layout/css/icons.less
+++ b/htdocs/assets/layout/css/icons.less
@@ -17,11 +17,20 @@
   vertical-align: bottom;
 }
 
-.ico.rotating {
+.ico.rotating,
+.dt-button-ico.rotating span::before {
   animation-name: rotate;
   animation-duration: 1s;
   animation-iteration-count: infinite;
   animation-timing-function: linear;
+}
+
+.dt-button-ico {
+  span::before {
+    content: '';
+    margin: -2px 5px -2px -1px;
+    .ico;
+  }
 }
 
 .ico.rotate-90 { transform: rotate(90deg); }
@@ -30,1003 +39,1016 @@
 .ico.flip-horizontal { transform: scale(-1, 1); }
 .ico.flip-vertical { transform: scale(1, -1); }
 
-.ico.accept, *:hover > .ico.hover-accept { background-position: -1px -1px; }
-.ico.add, *:hover > .ico.hover-add { background-position: -1px -19px; }
-.ico.anchor, *:hover > .ico.hover-anchor { background-position: -1px -37px; }
-.ico.application, *:hover > .ico.hover-application { background-position: -1px -55px; }
-.ico.application_add, *:hover > .ico.hover-application_add { background-position: -1px -73px; }
-.ico.application_cascade, *:hover > .ico.hover-application_cascade { background-position: -1px -91px; }
-.ico.application_delete, *:hover > .ico.hover-application_delete { background-position: -1px -109px; }
-.ico.application_double, *:hover > .ico.hover-application_double { background-position: -1px -127px; }
-.ico.application_edit, *:hover > .ico.hover-application_edit { background-position: -1px -145px; }
-.ico.application_error, *:hover > .ico.hover-application_error { background-position: -1px -163px; }
-.ico.application_form, *:hover > .ico.hover-application_form { background-position: -1px -181px; }
-.ico.application_form_add, *:hover > .ico.hover-application_form_add { background-position: -1px -199px; }
-.ico.application_form_delete, *:hover > .ico.hover-application_form_delete { background-position: -1px -217px; }
-.ico.application_form_edit, *:hover > .ico.hover-application_form_edit { background-position: -1px -235px; }
-.ico.application_form_magnify, *:hover > .ico.hover-application_form_magnify { background-position: -19px -1px; }
-.ico.application_get, *:hover > .ico.hover-application_get { background-position: -19px -19px; }
-.ico.application_go, *:hover > .ico.hover-application_go { background-position: -19px -37px; }
-.ico.application_home, *:hover > .ico.hover-application_home { background-position: -19px -55px; }
-.ico.application_key, *:hover > .ico.hover-application_key { background-position: -19px -73px; }
-.ico.application_lightning, *:hover > .ico.hover-application_lightning { background-position: -19px -91px; }
-.ico.application_link, *:hover > .ico.hover-application_link { background-position: -19px -109px; }
-.ico.application_osx, *:hover > .ico.hover-application_osx { background-position: -19px -127px; }
-.ico.application_osx_terminal, *:hover > .ico.hover-application_osx_terminal { background-position: -19px -145px; }
-.ico.application_put, *:hover > .ico.hover-application_put { background-position: -19px -163px; }
-.ico.application_side_boxes, *:hover > .ico.hover-application_side_boxes { background-position: -19px -181px; }
-.ico.application_side_contract, *:hover > .ico.hover-application_side_contract { background-position: -19px -199px; }
-.ico.application_side_expand, *:hover > .ico.hover-application_side_expand { background-position: -19px -217px; }
-.ico.application_side_list, *:hover > .ico.hover-application_side_list { background-position: -19px -235px; }
-.ico.application_side_tree, *:hover > .ico.hover-application_side_tree { background-position: -37px -1px; }
-.ico.application_split, *:hover > .ico.hover-application_split { background-position: -37px -19px; }
-.ico.application_tile_horizontal, *:hover > .ico.hover-application_tile_horizontal { background-position: -37px -37px; }
-.ico.application_tile_vertical, *:hover > .ico.hover-application_tile_vertical { background-position: -37px -55px; }
-.ico.application_view_columns, *:hover > .ico.hover-application_view_columns { background-position: -37px -73px; }
-.ico.application_view_detail, *:hover > .ico.hover-application_view_detail { background-position: -37px -91px; }
-.ico.application_view_gallery, *:hover > .ico.hover-application_view_gallery { background-position: -37px -109px; }
-.ico.application_view_icons, *:hover > .ico.hover-application_view_icons { background-position: -37px -127px; }
-.ico.application_view_list, *:hover > .ico.hover-application_view_list { background-position: -37px -145px; }
-.ico.application_view_tile, *:hover > .ico.hover-application_view_tile { background-position: -37px -163px; }
-.ico.application_xp, *:hover > .ico.hover-application_xp { background-position: -37px -181px; }
-.ico.application_xp_terminal, *:hover > .ico.hover-application_xp_terminal { background-position: -37px -199px; }
-.ico.arrow_branch, *:hover > .ico.hover-arrow_branch { background-position: -37px -217px; }
-.ico.arrow_divide, *:hover > .ico.hover-arrow_divide { background-position: -37px -235px; }
-.ico.arrow_down, *:hover > .ico.hover-arrow_down { background-position: -55px -1px; }
-.ico.arrow_in, *:hover > .ico.hover-arrow_in { background-position: -55px -19px; }
-.ico.arrow_inout, *:hover > .ico.hover-arrow_inout { background-position: -55px -37px; }
-.ico.arrow_join, *:hover > .ico.hover-arrow_join { background-position: -55px -55px; }
-.ico.arrow_left, *:hover > .ico.hover-arrow_left { background-position: -55px -73px; }
-.ico.arrow_merge, *:hover > .ico.hover-arrow_merge { background-position: -55px -91px; }
-.ico.arrow_out, *:hover > .ico.hover-arrow_out { background-position: -55px -109px; }
-.ico.arrow_redo, *:hover > .ico.hover-arrow_redo { background-position: -55px -127px; }
-.ico.arrow_refresh, *:hover > .ico.hover-arrow_refresh { background-position: -55px -145px; }
-.ico.arrow_refresh_small, *:hover > .ico.hover-arrow_refresh_small { background-position: -55px -163px; }
-.ico.arrow_right, *:hover > .ico.hover-arrow_right { background-position: -55px -181px; }
-.ico.arrow_rotate_anticlockwise, *:hover > .ico.hover-arrow_rotate_anticlockwise { background-position: -55px -199px; }
-.ico.arrow_rotate_clockwise, *:hover > .ico.hover-arrow_rotate_clockwise { background-position: -55px -217px; }
-.ico.arrow_switch, *:hover > .ico.hover-arrow_switch { background-position: -55px -235px; }
-.ico.arrow_turn_left, *:hover > .ico.hover-arrow_turn_left { background-position: -73px -1px; }
-.ico.arrow_turn_right, *:hover > .ico.hover-arrow_turn_right { background-position: -73px -19px; }
-.ico.arrow_undo, *:hover > .ico.hover-arrow_undo { background-position: -73px -37px; }
-.ico.arrow_up, *:hover > .ico.hover-arrow_up { background-position: -73px -55px; }
-.ico.asterisk_orange, *:hover > .ico.hover-asterisk_orange { background-position: -73px -73px; }
-.ico.asterisk_yellow, *:hover > .ico.hover-asterisk_yellow { background-position: -73px -91px; }
-.ico.attach, *:hover > .ico.hover-attach { background-position: -73px -109px; }
-.ico.award_star_add, *:hover > .ico.hover-award_star_add { background-position: -73px -127px; }
-.ico.award_star_bronze_1, *:hover > .ico.hover-award_star_bronze_1 { background-position: -73px -145px; }
-.ico.award_star_bronze_2, *:hover > .ico.hover-award_star_bronze_2 { background-position: -73px -163px; }
-.ico.award_star_bronze_3, *:hover > .ico.hover-award_star_bronze_3 { background-position: -73px -181px; }
-.ico.award_star_delete, *:hover > .ico.hover-award_star_delete { background-position: -73px -199px; }
-.ico.award_star_gold_1, *:hover > .ico.hover-award_star_gold_1 { background-position: -73px -217px; }
-.ico.award_star_gold_2, *:hover > .ico.hover-award_star_gold_2 { background-position: -73px -235px; }
-.ico.award_star_gold_3, *:hover > .ico.hover-award_star_gold_3 { background-position: -91px -1px; }
-.ico.award_star_silver_1, *:hover > .ico.hover-award_star_silver_1 { background-position: -91px -19px; }
-.ico.award_star_silver_2, *:hover > .ico.hover-award_star_silver_2 { background-position: -91px -37px; }
-.ico.award_star_silver_3, *:hover > .ico.hover-award_star_silver_3 { background-position: -91px -55px; }
-.ico.basket, *:hover > .ico.hover-basket { background-position: -91px -73px; }
-.ico.basket_add, *:hover > .ico.hover-basket_add { background-position: -91px -91px; }
-.ico.basket_delete, *:hover > .ico.hover-basket_delete { background-position: -91px -109px; }
-.ico.basket_edit, *:hover > .ico.hover-basket_edit { background-position: -91px -127px; }
-.ico.basket_error, *:hover > .ico.hover-basket_error { background-position: -91px -145px; }
-.ico.basket_go, *:hover > .ico.hover-basket_go { background-position: -91px -163px; }
-.ico.basket_put, *:hover > .ico.hover-basket_put { background-position: -91px -181px; }
-.ico.basket_remove, *:hover > .ico.hover-basket_remove { background-position: -91px -199px; }
-.ico.bell, *:hover > .ico.hover-bell { background-position: -91px -217px; }
-.ico.bell_add, *:hover > .ico.hover-bell_add { background-position: -91px -235px; }
-.ico.bell_delete, *:hover > .ico.hover-bell_delete { background-position: -109px -1px; }
-.ico.bell_error, *:hover > .ico.hover-bell_error { background-position: -109px -19px; }
-.ico.bell_go, *:hover > .ico.hover-bell_go { background-position: -109px -37px; }
-.ico.bell_link, *:hover > .ico.hover-bell_link { background-position: -109px -55px; }
-.ico.bin, *:hover > .ico.hover-bin { background-position: -109px -73px; }
-.ico.bin_closed, *:hover > .ico.hover-bin_closed { background-position: -109px -91px; }
-.ico.bin_empty, *:hover > .ico.hover-bin_empty { background-position: -109px -109px; }
-.ico.bomb, *:hover > .ico.hover-bomb { background-position: -109px -127px; }
-.ico.book, *:hover > .ico.hover-book { background-position: -109px -145px; }
-.ico.book_add, *:hover > .ico.hover-book_add { background-position: -109px -163px; }
-.ico.book_addresses, *:hover > .ico.hover-book_addresses { background-position: -109px -181px; }
-.ico.book_delete, *:hover > .ico.hover-book_delete { background-position: -109px -199px; }
-.ico.book_edit, *:hover > .ico.hover-book_edit { background-position: -109px -217px; }
-.ico.book_error, *:hover > .ico.hover-book_error { background-position: -109px -235px; }
-.ico.book_go, *:hover > .ico.hover-book_go { background-position: -127px -1px; }
-.ico.book_key, *:hover > .ico.hover-book_key { background-position: -127px -19px; }
-.ico.book_link, *:hover > .ico.hover-book_link { background-position: -127px -37px; }
-.ico.book_next, *:hover > .ico.hover-book_next { background-position: -127px -55px; }
-.ico.book_open, *:hover > .ico.hover-book_open { background-position: -127px -73px; }
-.ico.book_previous, *:hover > .ico.hover-book_previous { background-position: -127px -91px; }
-.ico.box, *:hover > .ico.hover-box { background-position: -127px -109px; }
-.ico.brick, *:hover > .ico.hover-brick { background-position: -127px -127px; }
-.ico.brick_add, *:hover > .ico.hover-brick_add { background-position: -127px -145px; }
-.ico.brick_delete, *:hover > .ico.hover-brick_delete { background-position: -127px -163px; }
-.ico.brick_edit, *:hover > .ico.hover-brick_edit { background-position: -127px -181px; }
-.ico.brick_error, *:hover > .ico.hover-brick_error { background-position: -127px -199px; }
-.ico.brick_go, *:hover > .ico.hover-brick_go { background-position: -127px -217px; }
-.ico.brick_link, *:hover > .ico.hover-brick_link { background-position: -127px -235px; }
-.ico.bricks, *:hover > .ico.hover-bricks { background-position: -145px -1px; }
-.ico.briefcase, *:hover > .ico.hover-briefcase { background-position: -145px -19px; }
-.ico.bug, *:hover > .ico.hover-bug { background-position: -145px -37px; }
-.ico.bug_add, *:hover > .ico.hover-bug_add { background-position: -145px -55px; }
-.ico.bug_delete, *:hover > .ico.hover-bug_delete { background-position: -145px -73px; }
-.ico.bug_edit, *:hover > .ico.hover-bug_edit { background-position: -145px -91px; }
-.ico.bug_error, *:hover > .ico.hover-bug_error { background-position: -145px -109px; }
-.ico.bug_go, *:hover > .ico.hover-bug_go { background-position: -145px -127px; }
-.ico.bug_link, *:hover > .ico.hover-bug_link { background-position: -145px -145px; }
-.ico.building, *:hover > .ico.hover-building { background-position: -145px -163px; }
-.ico.building_add, *:hover > .ico.hover-building_add { background-position: -145px -181px; }
-.ico.building_delete, *:hover > .ico.hover-building_delete { background-position: -145px -199px; }
-.ico.building_edit, *:hover > .ico.hover-building_edit { background-position: -145px -217px; }
-.ico.building_error, *:hover > .ico.hover-building_error { background-position: -145px -235px; }
-.ico.building_go, *:hover > .ico.hover-building_go { background-position: -163px -1px; }
-.ico.building_key, *:hover > .ico.hover-building_key { background-position: -163px -19px; }
-.ico.building_link, *:hover > .ico.hover-building_link { background-position: -163px -37px; }
-.ico.bullet_add, *:hover > .ico.hover-bullet_add { background-position: -163px -55px; }
-.ico.bullet_arrow_bottom, *:hover > .ico.hover-bullet_arrow_bottom { background-position: -163px -73px; }
-.ico.bullet_arrow_down, *:hover > .ico.hover-bullet_arrow_down { background-position: -163px -91px; }
-.ico.bullet_arrow_top, *:hover > .ico.hover-bullet_arrow_top { background-position: -163px -109px; }
-.ico.bullet_arrow_up, *:hover > .ico.hover-bullet_arrow_up { background-position: -163px -127px; }
-.ico.bullet_black, *:hover > .ico.hover-bullet_black { background-position: -163px -145px; }
-.ico.bullet_blue, *:hover > .ico.hover-bullet_blue { background-position: -163px -163px; }
-.ico.bullet_delete, *:hover > .ico.hover-bullet_delete { background-position: -163px -181px; }
-.ico.bullet_disk, *:hover > .ico.hover-bullet_disk { background-position: -163px -199px; }
-.ico.bullet_error, *:hover > .ico.hover-bullet_error { background-position: -163px -217px; }
-.ico.bullet_feed, *:hover > .ico.hover-bullet_feed { background-position: -163px -235px; }
-.ico.bullet_go, *:hover > .ico.hover-bullet_go { background-position: -181px -1px; }
-.ico.bullet_green, *:hover > .ico.hover-bullet_green { background-position: -181px -19px; }
-.ico.bullet_key, *:hover > .ico.hover-bullet_key { background-position: -181px -37px; }
-.ico.bullet_orange, *:hover > .ico.hover-bullet_orange { background-position: -181px -55px; }
-.ico.bullet_picture, *:hover > .ico.hover-bullet_picture { background-position: -181px -73px; }
-.ico.bullet_pink, *:hover > .ico.hover-bullet_pink { background-position: -181px -91px; }
-.ico.bullet_purple, *:hover > .ico.hover-bullet_purple { background-position: -181px -109px; }
-.ico.bullet_red, *:hover > .ico.hover-bullet_red { background-position: -181px -127px; }
-.ico.bullet_star, *:hover > .ico.hover-bullet_star { background-position: -181px -145px; }
-.ico.bullet_toggle_minus, *:hover > .ico.hover-bullet_toggle_minus { background-position: -181px -163px; }
-.ico.bullet_toggle_plus, *:hover > .ico.hover-bullet_toggle_plus { background-position: -181px -181px; }
-.ico.bullet_white, *:hover > .ico.hover-bullet_white { background-position: -181px -199px; }
-.ico.bullet_wrench, *:hover > .ico.hover-bullet_wrench { background-position: -181px -217px; }
-.ico.bullet_yellow, *:hover > .ico.hover-bullet_yellow { background-position: -181px -235px; }
-.ico.cake, *:hover > .ico.hover-cake { background-position: -199px -1px; }
-.ico.calculator, *:hover > .ico.hover-calculator { background-position: -199px -19px; }
-.ico.calculator_add, *:hover > .ico.hover-calculator_add { background-position: -199px -37px; }
-.ico.calculator_delete, *:hover > .ico.hover-calculator_delete { background-position: -199px -55px; }
-.ico.calculator_edit, *:hover > .ico.hover-calculator_edit { background-position: -199px -73px; }
-.ico.calculator_error, *:hover > .ico.hover-calculator_error { background-position: -199px -91px; }
-.ico.calculator_link, *:hover > .ico.hover-calculator_link { background-position: -199px -109px; }
-.ico.calendar, *:hover > .ico.hover-calendar { background-position: -199px -127px; }
-.ico.calendar_add, *:hover > .ico.hover-calendar_add { background-position: -199px -145px; }
-.ico.calendar_delete, *:hover > .ico.hover-calendar_delete { background-position: -199px -163px; }
-.ico.calendar_edit, *:hover > .ico.hover-calendar_edit { background-position: -199px -181px; }
-.ico.calendar_link, *:hover > .ico.hover-calendar_link { background-position: -199px -199px; }
-.ico.calendar_view_day, *:hover > .ico.hover-calendar_view_day { background-position: -199px -217px; }
-.ico.calendar_view_month, *:hover > .ico.hover-calendar_view_month { background-position: -199px -235px; }
-.ico.calendar_view_week, *:hover > .ico.hover-calendar_view_week { background-position: -217px -1px; }
-.ico.camera, *:hover > .ico.hover-camera { background-position: -217px -19px; }
-.ico.camera_add, *:hover > .ico.hover-camera_add { background-position: -217px -37px; }
-.ico.camera_delete, *:hover > .ico.hover-camera_delete { background-position: -217px -55px; }
-.ico.camera_edit, *:hover > .ico.hover-camera_edit { background-position: -217px -73px; }
-.ico.camera_error, *:hover > .ico.hover-camera_error { background-position: -217px -91px; }
-.ico.camera_go, *:hover > .ico.hover-camera_go { background-position: -217px -109px; }
-.ico.camera_link, *:hover > .ico.hover-camera_link { background-position: -217px -127px; }
-.ico.camera_small, *:hover > .ico.hover-camera_small { background-position: -217px -145px; }
-.ico.cancel, *:hover > .ico.hover-cancel { background-position: -217px -163px; }
-.ico.car, *:hover > .ico.hover-car { background-position: -217px -181px; }
-.ico.car_add, *:hover > .ico.hover-car_add { background-position: -217px -199px; }
-.ico.car_delete, *:hover > .ico.hover-car_delete { background-position: -217px -217px; }
-.ico.cart, *:hover > .ico.hover-cart { background-position: -217px -235px; }
-.ico.cart_add, *:hover > .ico.hover-cart_add { background-position: -235px -1px; }
-.ico.cart_delete, *:hover > .ico.hover-cart_delete { background-position: -235px -19px; }
-.ico.cart_edit, *:hover > .ico.hover-cart_edit { background-position: -235px -37px; }
-.ico.cart_error, *:hover > .ico.hover-cart_error { background-position: -235px -55px; }
-.ico.cart_go, *:hover > .ico.hover-cart_go { background-position: -235px -73px; }
-.ico.cart_put, *:hover > .ico.hover-cart_put { background-position: -235px -91px; }
-.ico.cart_remove, *:hover > .ico.hover-cart_remove { background-position: -235px -109px; }
-.ico.cd, *:hover > .ico.hover-cd { background-position: -235px -127px; }
-.ico.cd_add, *:hover > .ico.hover-cd_add { background-position: -235px -145px; }
-.ico.cd_burn, *:hover > .ico.hover-cd_burn { background-position: -235px -163px; }
-.ico.cd_delete, *:hover > .ico.hover-cd_delete { background-position: -235px -181px; }
-.ico.cd_edit, *:hover > .ico.hover-cd_edit { background-position: -235px -199px; }
-.ico.cd_eject, *:hover > .ico.hover-cd_eject { background-position: -235px -217px; }
-.ico.cd_go, *:hover > .ico.hover-cd_go { background-position: -235px -235px; }
-.ico.chart_bar, *:hover > .ico.hover-chart_bar { background-position: -253px -1px; }
-.ico.chart_bar_add, *:hover > .ico.hover-chart_bar_add { background-position: -253px -19px; }
-.ico.chart_bar_delete, *:hover > .ico.hover-chart_bar_delete { background-position: -253px -37px; }
-.ico.chart_bar_edit, *:hover > .ico.hover-chart_bar_edit { background-position: -253px -55px; }
-.ico.chart_bar_error, *:hover > .ico.hover-chart_bar_error { background-position: -253px -73px; }
-.ico.chart_bar_link, *:hover > .ico.hover-chart_bar_link { background-position: -253px -91px; }
-.ico.chart_curve, *:hover > .ico.hover-chart_curve { background-position: -253px -109px; }
-.ico.chart_curve_add, *:hover > .ico.hover-chart_curve_add { background-position: -253px -127px; }
-.ico.chart_curve_delete, *:hover > .ico.hover-chart_curve_delete { background-position: -253px -145px; }
-.ico.chart_curve_edit, *:hover > .ico.hover-chart_curve_edit { background-position: -253px -163px; }
-.ico.chart_curve_error, *:hover > .ico.hover-chart_curve_error { background-position: -253px -181px; }
-.ico.chart_curve_go, *:hover > .ico.hover-chart_curve_go { background-position: -253px -199px; }
-.ico.chart_curve_link, *:hover > .ico.hover-chart_curve_link { background-position: -253px -217px; }
-.ico.chart_line, *:hover > .ico.hover-chart_line { background-position: -253px -235px; }
-.ico.chart_line_add, *:hover > .ico.hover-chart_line_add { background-position: -271px -1px; }
-.ico.chart_line_delete, *:hover > .ico.hover-chart_line_delete { background-position: -271px -19px; }
-.ico.chart_line_edit, *:hover > .ico.hover-chart_line_edit { background-position: -271px -37px; }
-.ico.chart_line_error, *:hover > .ico.hover-chart_line_error { background-position: -271px -55px; }
-.ico.chart_line_link, *:hover > .ico.hover-chart_line_link { background-position: -271px -73px; }
-.ico.chart_organisation, *:hover > .ico.hover-chart_organisation { background-position: -271px -91px; }
-.ico.chart_organisation_add, *:hover > .ico.hover-chart_organisation_add { background-position: -271px -109px; }
-.ico.chart_organisation_delete, *:hover > .ico.hover-chart_organisation_delete { background-position: -271px -127px; }
-.ico.chart_pie, *:hover > .ico.hover-chart_pie { background-position: -271px -145px; }
-.ico.chart_pie_add, *:hover > .ico.hover-chart_pie_add { background-position: -271px -163px; }
-.ico.chart_pie_delete, *:hover > .ico.hover-chart_pie_delete { background-position: -271px -181px; }
-.ico.chart_pie_edit, *:hover > .ico.hover-chart_pie_edit { background-position: -271px -199px; }
-.ico.chart_pie_error, *:hover > .ico.hover-chart_pie_error { background-position: -271px -217px; }
-.ico.chart_pie_link, *:hover > .ico.hover-chart_pie_link { background-position: -271px -235px; }
-.ico.clock, *:hover > .ico.hover-clock { background-position: -289px -1px; }
-.ico.clock_add, *:hover > .ico.hover-clock_add { background-position: -289px -19px; }
-.ico.clock_delete, *:hover > .ico.hover-clock_delete { background-position: -289px -37px; }
-.ico.clock_edit, *:hover > .ico.hover-clock_edit { background-position: -289px -55px; }
-.ico.clock_error, *:hover > .ico.hover-clock_error { background-position: -289px -73px; }
-.ico.clock_go, *:hover > .ico.hover-clock_go { background-position: -289px -91px; }
-.ico.clock_link, *:hover > .ico.hover-clock_link { background-position: -289px -109px; }
-.ico.clock_pause, *:hover > .ico.hover-clock_pause { background-position: -289px -127px; }
-.ico.clock_play, *:hover > .ico.hover-clock_play { background-position: -289px -145px; }
-.ico.clock_red, *:hover > .ico.hover-clock_red { background-position: -289px -163px; }
-.ico.clock_stop, *:hover > .ico.hover-clock_stop { background-position: -289px -181px; }
-.ico.cog, *:hover > .ico.hover-cog { background-position: -289px -199px; }
-.ico.cog_add, *:hover > .ico.hover-cog_add { background-position: -289px -217px; }
-.ico.cog_delete, *:hover > .ico.hover-cog_delete { background-position: -289px -235px; }
-.ico.cog_edit, *:hover > .ico.hover-cog_edit { background-position: -307px -1px; }
-.ico.cog_error, *:hover > .ico.hover-cog_error { background-position: -307px -19px; }
-.ico.cog_go, *:hover > .ico.hover-cog_go { background-position: -307px -37px; }
-.ico.coins, *:hover > .ico.hover-coins { background-position: -307px -55px; }
-.ico.coins_add, *:hover > .ico.hover-coins_add { background-position: -307px -73px; }
-.ico.coins_delete, *:hover > .ico.hover-coins_delete { background-position: -307px -91px; }
-.ico.color_swatch, *:hover > .ico.hover-color_swatch { background-position: -307px -109px; }
-.ico.color_wheel, *:hover > .ico.hover-color_wheel { background-position: -307px -127px; }
-.ico.comment, *:hover > .ico.hover-comment { background-position: -307px -145px; }
-.ico.comment_add, *:hover > .ico.hover-comment_add { background-position: -307px -163px; }
-.ico.comment_delete, *:hover > .ico.hover-comment_delete { background-position: -307px -181px; }
-.ico.comment_edit, *:hover > .ico.hover-comment_edit { background-position: -307px -199px; }
-.ico.comments, *:hover > .ico.hover-comments { background-position: -307px -217px; }
-.ico.comments_add, *:hover > .ico.hover-comments_add { background-position: -307px -235px; }
-.ico.comments_delete, *:hover > .ico.hover-comments_delete { background-position: -325px -1px; }
-.ico.compress, *:hover > .ico.hover-compress { background-position: -325px -19px; }
-.ico.computer, *:hover > .ico.hover-computer { background-position: -325px -37px; }
-.ico.computer_add, *:hover > .ico.hover-computer_add { background-position: -325px -55px; }
-.ico.computer_delete, *:hover > .ico.hover-computer_delete { background-position: -325px -73px; }
-.ico.computer_edit, *:hover > .ico.hover-computer_edit { background-position: -325px -91px; }
-.ico.computer_error, *:hover > .ico.hover-computer_error { background-position: -325px -109px; }
-.ico.computer_go, *:hover > .ico.hover-computer_go { background-position: -325px -127px; }
-.ico.computer_key, *:hover > .ico.hover-computer_key { background-position: -325px -145px; }
-.ico.computer_link, *:hover > .ico.hover-computer_link { background-position: -325px -163px; }
-.ico.connect, *:hover > .ico.hover-connect { background-position: -325px -181px; }
-.ico.contrast, *:hover > .ico.hover-contrast { background-position: -325px -199px; }
-.ico.contrast_decrease, *:hover > .ico.hover-contrast_decrease { background-position: -325px -217px; }
-.ico.contrast_high, *:hover > .ico.hover-contrast_high { background-position: -325px -235px; }
-.ico.contrast_increase, *:hover > .ico.hover-contrast_increase { background-position: -343px -1px; }
-.ico.contrast_low, *:hover > .ico.hover-contrast_low { background-position: -343px -19px; }
-.ico.control_eject, *:hover > .ico.hover-control_eject { background-position: -343px -37px; }
-.ico.control_eject_blue, *:hover > .ico.hover-control_eject_blue { background-position: -343px -55px; }
-.ico.control_end, *:hover > .ico.hover-control_end { background-position: -343px -73px; }
-.ico.control_end_blue, *:hover > .ico.hover-control_end_blue { background-position: -343px -91px; }
-.ico.control_equalizer, *:hover > .ico.hover-control_equalizer { background-position: -343px -109px; }
-.ico.control_equalizer_blue, *:hover > .ico.hover-control_equalizer_blue { background-position: -343px -127px; }
-.ico.control_fastforward, *:hover > .ico.hover-control_fastforward { background-position: -343px -145px; }
-.ico.control_fastforward_blue, *:hover > .ico.hover-control_fastforward_blue { background-position: -343px -163px; }
-.ico.control_pause, *:hover > .ico.hover-control_pause { background-position: -343px -181px; }
-.ico.control_pause_blue, *:hover > .ico.hover-control_pause_blue { background-position: -343px -199px; }
-.ico.control_play, *:hover > .ico.hover-control_play { background-position: -343px -217px; }
-.ico.control_play_blue, *:hover > .ico.hover-control_play_blue { background-position: -343px -235px; }
-.ico.control_repeat, *:hover > .ico.hover-control_repeat { background-position: -361px -1px; }
-.ico.control_repeat_blue, *:hover > .ico.hover-control_repeat_blue { background-position: -361px -19px; }
-.ico.control_rewind, *:hover > .ico.hover-control_rewind { background-position: -361px -37px; }
-.ico.control_rewind_blue, *:hover > .ico.hover-control_rewind_blue { background-position: -361px -55px; }
-.ico.control_start, *:hover > .ico.hover-control_start { background-position: -361px -73px; }
-.ico.control_start_blue, *:hover > .ico.hover-control_start_blue { background-position: -361px -91px; }
-.ico.control_stop, *:hover > .ico.hover-control_stop { background-position: -361px -109px; }
-.ico.control_stop_blue, *:hover > .ico.hover-control_stop_blue { background-position: -361px -127px; }
-.ico.controller, *:hover > .ico.hover-controller { background-position: -361px -145px; }
-.ico.controller_add, *:hover > .ico.hover-controller_add { background-position: -361px -163px; }
-.ico.controller_delete, *:hover > .ico.hover-controller_delete { background-position: -361px -181px; }
-.ico.controller_error, *:hover > .ico.hover-controller_error { background-position: -361px -199px; }
-.ico.creditcards, *:hover > .ico.hover-creditcards { background-position: -361px -217px; }
-.ico.cross, *:hover > .ico.hover-cross { background-position: -361px -235px; }
-.ico.css, *:hover > .ico.hover-css { background-position: -379px -1px; }
-.ico.css_add, *:hover > .ico.hover-css_add { background-position: -379px -19px; }
-.ico.css_delete, *:hover > .ico.hover-css_delete { background-position: -379px -37px; }
-.ico.css_go, *:hover > .ico.hover-css_go { background-position: -379px -55px; }
-.ico.css_valid, *:hover > .ico.hover-css_valid { background-position: -379px -73px; }
-.ico.cup, *:hover > .ico.hover-cup { background-position: -379px -91px; }
-.ico.cup_add, *:hover > .ico.hover-cup_add { background-position: -379px -109px; }
-.ico.cup_delete, *:hover > .ico.hover-cup_delete { background-position: -379px -127px; }
-.ico.cup_edit, *:hover > .ico.hover-cup_edit { background-position: -379px -145px; }
-.ico.cup_error, *:hover > .ico.hover-cup_error { background-position: -379px -163px; }
-.ico.cup_go, *:hover > .ico.hover-cup_go { background-position: -379px -181px; }
-.ico.cup_key, *:hover > .ico.hover-cup_key { background-position: -379px -199px; }
-.ico.cup_link, *:hover > .ico.hover-cup_link { background-position: -379px -217px; }
-.ico.cursor, *:hover > .ico.hover-cursor { background-position: -379px -235px; }
-.ico.cut, *:hover > .ico.hover-cut { background-position: -397px -1px; }
-.ico.cut_red, *:hover > .ico.hover-cut_red { background-position: -397px -19px; }
-.ico.database, *:hover > .ico.hover-database { background-position: -397px -37px; }
-.ico.database_add, *:hover > .ico.hover-database_add { background-position: -397px -55px; }
-.ico.database_connect, *:hover > .ico.hover-database_connect { background-position: -397px -73px; }
-.ico.database_delete, *:hover > .ico.hover-database_delete { background-position: -397px -91px; }
-.ico.database_edit, *:hover > .ico.hover-database_edit { background-position: -397px -109px; }
-.ico.database_error, *:hover > .ico.hover-database_error { background-position: -397px -127px; }
-.ico.database_gear, *:hover > .ico.hover-database_gear { background-position: -397px -145px; }
-.ico.database_go, *:hover > .ico.hover-database_go { background-position: -397px -163px; }
-.ico.database_key, *:hover > .ico.hover-database_key { background-position: -397px -181px; }
-.ico.database_lightning, *:hover > .ico.hover-database_lightning { background-position: -397px -199px; }
-.ico.database_link, *:hover > .ico.hover-database_link { background-position: -397px -217px; }
-.ico.database_refresh, *:hover > .ico.hover-database_refresh { background-position: -397px -235px; }
-.ico.database_save, *:hover > .ico.hover-database_save { background-position: -415px -1px; }
-.ico.database_table, *:hover > .ico.hover-database_table { background-position: -415px -19px; }
-.ico.date, *:hover > .ico.hover-date { background-position: -415px -37px; }
-.ico.date_add, *:hover > .ico.hover-date_add { background-position: -415px -55px; }
-.ico.date_delete, *:hover > .ico.hover-date_delete { background-position: -415px -73px; }
-.ico.date_edit, *:hover > .ico.hover-date_edit { background-position: -415px -91px; }
-.ico.date_error, *:hover > .ico.hover-date_error { background-position: -415px -109px; }
-.ico.date_go, *:hover > .ico.hover-date_go { background-position: -415px -127px; }
-.ico.date_link, *:hover > .ico.hover-date_link { background-position: -415px -145px; }
-.ico.date_magnify, *:hover > .ico.hover-date_magnify { background-position: -415px -163px; }
-.ico.date_next, *:hover > .ico.hover-date_next { background-position: -415px -181px; }
-.ico.date_previous, *:hover > .ico.hover-date_previous { background-position: -415px -199px; }
-.ico.delete, *:hover > .ico.hover-delete { background-position: -415px -217px; }
-.ico.disconnect, *:hover > .ico.hover-disconnect { background-position: -415px -235px; }
-.ico.disk, *:hover > .ico.hover-disk { background-position: -433px -1px; }
-.ico.disk_multiple, *:hover > .ico.hover-disk_multiple { background-position: -433px -19px; }
-.ico.door, *:hover > .ico.hover-door { background-position: -433px -37px; }
-.ico.door_in, *:hover > .ico.hover-door_in { background-position: -433px -55px; }
-.ico.door_open, *:hover > .ico.hover-door_open { background-position: -433px -73px; }
-.ico.door_out, *:hover > .ico.hover-door_out { background-position: -433px -91px; }
-.ico.drink, *:hover > .ico.hover-drink { background-position: -433px -109px; }
-.ico.drink_empty, *:hover > .ico.hover-drink_empty { background-position: -433px -127px; }
-.ico.drive, *:hover > .ico.hover-drive { background-position: -433px -145px; }
-.ico.drive_add, *:hover > .ico.hover-drive_add { background-position: -433px -163px; }
-.ico.drive_burn, *:hover > .ico.hover-drive_burn { background-position: -433px -181px; }
-.ico.drive_cd, *:hover > .ico.hover-drive_cd { background-position: -433px -199px; }
-.ico.drive_cd_empty, *:hover > .ico.hover-drive_cd_empty { background-position: -433px -217px; }
-.ico.drive_delete, *:hover > .ico.hover-drive_delete { background-position: -433px -235px; }
-.ico.drive_disk, *:hover > .ico.hover-drive_disk { background-position: -451px -1px; }
-.ico.drive_edit, *:hover > .ico.hover-drive_edit { background-position: -451px -19px; }
-.ico.drive_error, *:hover > .ico.hover-drive_error { background-position: -451px -37px; }
-.ico.drive_go, *:hover > .ico.hover-drive_go { background-position: -451px -55px; }
-.ico.drive_key, *:hover > .ico.hover-drive_key { background-position: -451px -73px; }
-.ico.drive_link, *:hover > .ico.hover-drive_link { background-position: -451px -91px; }
-.ico.drive_magnify, *:hover > .ico.hover-drive_magnify { background-position: -451px -109px; }
-.ico.drive_network, *:hover > .ico.hover-drive_network { background-position: -451px -127px; }
-.ico.drive_rename, *:hover > .ico.hover-drive_rename { background-position: -451px -145px; }
-.ico.drive_user, *:hover > .ico.hover-drive_user { background-position: -451px -163px; }
-.ico.drive_web, *:hover > .ico.hover-drive_web { background-position: -451px -181px; }
-.ico.dvd, *:hover > .ico.hover-dvd { background-position: -451px -199px; }
-.ico.dvd_add, *:hover > .ico.hover-dvd_add { background-position: -451px -217px; }
-.ico.dvd_delete, *:hover > .ico.hover-dvd_delete { background-position: -451px -235px; }
-.ico.dvd_edit, *:hover > .ico.hover-dvd_edit { background-position: -469px -1px; }
-.ico.dvd_error, *:hover > .ico.hover-dvd_error { background-position: -469px -19px; }
-.ico.dvd_go, *:hover > .ico.hover-dvd_go { background-position: -469px -37px; }
-.ico.dvd_key, *:hover > .ico.hover-dvd_key { background-position: -469px -55px; }
-.ico.dvd_link, *:hover > .ico.hover-dvd_link { background-position: -469px -73px; }
-.ico.email, *:hover > .ico.hover-email { background-position: -469px -91px; }
-.ico.email_add, *:hover > .ico.hover-email_add { background-position: -469px -109px; }
-.ico.email_attach, *:hover > .ico.hover-email_attach { background-position: -469px -127px; }
-.ico.email_delete, *:hover > .ico.hover-email_delete { background-position: -469px -145px; }
-.ico.email_edit, *:hover > .ico.hover-email_edit { background-position: -469px -163px; }
-.ico.email_error, *:hover > .ico.hover-email_error { background-position: -469px -181px; }
-.ico.email_go, *:hover > .ico.hover-email_go { background-position: -469px -199px; }
-.ico.email_go_orange, *:hover > .ico.hover-email_go_orange { background-position: -469px -217px; }
-.ico.email_link, *:hover > .ico.hover-email_link { background-position: -469px -235px; }
-.ico.email_open, *:hover > .ico.hover-email_open { background-position: -487px -1px; }
-.ico.email_open_image, *:hover > .ico.hover-email_open_image { background-position: -487px -19px; }
-.ico.emoticon_evilgrin, *:hover > .ico.hover-emoticon_evilgrin { background-position: -487px -37px; }
-.ico.emoticon_grin, *:hover > .ico.hover-emoticon_grin { background-position: -487px -55px; }
-.ico.emoticon_happy, *:hover > .ico.hover-emoticon_happy { background-position: -487px -73px; }
-.ico.emoticon_smile, *:hover > .ico.hover-emoticon_smile { background-position: -487px -91px; }
-.ico.emoticon_surprised, *:hover > .ico.hover-emoticon_surprised { background-position: -487px -109px; }
-.ico.emoticon_tongue, *:hover > .ico.hover-emoticon_tongue { background-position: -487px -127px; }
-.ico.emoticon_unhappy, *:hover > .ico.hover-emoticon_unhappy { background-position: -487px -145px; }
-.ico.emoticon_waii, *:hover > .ico.hover-emoticon_waii { background-position: -487px -163px; }
-.ico.emoticon_wink, *:hover > .ico.hover-emoticon_wink { background-position: -487px -181px; }
-.ico.error, *:hover > .ico.hover-error { background-position: -487px -199px; }
-.ico.error_add, *:hover > .ico.hover-error_add { background-position: -487px -217px; }
-.ico.error_delete, *:hover > .ico.hover-error_delete { background-position: -487px -235px; }
-.ico.error_go, *:hover > .ico.hover-error_go { background-position: -505px -1px; }
-.ico.exclamation, *:hover > .ico.hover-exclamation { background-position: -505px -19px; }
-.ico.eye, *:hover > .ico.hover-eye { background-position: -505px -37px; }
-.ico.feed, *:hover > .ico.hover-feed { background-position: -505px -55px; }
-.ico.feed_add, *:hover > .ico.hover-feed_add { background-position: -505px -73px; }
-.ico.feed_delete, *:hover > .ico.hover-feed_delete { background-position: -505px -91px; }
-.ico.feed_disk, *:hover > .ico.hover-feed_disk { background-position: -505px -109px; }
-.ico.feed_edit, *:hover > .ico.hover-feed_edit { background-position: -505px -127px; }
-.ico.feed_error, *:hover > .ico.hover-feed_error { background-position: -505px -145px; }
-.ico.feed_go, *:hover > .ico.hover-feed_go { background-position: -505px -163px; }
-.ico.feed_key, *:hover > .ico.hover-feed_key { background-position: -505px -181px; }
-.ico.feed_link, *:hover > .ico.hover-feed_link { background-position: -505px -199px; }
-.ico.feed_magnify, *:hover > .ico.hover-feed_magnify { background-position: -505px -217px; }
-.ico.female, *:hover > .ico.hover-female { background-position: -505px -235px; }
-.ico.film, *:hover > .ico.hover-film { background-position: -523px -1px; }
-.ico.film_add, *:hover > .ico.hover-film_add { background-position: -523px -19px; }
-.ico.film_delete, *:hover > .ico.hover-film_delete { background-position: -523px -37px; }
-.ico.film_edit, *:hover > .ico.hover-film_edit { background-position: -523px -55px; }
-.ico.film_error, *:hover > .ico.hover-film_error { background-position: -523px -73px; }
-.ico.film_go, *:hover > .ico.hover-film_go { background-position: -523px -91px; }
-.ico.film_key, *:hover > .ico.hover-film_key { background-position: -523px -109px; }
-.ico.film_link, *:hover > .ico.hover-film_link { background-position: -523px -127px; }
-.ico.film_save, *:hover > .ico.hover-film_save { background-position: -523px -145px; }
-.ico.find, *:hover > .ico.hover-find { background-position: -523px -163px; }
-.ico.flag_blue, *:hover > .ico.hover-flag_blue { background-position: -523px -181px; }
-.ico.flag_green, *:hover > .ico.hover-flag_green { background-position: -523px -199px; }
-.ico.flag_orange, *:hover > .ico.hover-flag_orange { background-position: -523px -217px; }
-.ico.flag_pink, *:hover > .ico.hover-flag_pink { background-position: -523px -235px; }
-.ico.flag_purple, *:hover > .ico.hover-flag_purple { background-position: -541px -1px; }
-.ico.flag_red, *:hover > .ico.hover-flag_red { background-position: -541px -19px; }
-.ico.flag_yellow, *:hover > .ico.hover-flag_yellow { background-position: -541px -37px; }
-.ico.folder, *:hover > .ico.hover-folder { background-position: -541px -55px; }
-.ico.folder_add, *:hover > .ico.hover-folder_add { background-position: -541px -73px; }
-.ico.folder_bell, *:hover > .ico.hover-folder_bell { background-position: -541px -91px; }
-.ico.folder_brick, *:hover > .ico.hover-folder_brick { background-position: -541px -109px; }
-.ico.folder_bug, *:hover > .ico.hover-folder_bug { background-position: -541px -127px; }
-.ico.folder_camera, *:hover > .ico.hover-folder_camera { background-position: -541px -145px; }
-.ico.folder_database, *:hover > .ico.hover-folder_database { background-position: -541px -163px; }
-.ico.folder_delete, *:hover > .ico.hover-folder_delete { background-position: -541px -181px; }
-.ico.folder_edit, *:hover > .ico.hover-folder_edit { background-position: -541px -199px; }
-.ico.folder_error, *:hover > .ico.hover-folder_error { background-position: -541px -217px; }
-.ico.folder_explore, *:hover > .ico.hover-folder_explore { background-position: -541px -235px; }
-.ico.folder_feed, *:hover > .ico.hover-folder_feed { background-position: -559px -1px; }
-.ico.folder_find, *:hover > .ico.hover-folder_find { background-position: -559px -19px; }
-.ico.folder_go, *:hover > .ico.hover-folder_go { background-position: -559px -37px; }
-.ico.folder_heart, *:hover > .ico.hover-folder_heart { background-position: -559px -55px; }
-.ico.folder_image, *:hover > .ico.hover-folder_image { background-position: -559px -73px; }
-.ico.folder_key, *:hover > .ico.hover-folder_key { background-position: -559px -91px; }
-.ico.folder_lightbulb, *:hover > .ico.hover-folder_lightbulb { background-position: -559px -109px; }
-.ico.folder_link, *:hover > .ico.hover-folder_link { background-position: -559px -127px; }
-.ico.folder_magnify, *:hover > .ico.hover-folder_magnify { background-position: -559px -145px; }
-.ico.folder_page, *:hover > .ico.hover-folder_page { background-position: -559px -163px; }
-.ico.folder_page_white, *:hover > .ico.hover-folder_page_white { background-position: -559px -181px; }
-.ico.folder_palette, *:hover > .ico.hover-folder_palette { background-position: -559px -199px; }
-.ico.folder_picture, *:hover > .ico.hover-folder_picture { background-position: -559px -217px; }
-.ico.folder_star, *:hover > .ico.hover-folder_star { background-position: -559px -235px; }
-.ico.folder_table, *:hover > .ico.hover-folder_table { background-position: -577px -1px; }
-.ico.folder_user, *:hover > .ico.hover-folder_user { background-position: -577px -19px; }
-.ico.folder_wrench, *:hover > .ico.hover-folder_wrench { background-position: -577px -37px; }
-.ico.font, *:hover > .ico.hover-font { background-position: -577px -55px; }
-.ico.font_add, *:hover > .ico.hover-font_add { background-position: -577px -73px; }
-.ico.font_delete, *:hover > .ico.hover-font_delete { background-position: -577px -91px; }
-.ico.font_go, *:hover > .ico.hover-font_go { background-position: -577px -109px; }
-.ico.group, *:hover > .ico.hover-group { background-position: -577px -127px; }
-.ico.group_add, *:hover > .ico.hover-group_add { background-position: -577px -145px; }
-.ico.group_delete, *:hover > .ico.hover-group_delete { background-position: -577px -163px; }
-.ico.group_edit, *:hover > .ico.hover-group_edit { background-position: -577px -181px; }
-.ico.group_error, *:hover > .ico.hover-group_error { background-position: -577px -199px; }
-.ico.group_gear, *:hover > .ico.hover-group_gear { background-position: -577px -217px; }
-.ico.group_go, *:hover > .ico.hover-group_go { background-position: -577px -235px; }
-.ico.group_key, *:hover > .ico.hover-group_key { background-position: -595px -1px; }
-.ico.group_link, *:hover > .ico.hover-group_link { background-position: -595px -19px; }
-.ico.heart, *:hover > .ico.hover-heart { background-position: -595px -37px; }
-.ico.heart_add, *:hover > .ico.hover-heart_add { background-position: -595px -55px; }
-.ico.heart_delete, *:hover > .ico.hover-heart_delete { background-position: -595px -73px; }
-.ico.help, *:hover > .ico.hover-help { background-position: -595px -91px; }
-.ico.hourglass, *:hover > .ico.hover-hourglass { background-position: -595px -109px; }
-.ico.hourglass_add, *:hover > .ico.hover-hourglass_add { background-position: -595px -127px; }
-.ico.hourglass_delete, *:hover > .ico.hover-hourglass_delete { background-position: -595px -145px; }
-.ico.hourglass_go, *:hover > .ico.hover-hourglass_go { background-position: -595px -163px; }
-.ico.hourglass_link, *:hover > .ico.hover-hourglass_link { background-position: -595px -181px; }
-.ico.house, *:hover > .ico.hover-house { background-position: -595px -199px; }
-.ico.house_go, *:hover > .ico.hover-house_go { background-position: -595px -217px; }
-.ico.house_link, *:hover > .ico.hover-house_link { background-position: -595px -235px; }
-.ico.html, *:hover > .ico.hover-html { background-position: -613px -1px; }
-.ico.html_add, *:hover > .ico.hover-html_add { background-position: -613px -19px; }
-.ico.html_delete, *:hover > .ico.hover-html_delete { background-position: -613px -37px; }
-.ico.html_go, *:hover > .ico.hover-html_go { background-position: -613px -55px; }
-.ico.html_valid, *:hover > .ico.hover-html_valid { background-position: -613px -73px; }
-.ico.image, *:hover > .ico.hover-image { background-position: -613px -91px; }
-.ico.image_add, *:hover > .ico.hover-image_add { background-position: -613px -109px; }
-.ico.image_delete, *:hover > .ico.hover-image_delete { background-position: -613px -127px; }
-.ico.image_edit, *:hover > .ico.hover-image_edit { background-position: -613px -145px; }
-.ico.image_link, *:hover > .ico.hover-image_link { background-position: -613px -163px; }
-.ico.images, *:hover > .ico.hover-images { background-position: -613px -181px; }
-.ico.information, *:hover > .ico.hover-information { background-position: -613px -199px; }
-.ico.ipod, *:hover > .ico.hover-ipod { background-position: -613px -217px; }
-.ico.ipod_cast, *:hover > .ico.hover-ipod_cast { background-position: -613px -235px; }
-.ico.ipod_cast_add, *:hover > .ico.hover-ipod_cast_add { background-position: -631px -1px; }
-.ico.ipod_cast_delete, *:hover > .ico.hover-ipod_cast_delete { background-position: -631px -19px; }
-.ico.ipod_sound, *:hover > .ico.hover-ipod_sound { background-position: -631px -37px; }
-.ico.joystick, *:hover > .ico.hover-joystick { background-position: -631px -55px; }
-.ico.joystick_add, *:hover > .ico.hover-joystick_add { background-position: -631px -73px; }
-.ico.joystick_delete, *:hover > .ico.hover-joystick_delete { background-position: -631px -91px; }
-.ico.joystick_error, *:hover > .ico.hover-joystick_error { background-position: -631px -109px; }
-.ico.key, *:hover > .ico.hover-key { background-position: -631px -127px; }
-.ico.key_add, *:hover > .ico.hover-key_add { background-position: -631px -145px; }
-.ico.key_delete, *:hover > .ico.hover-key_delete { background-position: -631px -163px; }
-.ico.key_go, *:hover > .ico.hover-key_go { background-position: -631px -181px; }
-.ico.keyboard, *:hover > .ico.hover-keyboard { background-position: -631px -199px; }
-.ico.keyboard_add, *:hover > .ico.hover-keyboard_add { background-position: -631px -217px; }
-.ico.keyboard_delete, *:hover > .ico.hover-keyboard_delete { background-position: -631px -235px; }
-.ico.keyboard_magnify, *:hover > .ico.hover-keyboard_magnify { background-position: -649px -1px; }
-.ico.layers, *:hover > .ico.hover-layers { background-position: -649px -19px; }
-.ico.layout, *:hover > .ico.hover-layout { background-position: -649px -37px; }
-.ico.layout_add, *:hover > .ico.hover-layout_add { background-position: -649px -55px; }
-.ico.layout_content, *:hover > .ico.hover-layout_content { background-position: -649px -73px; }
-.ico.layout_delete, *:hover > .ico.hover-layout_delete { background-position: -649px -91px; }
-.ico.layout_edit, *:hover > .ico.hover-layout_edit { background-position: -649px -109px; }
-.ico.layout_error, *:hover > .ico.hover-layout_error { background-position: -649px -127px; }
-.ico.layout_header, *:hover > .ico.hover-layout_header { background-position: -649px -145px; }
-.ico.layout_link, *:hover > .ico.hover-layout_link { background-position: -649px -163px; }
-.ico.layout_sidebar, *:hover > .ico.hover-layout_sidebar { background-position: -649px -181px; }
-.ico.lightbulb, *:hover > .ico.hover-lightbulb { background-position: -649px -199px; }
-.ico.lightbulb_add, *:hover > .ico.hover-lightbulb_add { background-position: -649px -217px; }
-.ico.lightbulb_delete, *:hover > .ico.hover-lightbulb_delete { background-position: -649px -235px; }
-.ico.lightbulb_off, *:hover > .ico.hover-lightbulb_off { background-position: -667px -1px; }
-.ico.lightning, *:hover > .ico.hover-lightning { background-position: -667px -19px; }
-.ico.lightning_add, *:hover > .ico.hover-lightning_add { background-position: -667px -37px; }
-.ico.lightning_delete, *:hover > .ico.hover-lightning_delete { background-position: -667px -55px; }
-.ico.lightning_go, *:hover > .ico.hover-lightning_go { background-position: -667px -73px; }
-.ico.link, *:hover > .ico.hover-link { background-position: -667px -91px; }
-.ico.link_add, *:hover > .ico.hover-link_add { background-position: -667px -109px; }
-.ico.link_break, *:hover > .ico.hover-link_break { background-position: -667px -127px; }
-.ico.link_delete, *:hover > .ico.hover-link_delete { background-position: -667px -145px; }
-.ico.link_edit, *:hover > .ico.hover-link_edit { background-position: -667px -163px; }
-.ico.link_error, *:hover > .ico.hover-link_error { background-position: -667px -181px; }
-.ico.link_go, *:hover > .ico.hover-link_go { background-position: -667px -199px; }
-.ico.lock, *:hover > .ico.hover-lock { background-position: -667px -217px; }
-.ico.lock_add, *:hover > .ico.hover-lock_add { background-position: -667px -235px; }
-.ico.lock_break, *:hover > .ico.hover-lock_break { background-position: -685px -1px; }
-.ico.lock_delete, *:hover > .ico.hover-lock_delete { background-position: -685px -19px; }
-.ico.lock_edit, *:hover > .ico.hover-lock_edit { background-position: -685px -37px; }
-.ico.lock_go, *:hover > .ico.hover-lock_go { background-position: -685px -55px; }
-.ico.lock_open, *:hover > .ico.hover-lock_open { background-position: -685px -73px; }
-.ico.lorry, *:hover > .ico.hover-lorry { background-position: -685px -91px; }
-.ico.lorry_add, *:hover > .ico.hover-lorry_add { background-position: -685px -109px; }
-.ico.lorry_delete, *:hover > .ico.hover-lorry_delete { background-position: -685px -127px; }
-.ico.lorry_error, *:hover > .ico.hover-lorry_error { background-position: -685px -145px; }
-.ico.lorry_flatbed, *:hover > .ico.hover-lorry_flatbed { background-position: -685px -163px; }
-.ico.lorry_go, *:hover > .ico.hover-lorry_go { background-position: -685px -181px; }
-.ico.lorry_link, *:hover > .ico.hover-lorry_link { background-position: -685px -199px; }
-.ico.magifier_zoom_out, *:hover > .ico.hover-magifier_zoom_out { background-position: -685px -217px; }
-.ico.magnifier, *:hover > .ico.hover-magnifier { background-position: -685px -235px; }
-.ico.magnifier_zoom_in, *:hover > .ico.hover-magnifier_zoom_in { background-position: -703px -1px; }
-.ico.male, *:hover > .ico.hover-male { background-position: -703px -19px; }
-.ico.map, *:hover > .ico.hover-map { background-position: -703px -37px; }
-.ico.map_add, *:hover > .ico.hover-map_add { background-position: -703px -55px; }
-.ico.map_delete, *:hover > .ico.hover-map_delete { background-position: -703px -73px; }
-.ico.map_edit, *:hover > .ico.hover-map_edit { background-position: -703px -91px; }
-.ico.map_go, *:hover > .ico.hover-map_go { background-position: -703px -109px; }
-.ico.map_magnify, *:hover > .ico.hover-map_magnify { background-position: -703px -127px; }
-.ico.medal_bronze_1, *:hover > .ico.hover-medal_bronze_1 { background-position: -703px -145px; }
-.ico.medal_bronze_2, *:hover > .ico.hover-medal_bronze_2 { background-position: -703px -163px; }
-.ico.medal_bronze_3, *:hover > .ico.hover-medal_bronze_3 { background-position: -703px -181px; }
-.ico.medal_bronze_add, *:hover > .ico.hover-medal_bronze_add { background-position: -703px -199px; }
-.ico.medal_bronze_delete, *:hover > .ico.hover-medal_bronze_delete { background-position: -703px -217px; }
-.ico.medal_gold_1, *:hover > .ico.hover-medal_gold_1 { background-position: -703px -235px; }
-.ico.medal_gold_2, *:hover > .ico.hover-medal_gold_2 { background-position: -721px -1px; }
-.ico.medal_gold_3, *:hover > .ico.hover-medal_gold_3 { background-position: -721px -19px; }
-.ico.medal_gold_add, *:hover > .ico.hover-medal_gold_add { background-position: -721px -37px; }
-.ico.medal_gold_delete, *:hover > .ico.hover-medal_gold_delete { background-position: -721px -55px; }
-.ico.medal_silver_1, *:hover > .ico.hover-medal_silver_1 { background-position: -721px -73px; }
-.ico.medal_silver_2, *:hover > .ico.hover-medal_silver_2 { background-position: -721px -91px; }
-.ico.medal_silver_3, *:hover > .ico.hover-medal_silver_3 { background-position: -721px -109px; }
-.ico.medal_silver_add, *:hover > .ico.hover-medal_silver_add { background-position: -721px -127px; }
-.ico.medal_silver_delete, *:hover > .ico.hover-medal_silver_delete { background-position: -721px -145px; }
-.ico.money, *:hover > .ico.hover-money { background-position: -721px -163px; }
-.ico.money_add, *:hover > .ico.hover-money_add { background-position: -721px -181px; }
-.ico.money_delete, *:hover > .ico.hover-money_delete { background-position: -721px -199px; }
-.ico.money_dollar, *:hover > .ico.hover-money_dollar { background-position: -721px -217px; }
-.ico.money_euro, *:hover > .ico.hover-money_euro { background-position: -721px -235px; }
-.ico.money_pound, *:hover > .ico.hover-money_pound { background-position: -739px -1px; }
-.ico.money_yen, *:hover > .ico.hover-money_yen { background-position: -739px -19px; }
-.ico.monitor, *:hover > .ico.hover-monitor { background-position: -739px -37px; }
-.ico.monitor_add, *:hover > .ico.hover-monitor_add { background-position: -739px -55px; }
-.ico.monitor_delete, *:hover > .ico.hover-monitor_delete { background-position: -739px -73px; }
-.ico.monitor_edit, *:hover > .ico.hover-monitor_edit { background-position: -739px -91px; }
-.ico.monitor_error, *:hover > .ico.hover-monitor_error { background-position: -739px -109px; }
-.ico.monitor_go, *:hover > .ico.hover-monitor_go { background-position: -739px -127px; }
-.ico.monitor_lightning, *:hover > .ico.hover-monitor_lightning { background-position: -739px -145px; }
-.ico.monitor_link, *:hover > .ico.hover-monitor_link { background-position: -739px -163px; }
-.ico.mouse, *:hover > .ico.hover-mouse { background-position: -739px -181px; }
-.ico.mouse_add, *:hover > .ico.hover-mouse_add { background-position: -739px -199px; }
-.ico.mouse_delete, *:hover > .ico.hover-mouse_delete { background-position: -739px -217px; }
-.ico.mouse_error, *:hover > .ico.hover-mouse_error { background-position: -739px -235px; }
-.ico.music, *:hover > .ico.hover-music { background-position: -757px -1px; }
-.ico.new, *:hover > .ico.hover-new { background-position: -757px -19px; }
-.ico.newspaper, *:hover > .ico.hover-newspaper { background-position: -757px -37px; }
-.ico.newspaper_add, *:hover > .ico.hover-newspaper_add { background-position: -757px -55px; }
-.ico.newspaper_delete, *:hover > .ico.hover-newspaper_delete { background-position: -757px -73px; }
-.ico.newspaper_go, *:hover > .ico.hover-newspaper_go { background-position: -757px -91px; }
-.ico.newspaper_link, *:hover > .ico.hover-newspaper_link { background-position: -757px -109px; }
-.ico.note, *:hover > .ico.hover-note { background-position: -757px -127px; }
-.ico.note_add, *:hover > .ico.hover-note_add { background-position: -757px -145px; }
-.ico.note_delete, *:hover > .ico.hover-note_delete { background-position: -757px -163px; }
-.ico.note_edit, *:hover > .ico.hover-note_edit { background-position: -757px -181px; }
-.ico.note_error, *:hover > .ico.hover-note_error { background-position: -757px -199px; }
-.ico.note_go, *:hover > .ico.hover-note_go { background-position: -757px -217px; }
-.ico.package, *:hover > .ico.hover-package { background-position: -757px -235px; }
-.ico.package_add, *:hover > .ico.hover-package_add { background-position: -775px -1px; }
-.ico.package_delete, *:hover > .ico.hover-package_delete { background-position: -775px -19px; }
-.ico.package_go, *:hover > .ico.hover-package_go { background-position: -775px -37px; }
-.ico.package_green, *:hover > .ico.hover-package_green { background-position: -775px -55px; }
-.ico.package_link, *:hover > .ico.hover-package_link { background-position: -775px -73px; }
-.ico.page, *:hover > .ico.hover-page { background-position: -775px -91px; }
-.ico.page_add, *:hover > .ico.hover-page_add { background-position: -775px -109px; }
-.ico.page_attach, *:hover > .ico.hover-page_attach { background-position: -775px -127px; }
-.ico.page_code, *:hover > .ico.hover-page_code { background-position: -775px -145px; }
-.ico.page_copy, *:hover > .ico.hover-page_copy { background-position: -775px -163px; }
-.ico.page_delete, *:hover > .ico.hover-page_delete { background-position: -775px -181px; }
-.ico.page_edit, *:hover > .ico.hover-page_edit { background-position: -775px -199px; }
-.ico.page_error, *:hover > .ico.hover-page_error { background-position: -775px -217px; }
-.ico.page_excel, *:hover > .ico.hover-page_excel { background-position: -775px -235px; }
-.ico.page_find, *:hover > .ico.hover-page_find { background-position: -793px -1px; }
-.ico.page_gear, *:hover > .ico.hover-page_gear { background-position: -793px -19px; }
-.ico.page_go, *:hover > .ico.hover-page_go { background-position: -793px -37px; }
-.ico.page_green, *:hover > .ico.hover-page_green { background-position: -793px -55px; }
-.ico.page_key, *:hover > .ico.hover-page_key { background-position: -793px -73px; }
-.ico.page_lightning, *:hover > .ico.hover-page_lightning { background-position: -793px -91px; }
-.ico.page_link, *:hover > .ico.hover-page_link { background-position: -793px -109px; }
-.ico.page_paintbrush, *:hover > .ico.hover-page_paintbrush { background-position: -793px -127px; }
-.ico.page_paste, *:hover > .ico.hover-page_paste { background-position: -793px -145px; }
-.ico.page_red, *:hover > .ico.hover-page_red { background-position: -793px -163px; }
-.ico.page_refresh, *:hover > .ico.hover-page_refresh { background-position: -793px -181px; }
-.ico.page_save, *:hover > .ico.hover-page_save { background-position: -793px -199px; }
-.ico.page_white, *:hover > .ico.hover-page_white { background-position: -793px -217px; }
-.ico.page_white_acrobat, *:hover > .ico.hover-page_white_acrobat { background-position: -793px -235px; }
-.ico.page_white_actionscript, *:hover > .ico.hover-page_white_actionscript { background-position: -811px -1px; }
-.ico.page_white_add, *:hover > .ico.hover-page_white_add { background-position: -811px -19px; }
-.ico.page_white_c, *:hover > .ico.hover-page_white_c { background-position: -811px -37px; }
-.ico.page_white_camera, *:hover > .ico.hover-page_white_camera { background-position: -811px -55px; }
-.ico.page_white_cd, *:hover > .ico.hover-page_white_cd { background-position: -811px -73px; }
-.ico.page_white_code, *:hover > .ico.hover-page_white_code { background-position: -811px -91px; }
-.ico.page_white_code_red, *:hover > .ico.hover-page_white_code_red { background-position: -811px -109px; }
-.ico.page_white_coldfusion, *:hover > .ico.hover-page_white_coldfusion { background-position: -811px -127px; }
-.ico.page_white_compressed, *:hover > .ico.hover-page_white_compressed { background-position: -811px -145px; }
-.ico.page_white_copy, *:hover > .ico.hover-page_white_copy { background-position: -811px -163px; }
-.ico.page_white_cplusplus, *:hover > .ico.hover-page_white_cplusplus { background-position: -811px -181px; }
-.ico.page_white_csharp, *:hover > .ico.hover-page_white_csharp { background-position: -811px -199px; }
-.ico.page_white_cup, *:hover > .ico.hover-page_white_cup { background-position: -811px -217px; }
-.ico.page_white_database, *:hover > .ico.hover-page_white_database { background-position: -811px -235px; }
-.ico.page_white_delete, *:hover > .ico.hover-page_white_delete { background-position: -829px -1px; }
-.ico.page_white_dvd, *:hover > .ico.hover-page_white_dvd { background-position: -829px -19px; }
-.ico.page_white_edit, *:hover > .ico.hover-page_white_edit { background-position: -829px -37px; }
-.ico.page_white_error, *:hover > .ico.hover-page_white_error { background-position: -829px -55px; }
-.ico.page_white_excel, *:hover > .ico.hover-page_white_excel { background-position: -829px -73px; }
-.ico.page_white_find, *:hover > .ico.hover-page_white_find { background-position: -829px -91px; }
-.ico.page_white_flash, *:hover > .ico.hover-page_white_flash { background-position: -829px -109px; }
-.ico.page_white_freehand, *:hover > .ico.hover-page_white_freehand { background-position: -829px -127px; }
-.ico.page_white_gear, *:hover > .ico.hover-page_white_gear { background-position: -829px -145px; }
-.ico.page_white_get, *:hover > .ico.hover-page_white_get { background-position: -829px -163px; }
-.ico.page_white_go, *:hover > .ico.hover-page_white_go { background-position: -829px -181px; }
-.ico.page_white_h, *:hover > .ico.hover-page_white_h { background-position: -829px -199px; }
-.ico.page_white_horizontal, *:hover > .ico.hover-page_white_horizontal { background-position: -829px -217px; }
-.ico.page_white_key, *:hover > .ico.hover-page_white_key { background-position: -829px -235px; }
-.ico.page_white_lightning, *:hover > .ico.hover-page_white_lightning { background-position: -847px -1px; }
-.ico.page_white_link, *:hover > .ico.hover-page_white_link { background-position: -847px -19px; }
-.ico.page_white_magnify, *:hover > .ico.hover-page_white_magnify { background-position: -847px -37px; }
-.ico.page_white_medal, *:hover > .ico.hover-page_white_medal { background-position: -847px -55px; }
-.ico.page_white_office, *:hover > .ico.hover-page_white_office { background-position: -847px -73px; }
-.ico.page_white_paint, *:hover > .ico.hover-page_white_paint { background-position: -847px -91px; }
-.ico.page_white_paintbrush, *:hover > .ico.hover-page_white_paintbrush { background-position: -847px -109px; }
-.ico.page_white_paste, *:hover > .ico.hover-page_white_paste { background-position: -847px -127px; }
-.ico.page_white_php, *:hover > .ico.hover-page_white_php { background-position: -847px -145px; }
-.ico.page_white_picture, *:hover > .ico.hover-page_white_picture { background-position: -847px -163px; }
-.ico.page_white_powerpoint, *:hover > .ico.hover-page_white_powerpoint { background-position: -847px -181px; }
-.ico.page_white_put, *:hover > .ico.hover-page_white_put { background-position: -847px -199px; }
-.ico.page_white_ruby, *:hover > .ico.hover-page_white_ruby { background-position: -847px -217px; }
-.ico.page_white_stack, *:hover > .ico.hover-page_white_stack { background-position: -847px -235px; }
-.ico.page_white_star, *:hover > .ico.hover-page_white_star { background-position: -865px -1px; }
-.ico.page_white_swoosh, *:hover > .ico.hover-page_white_swoosh { background-position: -865px -19px; }
-.ico.page_white_text, *:hover > .ico.hover-page_white_text { background-position: -865px -37px; }
-.ico.page_white_text_width, *:hover > .ico.hover-page_white_text_width { background-position: -865px -55px; }
-.ico.page_white_tux, *:hover > .ico.hover-page_white_tux { background-position: -865px -73px; }
-.ico.page_white_vector, *:hover > .ico.hover-page_white_vector { background-position: -865px -91px; }
-.ico.page_white_visualstudio, *:hover > .ico.hover-page_white_visualstudio { background-position: -865px -109px; }
-.ico.page_white_width, *:hover > .ico.hover-page_white_width { background-position: -865px -127px; }
-.ico.page_white_word, *:hover > .ico.hover-page_white_word { background-position: -865px -145px; }
-.ico.page_white_world, *:hover > .ico.hover-page_white_world { background-position: -865px -163px; }
-.ico.page_white_wrench, *:hover > .ico.hover-page_white_wrench { background-position: -865px -181px; }
-.ico.page_white_zip, *:hover > .ico.hover-page_white_zip { background-position: -865px -199px; }
-.ico.page_word, *:hover > .ico.hover-page_word { background-position: -865px -217px; }
-.ico.page_world, *:hover > .ico.hover-page_world { background-position: -865px -235px; }
-.ico.paintbrush, *:hover > .ico.hover-paintbrush { background-position: -883px -1px; }
-.ico.paintcan, *:hover > .ico.hover-paintcan { background-position: -883px -19px; }
-.ico.palette, *:hover > .ico.hover-palette { background-position: -883px -37px; }
-.ico.paste_plain, *:hover > .ico.hover-paste_plain { background-position: -883px -55px; }
-.ico.paste_word, *:hover > .ico.hover-paste_word { background-position: -883px -73px; }
-.ico.pencil, *:hover > .ico.hover-pencil { background-position: -883px -91px; }
-.ico.pencil_add, *:hover > .ico.hover-pencil_add { background-position: -883px -109px; }
-.ico.pencil_delete, *:hover > .ico.hover-pencil_delete { background-position: -883px -127px; }
-.ico.pencil_go, *:hover > .ico.hover-pencil_go { background-position: -883px -145px; }
-.ico.phone, *:hover > .ico.hover-phone { background-position: -883px -163px; }
-.ico.phone_add, *:hover > .ico.hover-phone_add { background-position: -883px -181px; }
-.ico.phone_delete, *:hover > .ico.hover-phone_delete { background-position: -883px -199px; }
-.ico.phone_sound, *:hover > .ico.hover-phone_sound { background-position: -883px -217px; }
-.ico.photo, *:hover > .ico.hover-photo { background-position: -883px -235px; }
-.ico.photo_add, *:hover > .ico.hover-photo_add { background-position: -901px -1px; }
-.ico.photo_delete, *:hover > .ico.hover-photo_delete { background-position: -901px -19px; }
-.ico.photo_link, *:hover > .ico.hover-photo_link { background-position: -901px -37px; }
-.ico.photos, *:hover > .ico.hover-photos { background-position: -901px -55px; }
-.ico.picture, *:hover > .ico.hover-picture { background-position: -901px -73px; }
-.ico.picture_add, *:hover > .ico.hover-picture_add { background-position: -901px -91px; }
-.ico.picture_delete, *:hover > .ico.hover-picture_delete { background-position: -901px -109px; }
-.ico.picture_edit, *:hover > .ico.hover-picture_edit { background-position: -901px -127px; }
-.ico.picture_empty, *:hover > .ico.hover-picture_empty { background-position: -901px -145px; }
-.ico.picture_error, *:hover > .ico.hover-picture_error { background-position: -901px -163px; }
-.ico.picture_go, *:hover > .ico.hover-picture_go { background-position: -901px -181px; }
-.ico.picture_key, *:hover > .ico.hover-picture_key { background-position: -901px -199px; }
-.ico.picture_link, *:hover > .ico.hover-picture_link { background-position: -901px -217px; }
-.ico.picture_save, *:hover > .ico.hover-picture_save { background-position: -901px -235px; }
-.ico.pictures, *:hover > .ico.hover-pictures { background-position: -919px -1px; }
-.ico.pilcrow, *:hover > .ico.hover-pilcrow { background-position: -919px -19px; }
-.ico.pill, *:hover > .ico.hover-pill { background-position: -919px -37px; }
-.ico.pill_add, *:hover > .ico.hover-pill_add { background-position: -919px -55px; }
-.ico.pill_delete, *:hover > .ico.hover-pill_delete { background-position: -919px -73px; }
-.ico.pill_go, *:hover > .ico.hover-pill_go { background-position: -919px -91px; }
-.ico.plugin, *:hover > .ico.hover-plugin { background-position: -919px -109px; }
-.ico.plugin_add, *:hover > .ico.hover-plugin_add { background-position: -919px -127px; }
-.ico.plugin_delete, *:hover > .ico.hover-plugin_delete { background-position: -919px -145px; }
-.ico.plugin_disabled, *:hover > .ico.hover-plugin_disabled { background-position: -919px -163px; }
-.ico.plugin_edit, *:hover > .ico.hover-plugin_edit { background-position: -919px -181px; }
-.ico.plugin_error, *:hover > .ico.hover-plugin_error { background-position: -919px -199px; }
-.ico.plugin_go, *:hover > .ico.hover-plugin_go { background-position: -919px -217px; }
-.ico.plugin_link, *:hover > .ico.hover-plugin_link { background-position: -919px -235px; }
-.ico.printer, *:hover > .ico.hover-printer { background-position: -937px -1px; }
-.ico.printer_add, *:hover > .ico.hover-printer_add { background-position: -937px -19px; }
-.ico.printer_delete, *:hover > .ico.hover-printer_delete { background-position: -937px -37px; }
-.ico.printer_empty, *:hover > .ico.hover-printer_empty { background-position: -937px -55px; }
-.ico.printer_error, *:hover > .ico.hover-printer_error { background-position: -937px -73px; }
-.ico.rainbow, *:hover > .ico.hover-rainbow { background-position: -937px -91px; }
-.ico.report, *:hover > .ico.hover-report { background-position: -937px -109px; }
-.ico.report_add, *:hover > .ico.hover-report_add { background-position: -937px -127px; }
-.ico.report_delete, *:hover > .ico.hover-report_delete { background-position: -937px -145px; }
-.ico.report_disk, *:hover > .ico.hover-report_disk { background-position: -937px -163px; }
-.ico.report_edit, *:hover > .ico.hover-report_edit { background-position: -937px -181px; }
-.ico.report_go, *:hover > .ico.hover-report_go { background-position: -937px -199px; }
-.ico.report_key, *:hover > .ico.hover-report_key { background-position: -937px -217px; }
-.ico.report_link, *:hover > .ico.hover-report_link { background-position: -937px -235px; }
-.ico.report_magnify, *:hover > .ico.hover-report_magnify { background-position: -955px -1px; }
-.ico.report_picture, *:hover > .ico.hover-report_picture { background-position: -955px -19px; }
-.ico.report_user, *:hover > .ico.hover-report_user { background-position: -955px -37px; }
-.ico.report_word, *:hover > .ico.hover-report_word { background-position: -955px -55px; }
-.ico.resultset_first, *:hover > .ico.hover-resultset_first { background-position: -955px -73px; }
-.ico.resultset_last, *:hover > .ico.hover-resultset_last { background-position: -955px -91px; }
-.ico.resultset_next, *:hover > .ico.hover-resultset_next { background-position: -955px -109px; }
-.ico.resultset_previous, *:hover > .ico.hover-resultset_previous { background-position: -955px -127px; }
-.ico.rosette, *:hover > .ico.hover-rosette { background-position: -955px -145px; }
-.ico.rss, *:hover > .ico.hover-rss { background-position: -955px -163px; }
-.ico.rss_add, *:hover > .ico.hover-rss_add { background-position: -955px -181px; }
-.ico.rss_delete, *:hover > .ico.hover-rss_delete { background-position: -955px -199px; }
-.ico.rss_go, *:hover > .ico.hover-rss_go { background-position: -955px -217px; }
-.ico.rss_valid, *:hover > .ico.hover-rss_valid { background-position: -955px -235px; }
-.ico.ruby, *:hover > .ico.hover-ruby { background-position: -973px -1px; }
-.ico.ruby_add, *:hover > .ico.hover-ruby_add { background-position: -973px -19px; }
-.ico.ruby_delete, *:hover > .ico.hover-ruby_delete { background-position: -973px -37px; }
-.ico.ruby_gear, *:hover > .ico.hover-ruby_gear { background-position: -973px -55px; }
-.ico.ruby_get, *:hover > .ico.hover-ruby_get { background-position: -973px -73px; }
-.ico.ruby_go, *:hover > .ico.hover-ruby_go { background-position: -973px -91px; }
-.ico.ruby_key, *:hover > .ico.hover-ruby_key { background-position: -973px -109px; }
-.ico.ruby_link, *:hover > .ico.hover-ruby_link { background-position: -973px -127px; }
-.ico.ruby_put, *:hover > .ico.hover-ruby_put { background-position: -973px -145px; }
-.ico.script, *:hover > .ico.hover-script { background-position: -973px -163px; }
-.ico.script_add, *:hover > .ico.hover-script_add { background-position: -973px -181px; }
-.ico.script_code, *:hover > .ico.hover-script_code { background-position: -973px -199px; }
-.ico.script_code_red, *:hover > .ico.hover-script_code_red { background-position: -973px -217px; }
-.ico.script_delete, *:hover > .ico.hover-script_delete { background-position: -973px -235px; }
-.ico.script_edit, *:hover > .ico.hover-script_edit { background-position: -991px -1px; }
-.ico.script_error, *:hover > .ico.hover-script_error { background-position: -991px -19px; }
-.ico.script_gear, *:hover > .ico.hover-script_gear { background-position: -991px -37px; }
-.ico.script_go, *:hover > .ico.hover-script_go { background-position: -991px -55px; }
-.ico.script_key, *:hover > .ico.hover-script_key { background-position: -991px -73px; }
-.ico.script_lightning, *:hover > .ico.hover-script_lightning { background-position: -991px -91px; }
-.ico.script_link, *:hover > .ico.hover-script_link { background-position: -991px -109px; }
-.ico.script_palette, *:hover > .ico.hover-script_palette { background-position: -991px -127px; }
-.ico.script_save, *:hover > .ico.hover-script_save { background-position: -991px -145px; }
-.ico.server, *:hover > .ico.hover-server { background-position: -991px -163px; }
-.ico.server_add, *:hover > .ico.hover-server_add { background-position: -991px -181px; }
-.ico.server_chart, *:hover > .ico.hover-server_chart { background-position: -991px -199px; }
-.ico.server_compressed, *:hover > .ico.hover-server_compressed { background-position: -991px -217px; }
-.ico.server_connect, *:hover > .ico.hover-server_connect { background-position: -991px -235px; }
-.ico.server_database, *:hover > .ico.hover-server_database { background-position: -1009px -1px; }
-.ico.server_delete, *:hover > .ico.hover-server_delete { background-position: -1009px -19px; }
-.ico.server_edit, *:hover > .ico.hover-server_edit { background-position: -1009px -37px; }
-.ico.server_error, *:hover > .ico.hover-server_error { background-position: -1009px -55px; }
-.ico.server_go, *:hover > .ico.hover-server_go { background-position: -1009px -73px; }
-.ico.server_key, *:hover > .ico.hover-server_key { background-position: -1009px -91px; }
-.ico.server_lightning, *:hover > .ico.hover-server_lightning { background-position: -1009px -109px; }
-.ico.server_link, *:hover > .ico.hover-server_link { background-position: -1009px -127px; }
-.ico.server_uncompressed, *:hover > .ico.hover-server_uncompressed { background-position: -1009px -145px; }
-.ico.shading, *:hover > .ico.hover-shading { background-position: -1009px -163px; }
-.ico.shape_align_bottom, *:hover > .ico.hover-shape_align_bottom { background-position: -1009px -181px; }
-.ico.shape_align_center, *:hover > .ico.hover-shape_align_center { background-position: -1009px -199px; }
-.ico.shape_align_left, *:hover > .ico.hover-shape_align_left { background-position: -1009px -217px; }
-.ico.shape_align_middle, *:hover > .ico.hover-shape_align_middle { background-position: -1009px -235px; }
-.ico.shape_align_right, *:hover > .ico.hover-shape_align_right { background-position: -1027px -1px; }
-.ico.shape_align_top, *:hover > .ico.hover-shape_align_top { background-position: -1027px -19px; }
-.ico.shape_flip_horizontal, *:hover > .ico.hover-shape_flip_horizontal { background-position: -1027px -37px; }
-.ico.shape_flip_vertical, *:hover > .ico.hover-shape_flip_vertical { background-position: -1027px -55px; }
-.ico.shape_group, *:hover > .ico.hover-shape_group { background-position: -1027px -73px; }
-.ico.shape_handles, *:hover > .ico.hover-shape_handles { background-position: -1027px -91px; }
-.ico.shape_move_back, *:hover > .ico.hover-shape_move_back { background-position: -1027px -109px; }
-.ico.shape_move_backwards, *:hover > .ico.hover-shape_move_backwards { background-position: -1027px -127px; }
-.ico.shape_move_forwards, *:hover > .ico.hover-shape_move_forwards { background-position: -1027px -145px; }
-.ico.shape_move_front, *:hover > .ico.hover-shape_move_front { background-position: -1027px -163px; }
-.ico.shape_rotate_anticlockwise, *:hover > .ico.hover-shape_rotate_anticlockwise { background-position: -1027px -181px; }
-.ico.shape_rotate_clockwise, *:hover > .ico.hover-shape_rotate_clockwise { background-position: -1027px -199px; }
-.ico.shape_square, *:hover > .ico.hover-shape_square { background-position: -1027px -217px; }
-.ico.shape_square_add, *:hover > .ico.hover-shape_square_add { background-position: -1027px -235px; }
-.ico.shape_square_delete, *:hover > .ico.hover-shape_square_delete { background-position: -1045px -1px; }
-.ico.shape_square_edit, *:hover > .ico.hover-shape_square_edit { background-position: -1045px -19px; }
-.ico.shape_square_error, *:hover > .ico.hover-shape_square_error { background-position: -1045px -37px; }
-.ico.shape_square_go, *:hover > .ico.hover-shape_square_go { background-position: -1045px -55px; }
-.ico.shape_square_key, *:hover > .ico.hover-shape_square_key { background-position: -1045px -73px; }
-.ico.shape_square_link, *:hover > .ico.hover-shape_square_link { background-position: -1045px -91px; }
-.ico.shape_ungroup, *:hover > .ico.hover-shape_ungroup { background-position: -1045px -109px; }
-.ico.shield, *:hover > .ico.hover-shield { background-position: -1045px -127px; }
-.ico.shield_add, *:hover > .ico.hover-shield_add { background-position: -1045px -145px; }
-.ico.shield_delete, *:hover > .ico.hover-shield_delete { background-position: -1045px -163px; }
-.ico.shield_go, *:hover > .ico.hover-shield_go { background-position: -1045px -181px; }
-.ico.sitemap, *:hover > .ico.hover-sitemap { background-position: -1045px -199px; }
-.ico.sitemap_color, *:hover > .ico.hover-sitemap_color { background-position: -1045px -217px; }
-.ico.sound, *:hover > .ico.hover-sound { background-position: -1045px -235px; }
-.ico.sound_add, *:hover > .ico.hover-sound_add { background-position: -1063px -1px; }
-.ico.sound_delete, *:hover > .ico.hover-sound_delete { background-position: -1063px -19px; }
-.ico.sound_low, *:hover > .ico.hover-sound_low { background-position: -1063px -37px; }
-.ico.sound_mute, *:hover > .ico.hover-sound_mute { background-position: -1063px -55px; }
-.ico.sound_none, *:hover > .ico.hover-sound_none { background-position: -1063px -73px; }
-.ico.spellcheck, *:hover > .ico.hover-spellcheck { background-position: -1063px -91px; }
-.ico.sport_8ball, *:hover > .ico.hover-sport_8ball { background-position: -1063px -109px; }
-.ico.sport_basketball, *:hover > .ico.hover-sport_basketball { background-position: -1063px -127px; }
-.ico.sport_football, *:hover > .ico.hover-sport_football { background-position: -1063px -145px; }
-.ico.sport_golf, *:hover > .ico.hover-sport_golf { background-position: -1063px -163px; }
-.ico.sport_raquet, *:hover > .ico.hover-sport_raquet { background-position: -1063px -181px; }
-.ico.sport_shuttlecock, *:hover > .ico.hover-sport_shuttlecock { background-position: -1063px -199px; }
-.ico.sport_soccer, *:hover > .ico.hover-sport_soccer { background-position: -1063px -217px; }
-.ico.sport_tennis, *:hover > .ico.hover-sport_tennis { background-position: -1063px -235px; }
-.ico.star, *:hover > .ico.hover-star { background-position: -1081px -1px; }
-.ico.status_away, *:hover > .ico.hover-status_away { background-position: -1081px -19px; }
-.ico.status_busy, *:hover > .ico.hover-status_busy { background-position: -1081px -37px; }
-.ico.status_offline, *:hover > .ico.hover-status_offline { background-position: -1081px -55px; }
-.ico.status_online, *:hover > .ico.hover-status_online { background-position: -1081px -73px; }
-.ico.stop, *:hover > .ico.hover-stop { background-position: -1081px -91px; }
-.ico.style, *:hover > .ico.hover-style { background-position: -1081px -109px; }
-.ico.style_add, *:hover > .ico.hover-style_add { background-position: -1081px -127px; }
-.ico.style_delete, *:hover > .ico.hover-style_delete { background-position: -1081px -145px; }
-.ico.style_edit, *:hover > .ico.hover-style_edit { background-position: -1081px -163px; }
-.ico.style_go, *:hover > .ico.hover-style_go { background-position: -1081px -181px; }
-.ico.sum, *:hover > .ico.hover-sum { background-position: -1081px -199px; }
-.ico.tab, *:hover > .ico.hover-tab { background-position: -1081px -217px; }
-.ico.tab_add, *:hover > .ico.hover-tab_add { background-position: -1081px -235px; }
-.ico.tab_delete, *:hover > .ico.hover-tab_delete { background-position: -1099px -1px; }
-.ico.tab_edit, *:hover > .ico.hover-tab_edit { background-position: -1099px -19px; }
-.ico.tab_go, *:hover > .ico.hover-tab_go { background-position: -1099px -37px; }
-.ico.table_normal, *:hover > .ico.hover-table_normal { background-position: -1099px -55px; }
-.ico.table_add, *:hover > .ico.hover-table_add { background-position: -1099px -73px; }
-.ico.table_delete, *:hover > .ico.hover-table_delete { background-position: -1099px -91px; }
-.ico.table_edit, *:hover > .ico.hover-table_edit { background-position: -1099px -109px; }
-.ico.table_error, *:hover > .ico.hover-table_error { background-position: -1099px -127px; }
-.ico.table_gear, *:hover > .ico.hover-table_gear { background-position: -1099px -145px; }
-.ico.table_go, *:hover > .ico.hover-table_go { background-position: -1099px -163px; }
-.ico.table_key, *:hover > .ico.hover-table_key { background-position: -1099px -181px; }
-.ico.table_lightning, *:hover > .ico.hover-table_lightning { background-position: -1099px -199px; }
-.ico.table_link, *:hover > .ico.hover-table_link { background-position: -1099px -217px; }
-.ico.table_multiple, *:hover > .ico.hover-table_multiple { background-position: -1099px -235px; }
-.ico.table_refresh, *:hover > .ico.hover-table_refresh { background-position: -1117px -1px; }
-.ico.table_relationship, *:hover > .ico.hover-table_relationship { background-position: -1117px -19px; }
-.ico.table_row_delete, *:hover > .ico.hover-table_row_delete { background-position: -1117px -37px; }
-.ico.table_row_insert, *:hover > .ico.hover-table_row_insert { background-position: -1117px -55px; }
-.ico.table_save, *:hover > .ico.hover-table_save { background-position: -1117px -73px; }
-.ico.table_sort, *:hover > .ico.hover-table_sort { background-position: -1117px -91px; }
-.ico.tag, *:hover > .ico.hover-tag { background-position: -1117px -109px; }
-.ico.tag_blue, *:hover > .ico.hover-tag_blue { background-position: -1117px -127px; }
-.ico.tag_blue_add, *:hover > .ico.hover-tag_blue_add { background-position: -1117px -145px; }
-.ico.tag_blue_delete, *:hover > .ico.hover-tag_blue_delete { background-position: -1117px -163px; }
-.ico.tag_blue_edit, *:hover > .ico.hover-tag_blue_edit { background-position: -1117px -181px; }
-.ico.tag_green, *:hover > .ico.hover-tag_green { background-position: -1117px -199px; }
-.ico.tag_orange, *:hover > .ico.hover-tag_orange { background-position: -1117px -217px; }
-.ico.tag_pink, *:hover > .ico.hover-tag_pink { background-position: -1117px -235px; }
-.ico.tag_purple, *:hover > .ico.hover-tag_purple { background-position: -1135px -1px; }
-.ico.tag_red, *:hover > .ico.hover-tag_red { background-position: -1135px -19px; }
-.ico.tag_yellow, *:hover > .ico.hover-tag_yellow { background-position: -1135px -37px; }
-.ico.telephone, *:hover > .ico.hover-telephone { background-position: -1135px -55px; }
-.ico.telephone_add, *:hover > .ico.hover-telephone_add { background-position: -1135px -73px; }
-.ico.telephone_delete, *:hover > .ico.hover-telephone_delete { background-position: -1135px -91px; }
-.ico.telephone_edit, *:hover > .ico.hover-telephone_edit { background-position: -1135px -109px; }
-.ico.telephone_error, *:hover > .ico.hover-telephone_error { background-position: -1135px -127px; }
-.ico.telephone_go, *:hover > .ico.hover-telephone_go { background-position: -1135px -145px; }
-.ico.telephone_key, *:hover > .ico.hover-telephone_key { background-position: -1135px -163px; }
-.ico.telephone_link, *:hover > .ico.hover-telephone_link { background-position: -1135px -181px; }
-.ico.television, *:hover > .ico.hover-television { background-position: -1135px -199px; }
-.ico.television_add, *:hover > .ico.hover-television_add { background-position: -1135px -217px; }
-.ico.television_delete, *:hover > .ico.hover-television_delete { background-position: -1135px -235px; }
-.ico.text_align_center, *:hover > .ico.hover-text_align_center { background-position: -1153px -1px; }
-.ico.text_align_justify, *:hover > .ico.hover-text_align_justify { background-position: -1153px -19px; }
-.ico.text_align_left, *:hover > .ico.hover-text_align_left { background-position: -1153px -37px; }
-.ico.text_align_right, *:hover > .ico.hover-text_align_right { background-position: -1153px -55px; }
-.ico.text_allcaps, *:hover > .ico.hover-text_allcaps { background-position: -1153px -73px; }
-.ico.text_bold, *:hover > .ico.hover-text_bold { background-position: -1153px -91px; }
-.ico.text_columns, *:hover > .ico.hover-text_columns { background-position: -1153px -109px; }
-.ico.text_dropcaps, *:hover > .ico.hover-text_dropcaps { background-position: -1153px -127px; }
-.ico.text_heading_1, *:hover > .ico.hover-text_heading_1 { background-position: -1153px -145px; }
-.ico.text_heading_2, *:hover > .ico.hover-text_heading_2 { background-position: -1153px -163px; }
-.ico.text_heading_3, *:hover > .ico.hover-text_heading_3 { background-position: -1153px -181px; }
-.ico.text_heading_4, *:hover > .ico.hover-text_heading_4 { background-position: -1153px -199px; }
-.ico.text_heading_5, *:hover > .ico.hover-text_heading_5 { background-position: -1153px -217px; }
-.ico.text_heading_6, *:hover > .ico.hover-text_heading_6 { background-position: -1153px -235px; }
-.ico.text_horizontalrule, *:hover > .ico.hover-text_horizontalrule { background-position: -1171px -1px; }
-.ico.text_indent, *:hover > .ico.hover-text_indent { background-position: -1171px -19px; }
-.ico.text_indent_remove, *:hover > .ico.hover-text_indent_remove { background-position: -1171px -37px; }
-.ico.text_italic, *:hover > .ico.hover-text_italic { background-position: -1171px -55px; }
-.ico.text_kerning, *:hover > .ico.hover-text_kerning { background-position: -1171px -73px; }
-.ico.text_letter_omega, *:hover > .ico.hover-text_letter_omega { background-position: -1171px -91px; }
-.ico.text_letterspacing, *:hover > .ico.hover-text_letterspacing { background-position: -1171px -109px; }
-.ico.text_linespacing, *:hover > .ico.hover-text_linespacing { background-position: -1171px -127px; }
-.ico.text_list_bullets, *:hover > .ico.hover-text_list_bullets { background-position: -1171px -145px; }
-.ico.text_list_numbers, *:hover > .ico.hover-text_list_numbers { background-position: -1171px -163px; }
-.ico.text_lowercase, *:hover > .ico.hover-text_lowercase { background-position: -1171px -181px; }
-.ico.text_padding_bottom, *:hover > .ico.hover-text_padding_bottom { background-position: -1171px -199px; }
-.ico.text_padding_left, *:hover > .ico.hover-text_padding_left { background-position: -1171px -217px; }
-.ico.text_padding_right, *:hover > .ico.hover-text_padding_right { background-position: -1171px -235px; }
-.ico.text_padding_top, *:hover > .ico.hover-text_padding_top { background-position: -1189px -1px; }
-.ico.text_replace, *:hover > .ico.hover-text_replace { background-position: -1189px -19px; }
-.ico.text_signature, *:hover > .ico.hover-text_signature { background-position: -1189px -37px; }
-.ico.text_smallcaps, *:hover > .ico.hover-text_smallcaps { background-position: -1189px -55px; }
-.ico.text_strikethrough, *:hover > .ico.hover-text_strikethrough { background-position: -1189px -73px; }
-.ico.text_subscript, *:hover > .ico.hover-text_subscript { background-position: -1189px -91px; }
-.ico.text_superscript, *:hover > .ico.hover-text_superscript { background-position: -1189px -109px; }
-.ico.text_underline, *:hover > .ico.hover-text_underline { background-position: -1189px -127px; }
-.ico.text_uppercase, *:hover > .ico.hover-text_uppercase { background-position: -1189px -145px; }
-.ico.textfield, *:hover > .ico.hover-textfield { background-position: -1189px -163px; }
-.ico.textfield_add, *:hover > .ico.hover-textfield_add { background-position: -1189px -181px; }
-.ico.textfield_delete, *:hover > .ico.hover-textfield_delete { background-position: -1189px -199px; }
-.ico.textfield_key, *:hover > .ico.hover-textfield_key { background-position: -1189px -217px; }
-.ico.textfield_rename, *:hover > .ico.hover-textfield_rename { background-position: -1189px -235px; }
-.ico.thumb_down, *:hover > .ico.hover-thumb_down { background-position: -1207px -1px; }
-.ico.thumb_up, *:hover > .ico.hover-thumb_up { background-position: -1207px -19px; }
-.ico.tick, *:hover > .ico.hover-tick { background-position: -1207px -37px; }
-.ico.time, *:hover > .ico.hover-time { background-position: -1207px -55px; }
-.ico.time_add, *:hover > .ico.hover-time_add { background-position: -1207px -73px; }
-.ico.time_delete, *:hover > .ico.hover-time_delete { background-position: -1207px -91px; }
-.ico.time_go, *:hover > .ico.hover-time_go { background-position: -1207px -109px; }
-.ico.timeline_marker, *:hover > .ico.hover-timeline_marker { background-position: -1207px -127px; }
-.ico.transmit, *:hover > .ico.hover-transmit { background-position: -1207px -145px; }
-.ico.transmit_add, *:hover > .ico.hover-transmit_add { background-position: -1207px -163px; }
-.ico.transmit_blue, *:hover > .ico.hover-transmit_blue { background-position: -1207px -181px; }
-.ico.transmit_delete, *:hover > .ico.hover-transmit_delete { background-position: -1207px -199px; }
-.ico.transmit_edit, *:hover > .ico.hover-transmit_edit { background-position: -1207px -217px; }
-.ico.transmit_error, *:hover > .ico.hover-transmit_error { background-position: -1207px -235px; }
-.ico.transmit_go, *:hover > .ico.hover-transmit_go { background-position: -1225px -1px; }
-.ico.tux, *:hover > .ico.hover-tux { background-position: -1225px -19px; }
-.ico.user, *:hover > .ico.hover-user { background-position: -1225px -37px; }
-.ico.user_add, *:hover > .ico.hover-user_add { background-position: -1225px -55px; }
-.ico.user_comment, *:hover > .ico.hover-user_comment { background-position: -1225px -73px; }
-.ico.user_delete, *:hover > .ico.hover-user_delete { background-position: -1225px -91px; }
-.ico.user_edit, *:hover > .ico.hover-user_edit { background-position: -1225px -109px; }
-.ico.user_female, *:hover > .ico.hover-user_female { background-position: -1225px -127px; }
-.ico.user_go, *:hover > .ico.hover-user_go { background-position: -1225px -145px; }
-.ico.user_gray, *:hover > .ico.hover-user_gray { background-position: -1225px -163px; }
-.ico.user_green, *:hover > .ico.hover-user_green { background-position: -1225px -181px; }
-.ico.user_orange, *:hover > .ico.hover-user_orange { background-position: -1225px -199px; }
-.ico.user_red, *:hover > .ico.hover-user_red { background-position: -1225px -217px; }
-.ico.user_suit, *:hover > .ico.hover-user_suit { background-position: -1225px -235px; }
-.ico.vcard, *:hover > .ico.hover-vcard { background-position: -1243px -1px; }
-.ico.vcard_add, *:hover > .ico.hover-vcard_add { background-position: -1243px -19px; }
-.ico.vcard_delete, *:hover > .ico.hover-vcard_delete { background-position: -1243px -37px; }
-.ico.vcard_edit, *:hover > .ico.hover-vcard_edit { background-position: -1243px -55px; }
-.ico.vector, *:hover > .ico.hover-vector { background-position: -1243px -73px; }
-.ico.vector_add, *:hover > .ico.hover-vector_add { background-position: -1243px -91px; }
-.ico.vector_delete, *:hover > .ico.hover-vector_delete { background-position: -1243px -109px; }
-.ico.wand, *:hover > .ico.hover-wand { background-position: -1243px -127px; }
-.ico.weather_clouds, *:hover > .ico.hover-weather_clouds { background-position: -1243px -145px; }
-.ico.weather_cloudy, *:hover > .ico.hover-weather_cloudy { background-position: -1243px -163px; }
-.ico.weather_lightning, *:hover > .ico.hover-weather_lightning { background-position: -1243px -181px; }
-.ico.weather_rain, *:hover > .ico.hover-weather_rain { background-position: -1243px -199px; }
-.ico.weather_snow, *:hover > .ico.hover-weather_snow { background-position: -1243px -217px; }
-.ico.weather_sun, *:hover > .ico.hover-weather_sun { background-position: -1243px -235px; }
-.ico.webcam, *:hover > .ico.hover-webcam { background-position: -1261px -1px; }
-.ico.webcam_add, *:hover > .ico.hover-webcam_add { background-position: -1261px -19px; }
-.ico.webcam_delete, *:hover > .ico.hover-webcam_delete { background-position: -1261px -37px; }
-.ico.webcam_error, *:hover > .ico.hover-webcam_error { background-position: -1261px -55px; }
-.ico.world, *:hover > .ico.hover-world { background-position: -1261px -73px; }
-.ico.world_add, *:hover > .ico.hover-world_add { background-position: -1261px -91px; }
-.ico.world_delete, *:hover > .ico.hover-world_delete { background-position: -1261px -109px; }
-.ico.world_edit, *:hover > .ico.hover-world_edit { background-position: -1261px -127px; }
-.ico.world_go, *:hover > .ico.hover-world_go { background-position: -1261px -145px; }
-.ico.world_link, *:hover > .ico.hover-world_link { background-position: -1261px -163px; }
-.ico.wrench, *:hover > .ico.hover-wrench { background-position: -1261px -181px; }
-.ico.wrench_orange, *:hover > .ico.hover-wrench_orange { background-position: -1261px -199px; }
-.ico.xhtml, *:hover > .ico.hover-xhtml { background-position: -1261px -217px; }
-.ico.xhtml_add, *:hover > .ico.hover-xhtml_add { background-position: -1261px -235px; }
-.ico.xhtml_delete, *:hover > .ico.hover-xhtml_delete { background-position: -1279px -1px; }
-.ico.xhtml_go, *:hover > .ico.hover-xhtml_go { background-position: -1279px -19px; }
-.ico.xhtml_valid, *:hover > .ico.hover-xhtml_valid { background-position: -1279px -37px; }
-.ico.zoom, *:hover > .ico.hover-zoom { background-position: -1279px -55px; }
-.ico.zoom_in, *:hover > .ico.hover-zoom_in { background-position: -1279px -73px; }
-.ico.zoom_out, *:hover > .ico.hover-zoom_out { background-position: -1279px -91px; }
+.icon(@name, @position) {
+  .ico.@{name},
+  *:hover > .ico.hover-@{name} {
+    background-position: @position;
+  }
+
+  .dt-button-ico.dt-ico-@{name} {
+    span::before {
+      background-position: @position;
+    }
+  }
+}
+
+.icon(accept, -1px -1px);
+.icon(add, -1px -19px);
+.icon(anchor, -1px -37px);
+.icon(application, -1px -55px);
+.icon(application_add, -1px -73px);
+.icon(application_cascade, -1px -91px);
+.icon(application_delete, -1px -109px);
+.icon(application_double, -1px -127px);
+.icon(application_edit, -1px -145px);
+.icon(application_error, -1px -163px);
+.icon(application_form, -1px -181px);
+.icon(application_form_add, -1px -199px);
+.icon(application_form_delete, -1px -217px);
+.icon(application_form_edit, -1px -235px);
+.icon(application_form_magnify, -19px -1px);
+.icon(application_get, -19px -19px);
+.icon(application_go, -19px -37px);
+.icon(application_home, -19px -55px);
+.icon(application_key, -19px -73px);
+.icon(application_lightning, -19px -91px);
+.icon(application_link, -19px -109px);
+.icon(application_osx, -19px -127px);
+.icon(application_osx_terminal, -19px -145px);
+.icon(application_put, -19px -163px);
+.icon(application_side_boxes, -19px -181px);
+.icon(application_side_contract, -19px -199px);
+.icon(application_side_expand, -19px -217px);
+.icon(application_side_list, -19px -235px);
+.icon(application_side_tree, -37px -1px);
+.icon(application_split, -37px -19px);
+.icon(application_tile_horizontal, -37px -37px);
+.icon(application_tile_vertical, -37px -55px);
+.icon(application_view_columns, -37px -73px);
+.icon(application_view_detail, -37px -91px);
+.icon(application_view_gallery, -37px -109px);
+.icon(application_view_icons, -37px -127px);
+.icon(application_view_list, -37px -145px);
+.icon(application_view_tile, -37px -163px);
+.icon(application_xp, -37px -181px);
+.icon(application_xp_terminal, -37px -199px);
+.icon(arrow_branch, -37px -217px);
+.icon(arrow_divide, -37px -235px);
+.icon(arrow_down, -55px -1px);
+.icon(arrow_in, -55px -19px);
+.icon(arrow_inout, -55px -37px);
+.icon(arrow_join, -55px -55px);
+.icon(arrow_left, -55px -73px);
+.icon(arrow_merge, -55px -91px);
+.icon(arrow_out, -55px -109px);
+.icon(arrow_redo, -55px -127px);
+.icon(arrow_refresh, -55px -145px);
+.icon(arrow_refresh_small, -55px -163px);
+.icon(arrow_right, -55px -181px);
+.icon(arrow_rotate_anticlockwise, -55px -199px);
+.icon(arrow_rotate_clockwise, -55px -217px);
+.icon(arrow_switch, -55px -235px);
+.icon(arrow_turn_left, -73px -1px);
+.icon(arrow_turn_right, -73px -19px);
+.icon(arrow_undo, -73px -37px);
+.icon(arrow_up, -73px -55px);
+.icon(asterisk_orange, -73px -73px);
+.icon(asterisk_yellow, -73px -91px);
+.icon(attach, -73px -109px);
+.icon(award_star_add, -73px -127px);
+.icon(award_star_bronze_1, -73px -145px);
+.icon(award_star_bronze_2, -73px -163px);
+.icon(award_star_bronze_3, -73px -181px);
+.icon(award_star_delete, -73px -199px);
+.icon(award_star_gold_1, -73px -217px);
+.icon(award_star_gold_2, -73px -235px);
+.icon(award_star_gold_3, -91px -1px);
+.icon(award_star_silver_1, -91px -19px);
+.icon(award_star_silver_2, -91px -37px);
+.icon(award_star_silver_3, -91px -55px);
+.icon(basket, -91px -73px);
+.icon(basket_add, -91px -91px);
+.icon(basket_delete, -91px -109px);
+.icon(basket_edit, -91px -127px);
+.icon(basket_error, -91px -145px);
+.icon(basket_go, -91px -163px);
+.icon(basket_put, -91px -181px);
+.icon(basket_remove, -91px -199px);
+.icon(bell, -91px -217px);
+.icon(bell_add, -91px -235px);
+.icon(bell_delete, -109px -1px);
+.icon(bell_error, -109px -19px);
+.icon(bell_go, -109px -37px);
+.icon(bell_link, -109px -55px);
+.icon(bin, -109px -73px);
+.icon(bin_closed, -109px -91px);
+.icon(bin_empty, -109px -109px);
+.icon(bomb, -109px -127px);
+.icon(book, -109px -145px);
+.icon(book_add, -109px -163px);
+.icon(book_addresses, -109px -181px);
+.icon(book_delete, -109px -199px);
+.icon(book_edit, -109px -217px);
+.icon(book_error, -109px -235px);
+.icon(book_go, -127px -1px);
+.icon(book_key, -127px -19px);
+.icon(book_link, -127px -37px);
+.icon(book_next, -127px -55px);
+.icon(book_open, -127px -73px);
+.icon(book_previous, -127px -91px);
+.icon(box, -127px -109px);
+.icon(brick, -127px -127px);
+.icon(brick_add, -127px -145px);
+.icon(brick_delete, -127px -163px);
+.icon(brick_edit, -127px -181px);
+.icon(brick_error, -127px -199px);
+.icon(brick_go, -127px -217px);
+.icon(brick_link, -127px -235px);
+.icon(bricks, -145px -1px);
+.icon(briefcase, -145px -19px);
+.icon(bug, -145px -37px);
+.icon(bug_add, -145px -55px);
+.icon(bug_delete, -145px -73px);
+.icon(bug_edit, -145px -91px);
+.icon(bug_error, -145px -109px);
+.icon(bug_go, -145px -127px);
+.icon(bug_link, -145px -145px);
+.icon(building, -145px -163px);
+.icon(building_add, -145px -181px);
+.icon(building_delete, -145px -199px);
+.icon(building_edit, -145px -217px);
+.icon(building_error, -145px -235px);
+.icon(building_go, -163px -1px);
+.icon(building_key, -163px -19px);
+.icon(building_link, -163px -37px);
+.icon(bullet_add, -163px -55px);
+.icon(bullet_arrow_bottom, -163px -73px);
+.icon(bullet_arrow_down, -163px -91px);
+.icon(bullet_arrow_top, -163px -109px);
+.icon(bullet_arrow_up, -163px -127px);
+.icon(bullet_black, -163px -145px);
+.icon(bullet_blue, -163px -163px);
+.icon(bullet_delete, -163px -181px);
+.icon(bullet_disk, -163px -199px);
+.icon(bullet_error, -163px -217px);
+.icon(bullet_feed, -163px -235px);
+.icon(bullet_go, -181px -1px);
+.icon(bullet_green, -181px -19px);
+.icon(bullet_key, -181px -37px);
+.icon(bullet_orange, -181px -55px);
+.icon(bullet_picture, -181px -73px);
+.icon(bullet_pink, -181px -91px);
+.icon(bullet_purple, -181px -109px);
+.icon(bullet_red, -181px -127px);
+.icon(bullet_star, -181px -145px);
+.icon(bullet_toggle_minus, -181px -163px);
+.icon(bullet_toggle_plus, -181px -181px);
+.icon(bullet_white, -181px -199px);
+.icon(bullet_wrench, -181px -217px);
+.icon(bullet_yellow, -181px -235px);
+.icon(cake, -199px -1px);
+.icon(calculator, -199px -19px);
+.icon(calculator_add, -199px -37px);
+.icon(calculator_delete, -199px -55px);
+.icon(calculator_edit, -199px -73px);
+.icon(calculator_error, -199px -91px);
+.icon(calculator_link, -199px -109px);
+.icon(calendar, -199px -127px);
+.icon(calendar_add, -199px -145px);
+.icon(calendar_delete, -199px -163px);
+.icon(calendar_edit, -199px -181px);
+.icon(calendar_link, -199px -199px);
+.icon(calendar_view_day, -199px -217px);
+.icon(calendar_view_month, -199px -235px);
+.icon(calendar_view_week, -217px -1px);
+.icon(camera, -217px -19px);
+.icon(camera_add, -217px -37px);
+.icon(camera_delete, -217px -55px);
+.icon(camera_edit, -217px -73px);
+.icon(camera_error, -217px -91px);
+.icon(camera_go, -217px -109px);
+.icon(camera_link, -217px -127px);
+.icon(camera_small, -217px -145px);
+.icon(cancel, -217px -163px);
+.icon(car, -217px -181px);
+.icon(car_add, -217px -199px);
+.icon(car_delete, -217px -217px);
+.icon(cart, -217px -235px);
+.icon(cart_add, -235px -1px);
+.icon(cart_delete, -235px -19px);
+.icon(cart_edit, -235px -37px);
+.icon(cart_error, -235px -55px);
+.icon(cart_go, -235px -73px);
+.icon(cart_put, -235px -91px);
+.icon(cart_remove, -235px -109px);
+.icon(cd, -235px -127px);
+.icon(cd_add, -235px -145px);
+.icon(cd_burn, -235px -163px);
+.icon(cd_delete, -235px -181px);
+.icon(cd_edit, -235px -199px);
+.icon(cd_eject, -235px -217px);
+.icon(cd_go, -235px -235px);
+.icon(chart_bar, -253px -1px);
+.icon(chart_bar_add, -253px -19px);
+.icon(chart_bar_delete, -253px -37px);
+.icon(chart_bar_edit, -253px -55px);
+.icon(chart_bar_error, -253px -73px);
+.icon(chart_bar_link, -253px -91px);
+.icon(chart_curve, -253px -109px);
+.icon(chart_curve_add, -253px -127px);
+.icon(chart_curve_delete, -253px -145px);
+.icon(chart_curve_edit, -253px -163px);
+.icon(chart_curve_error, -253px -181px);
+.icon(chart_curve_go, -253px -199px);
+.icon(chart_curve_link, -253px -217px);
+.icon(chart_line, -253px -235px);
+.icon(chart_line_add, -271px -1px);
+.icon(chart_line_delete, -271px -19px);
+.icon(chart_line_edit, -271px -37px);
+.icon(chart_line_error, -271px -55px);
+.icon(chart_line_link, -271px -73px);
+.icon(chart_organisation, -271px -91px);
+.icon(chart_organisation_add, -271px -109px);
+.icon(chart_organisation_delete, -271px -127px);
+.icon(chart_pie, -271px -145px);
+.icon(chart_pie_add, -271px -163px);
+.icon(chart_pie_delete, -271px -181px);
+.icon(chart_pie_edit, -271px -199px);
+.icon(chart_pie_error, -271px -217px);
+.icon(chart_pie_link, -271px -235px);
+.icon(clock, -289px -1px);
+.icon(clock_add, -289px -19px);
+.icon(clock_delete, -289px -37px);
+.icon(clock_edit, -289px -55px);
+.icon(clock_error, -289px -73px);
+.icon(clock_go, -289px -91px);
+.icon(clock_link, -289px -109px);
+.icon(clock_pause, -289px -127px);
+.icon(clock_play, -289px -145px);
+.icon(clock_red, -289px -163px);
+.icon(clock_stop, -289px -181px);
+.icon(cog, -289px -199px);
+.icon(cog_add, -289px -217px);
+.icon(cog_delete, -289px -235px);
+.icon(cog_edit, -307px -1px);
+.icon(cog_error, -307px -19px);
+.icon(cog_go, -307px -37px);
+.icon(coins, -307px -55px);
+.icon(coins_add, -307px -73px);
+.icon(coins_delete, -307px -91px);
+.icon(color_swatch, -307px -109px);
+.icon(color_wheel, -307px -127px);
+.icon(comment, -307px -145px);
+.icon(comment_add, -307px -163px);
+.icon(comment_delete, -307px -181px);
+.icon(comment_edit, -307px -199px);
+.icon(comments, -307px -217px);
+.icon(comments_add, -307px -235px);
+.icon(comments_delete, -325px -1px);
+.icon(compress, -325px -19px);
+.icon(computer, -325px -37px);
+.icon(computer_add, -325px -55px);
+.icon(computer_delete, -325px -73px);
+.icon(computer_edit, -325px -91px);
+.icon(computer_error, -325px -109px);
+.icon(computer_go, -325px -127px);
+.icon(computer_key, -325px -145px);
+.icon(computer_link, -325px -163px);
+.icon(connect, -325px -181px);
+.icon(contrast, -325px -199px);
+.icon(contrast_decrease, -325px -217px);
+.icon(contrast_high, -325px -235px);
+.icon(contrast_increase, -343px -1px);
+.icon(contrast_low, -343px -19px);
+.icon(control_eject, -343px -37px);
+.icon(control_eject_blue, -343px -55px);
+.icon(control_end, -343px -73px);
+.icon(control_end_blue, -343px -91px);
+.icon(control_equalizer, -343px -109px);
+.icon(control_equalizer_blue, -343px -127px);
+.icon(control_fastforward, -343px -145px);
+.icon(control_fastforward_blue, -343px -163px);
+.icon(control_pause, -343px -181px);
+.icon(control_pause_blue, -343px -199px);
+.icon(control_play, -343px -217px);
+.icon(control_play_blue, -343px -235px);
+.icon(control_repeat, -361px -1px);
+.icon(control_repeat_blue, -361px -19px);
+.icon(control_rewind, -361px -37px);
+.icon(control_rewind_blue, -361px -55px);
+.icon(control_start, -361px -73px);
+.icon(control_start_blue, -361px -91px);
+.icon(control_stop, -361px -109px);
+.icon(control_stop_blue, -361px -127px);
+.icon(controller, -361px -145px);
+.icon(controller_add, -361px -163px);
+.icon(controller_delete, -361px -181px);
+.icon(controller_error, -361px -199px);
+.icon(creditcards, -361px -217px);
+.icon(cross, -361px -235px);
+.icon(css, -379px -1px);
+.icon(css_add, -379px -19px);
+.icon(css_delete, -379px -37px);
+.icon(css_go, -379px -55px);
+.icon(css_valid, -379px -73px);
+.icon(cup, -379px -91px);
+.icon(cup_add, -379px -109px);
+.icon(cup_delete, -379px -127px);
+.icon(cup_edit, -379px -145px);
+.icon(cup_error, -379px -163px);
+.icon(cup_go, -379px -181px);
+.icon(cup_key, -379px -199px);
+.icon(cup_link, -379px -217px);
+.icon(cursor, -379px -235px);
+.icon(cut, -397px -1px);
+.icon(cut_red, -397px -19px);
+.icon(database, -397px -37px);
+.icon(database_add, -397px -55px);
+.icon(database_connect, -397px -73px);
+.icon(database_delete, -397px -91px);
+.icon(database_edit, -397px -109px);
+.icon(database_error, -397px -127px);
+.icon(database_gear, -397px -145px);
+.icon(database_go, -397px -163px);
+.icon(database_key, -397px -181px);
+.icon(database_lightning, -397px -199px);
+.icon(database_link, -397px -217px);
+.icon(database_refresh, -397px -235px);
+.icon(database_save, -415px -1px);
+.icon(database_table, -415px -19px);
+.icon(date, -415px -37px);
+.icon(date_add, -415px -55px);
+.icon(date_delete, -415px -73px);
+.icon(date_edit, -415px -91px);
+.icon(date_error, -415px -109px);
+.icon(date_go, -415px -127px);
+.icon(date_link, -415px -145px);
+.icon(date_magnify, -415px -163px);
+.icon(date_next, -415px -181px);
+.icon(date_previous, -415px -199px);
+.icon(delete, -415px -217px);
+.icon(disconnect, -415px -235px);
+.icon(disk, -433px -1px);
+.icon(disk_multiple, -433px -19px);
+.icon(door, -433px -37px);
+.icon(door_in, -433px -55px);
+.icon(door_open, -433px -73px);
+.icon(door_out, -433px -91px);
+.icon(drink, -433px -109px);
+.icon(drink_empty, -433px -127px);
+.icon(drive, -433px -145px);
+.icon(drive_add, -433px -163px);
+.icon(drive_burn, -433px -181px);
+.icon(drive_cd, -433px -199px);
+.icon(drive_cd_empty, -433px -217px);
+.icon(drive_delete, -433px -235px);
+.icon(drive_disk, -451px -1px);
+.icon(drive_edit, -451px -19px);
+.icon(drive_error, -451px -37px);
+.icon(drive_go, -451px -55px);
+.icon(drive_key, -451px -73px);
+.icon(drive_link, -451px -91px);
+.icon(drive_magnify, -451px -109px);
+.icon(drive_network, -451px -127px);
+.icon(drive_rename, -451px -145px);
+.icon(drive_user, -451px -163px);
+.icon(drive_web, -451px -181px);
+.icon(dvd, -451px -199px);
+.icon(dvd_add, -451px -217px);
+.icon(dvd_delete, -451px -235px);
+.icon(dvd_edit, -469px -1px);
+.icon(dvd_error, -469px -19px);
+.icon(dvd_go, -469px -37px);
+.icon(dvd_key, -469px -55px);
+.icon(dvd_link, -469px -73px);
+.icon(email, -469px -91px);
+.icon(email_add, -469px -109px);
+.icon(email_attach, -469px -127px);
+.icon(email_delete, -469px -145px);
+.icon(email_edit, -469px -163px);
+.icon(email_error, -469px -181px);
+.icon(email_go, -469px -199px);
+.icon(email_go_orange, -469px -217px);
+.icon(email_link, -469px -235px);
+.icon(email_open, -487px -1px);
+.icon(email_open_image, -487px -19px);
+.icon(emoticon_evilgrin, -487px -37px);
+.icon(emoticon_grin, -487px -55px);
+.icon(emoticon_happy, -487px -73px);
+.icon(emoticon_smile, -487px -91px);
+.icon(emoticon_surprised, -487px -109px);
+.icon(emoticon_tongue, -487px -127px);
+.icon(emoticon_unhappy, -487px -145px);
+.icon(emoticon_waii, -487px -163px);
+.icon(emoticon_wink, -487px -181px);
+.icon(error, -487px -199px);
+.icon(error_add, -487px -217px);
+.icon(error_delete, -487px -235px);
+.icon(error_go, -505px -1px);
+.icon(exclamation, -505px -19px);
+.icon(eye, -505px -37px);
+.icon(feed, -505px -55px);
+.icon(feed_add, -505px -73px);
+.icon(feed_delete, -505px -91px);
+.icon(feed_disk, -505px -109px);
+.icon(feed_edit, -505px -127px);
+.icon(feed_error, -505px -145px);
+.icon(feed_go, -505px -163px);
+.icon(feed_key, -505px -181px);
+.icon(feed_link, -505px -199px);
+.icon(feed_magnify, -505px -217px);
+.icon(female, -505px -235px);
+.icon(film, -523px -1px);
+.icon(film_add, -523px -19px);
+.icon(film_delete, -523px -37px);
+.icon(film_edit, -523px -55px);
+.icon(film_error, -523px -73px);
+.icon(film_go, -523px -91px);
+.icon(film_key, -523px -109px);
+.icon(film_link, -523px -127px);
+.icon(film_save, -523px -145px);
+.icon(find, -523px -163px);
+.icon(flag_blue, -523px -181px);
+.icon(flag_green, -523px -199px);
+.icon(flag_orange, -523px -217px);
+.icon(flag_pink, -523px -235px);
+.icon(flag_purple, -541px -1px);
+.icon(flag_red, -541px -19px);
+.icon(flag_yellow, -541px -37px);
+.icon(folder, -541px -55px);
+.icon(folder_add, -541px -73px);
+.icon(folder_bell, -541px -91px);
+.icon(folder_brick, -541px -109px);
+.icon(folder_bug, -541px -127px);
+.icon(folder_camera, -541px -145px);
+.icon(folder_database, -541px -163px);
+.icon(folder_delete, -541px -181px);
+.icon(folder_edit, -541px -199px);
+.icon(folder_error, -541px -217px);
+.icon(folder_explore, -541px -235px);
+.icon(folder_feed, -559px -1px);
+.icon(folder_find, -559px -19px);
+.icon(folder_go, -559px -37px);
+.icon(folder_heart, -559px -55px);
+.icon(folder_image, -559px -73px);
+.icon(folder_key, -559px -91px);
+.icon(folder_lightbulb, -559px -109px);
+.icon(folder_link, -559px -127px);
+.icon(folder_magnify, -559px -145px);
+.icon(folder_page, -559px -163px);
+.icon(folder_page_white, -559px -181px);
+.icon(folder_palette, -559px -199px);
+.icon(folder_picture, -559px -217px);
+.icon(folder_star, -559px -235px);
+.icon(folder_table, -577px -1px);
+.icon(folder_user, -577px -19px);
+.icon(folder_wrench, -577px -37px);
+.icon(font, -577px -55px);
+.icon(font_add, -577px -73px);
+.icon(font_delete, -577px -91px);
+.icon(font_go, -577px -109px);
+.icon(group, -577px -127px);
+.icon(group_add, -577px -145px);
+.icon(group_delete, -577px -163px);
+.icon(group_edit, -577px -181px);
+.icon(group_error, -577px -199px);
+.icon(group_gear, -577px -217px);
+.icon(group_go, -577px -235px);
+.icon(group_key, -595px -1px);
+.icon(group_link, -595px -19px);
+.icon(heart, -595px -37px);
+.icon(heart_add, -595px -55px);
+.icon(heart_delete, -595px -73px);
+.icon(help, -595px -91px);
+.icon(hourglass, -595px -109px);
+.icon(hourglass_add, -595px -127px);
+.icon(hourglass_delete, -595px -145px);
+.icon(hourglass_go, -595px -163px);
+.icon(hourglass_link, -595px -181px);
+.icon(house, -595px -199px);
+.icon(house_go, -595px -217px);
+.icon(house_link, -595px -235px);
+.icon(html, -613px -1px);
+.icon(html_add, -613px -19px);
+.icon(html_delete, -613px -37px);
+.icon(html_go, -613px -55px);
+.icon(html_valid, -613px -73px);
+.icon(image, -613px -91px);
+.icon(image_add, -613px -109px);
+.icon(image_delete, -613px -127px);
+.icon(image_edit, -613px -145px);
+.icon(image_link, -613px -163px);
+.icon(images, -613px -181px);
+.icon(information, -613px -199px);
+.icon(ipod, -613px -217px);
+.icon(ipod_cast, -613px -235px);
+.icon(ipod_cast_add, -631px -1px);
+.icon(ipod_cast_delete, -631px -19px);
+.icon(ipod_sound, -631px -37px);
+.icon(joystick, -631px -55px);
+.icon(joystick_add, -631px -73px);
+.icon(joystick_delete, -631px -91px);
+.icon(joystick_error, -631px -109px);
+.icon(key, -631px -127px);
+.icon(key_add, -631px -145px);
+.icon(key_delete, -631px -163px);
+.icon(key_go, -631px -181px);
+.icon(keyboard, -631px -199px);
+.icon(keyboard_add, -631px -217px);
+.icon(keyboard_delete, -631px -235px);
+.icon(keyboard_magnify, -649px -1px);
+.icon(layers, -649px -19px);
+.icon(layout, -649px -37px);
+.icon(layout_add, -649px -55px);
+.icon(layout_content, -649px -73px);
+.icon(layout_delete, -649px -91px);
+.icon(layout_edit, -649px -109px);
+.icon(layout_error, -649px -127px);
+.icon(layout_header, -649px -145px);
+.icon(layout_link, -649px -163px);
+.icon(layout_sidebar, -649px -181px);
+.icon(lightbulb, -649px -199px);
+.icon(lightbulb_add, -649px -217px);
+.icon(lightbulb_delete, -649px -235px);
+.icon(lightbulb_off, -667px -1px);
+.icon(lightning, -667px -19px);
+.icon(lightning_add, -667px -37px);
+.icon(lightning_delete, -667px -55px);
+.icon(lightning_go, -667px -73px);
+.icon(link, -667px -91px);
+.icon(link_add, -667px -109px);
+.icon(link_break, -667px -127px);
+.icon(link_delete, -667px -145px);
+.icon(link_edit, -667px -163px);
+.icon(link_error, -667px -181px);
+.icon(link_go, -667px -199px);
+.icon(lock, -667px -217px);
+.icon(lock_add, -667px -235px);
+.icon(lock_break, -685px -1px);
+.icon(lock_delete, -685px -19px);
+.icon(lock_edit, -685px -37px);
+.icon(lock_go, -685px -55px);
+.icon(lock_open, -685px -73px);
+.icon(lorry, -685px -91px);
+.icon(lorry_add, -685px -109px);
+.icon(lorry_delete, -685px -127px);
+.icon(lorry_error, -685px -145px);
+.icon(lorry_flatbed, -685px -163px);
+.icon(lorry_go, -685px -181px);
+.icon(lorry_link, -685px -199px);
+.icon(magifier_zoom_out, -685px -217px);
+.icon(magnifier, -685px -235px);
+.icon(magnifier_zoom_in, -703px -1px);
+.icon(male, -703px -19px);
+.icon(map, -703px -37px);
+.icon(map_add, -703px -55px);
+.icon(map_delete, -703px -73px);
+.icon(map_edit, -703px -91px);
+.icon(map_go, -703px -109px);
+.icon(map_magnify, -703px -127px);
+.icon(medal_bronze_1, -703px -145px);
+.icon(medal_bronze_2, -703px -163px);
+.icon(medal_bronze_3, -703px -181px);
+.icon(medal_bronze_add, -703px -199px);
+.icon(medal_bronze_delete, -703px -217px);
+.icon(medal_gold_1, -703px -235px);
+.icon(medal_gold_2, -721px -1px);
+.icon(medal_gold_3, -721px -19px);
+.icon(medal_gold_add, -721px -37px);
+.icon(medal_gold_delete, -721px -55px);
+.icon(medal_silver_1, -721px -73px);
+.icon(medal_silver_2, -721px -91px);
+.icon(medal_silver_3, -721px -109px);
+.icon(medal_silver_add, -721px -127px);
+.icon(medal_silver_delete, -721px -145px);
+.icon(money, -721px -163px);
+.icon(money_add, -721px -181px);
+.icon(money_delete, -721px -199px);
+.icon(money_dollar, -721px -217px);
+.icon(money_euro, -721px -235px);
+.icon(money_pound, -739px -1px);
+.icon(money_yen, -739px -19px);
+.icon(monitor, -739px -37px);
+.icon(monitor_add, -739px -55px);
+.icon(monitor_delete, -739px -73px);
+.icon(monitor_edit, -739px -91px);
+.icon(monitor_error, -739px -109px);
+.icon(monitor_go, -739px -127px);
+.icon(monitor_lightning, -739px -145px);
+.icon(monitor_link, -739px -163px);
+.icon(mouse, -739px -181px);
+.icon(mouse_add, -739px -199px);
+.icon(mouse_delete, -739px -217px);
+.icon(mouse_error, -739px -235px);
+.icon(music, -757px -1px);
+.icon(new, -757px -19px);
+.icon(newspaper, -757px -37px);
+.icon(newspaper_add, -757px -55px);
+.icon(newspaper_delete, -757px -73px);
+.icon(newspaper_go, -757px -91px);
+.icon(newspaper_link, -757px -109px);
+.icon(note, -757px -127px);
+.icon(note_add, -757px -145px);
+.icon(note_delete, -757px -163px);
+.icon(note_edit, -757px -181px);
+.icon(note_error, -757px -199px);
+.icon(note_go, -757px -217px);
+.icon(package, -757px -235px);
+.icon(package_add, -775px -1px);
+.icon(package_delete, -775px -19px);
+.icon(package_go, -775px -37px);
+.icon(package_green, -775px -55px);
+.icon(package_link, -775px -73px);
+.icon(page, -775px -91px);
+.icon(page_add, -775px -109px);
+.icon(page_attach, -775px -127px);
+.icon(page_code, -775px -145px);
+.icon(page_copy, -775px -163px);
+.icon(page_delete, -775px -181px);
+.icon(page_edit, -775px -199px);
+.icon(page_error, -775px -217px);
+.icon(page_excel, -775px -235px);
+.icon(page_find, -793px -1px);
+.icon(page_gear, -793px -19px);
+.icon(page_go, -793px -37px);
+.icon(page_green, -793px -55px);
+.icon(page_key, -793px -73px);
+.icon(page_lightning, -793px -91px);
+.icon(page_link, -793px -109px);
+.icon(page_paintbrush, -793px -127px);
+.icon(page_paste, -793px -145px);
+.icon(page_red, -793px -163px);
+.icon(page_refresh, -793px -181px);
+.icon(page_save, -793px -199px);
+.icon(page_white, -793px -217px);
+.icon(page_white_acrobat, -793px -235px);
+.icon(page_white_actionscript, -811px -1px);
+.icon(page_white_add, -811px -19px);
+.icon(page_white_c, -811px -37px);
+.icon(page_white_camera, -811px -55px);
+.icon(page_white_cd, -811px -73px);
+.icon(page_white_code, -811px -91px);
+.icon(page_white_code_red, -811px -109px);
+.icon(page_white_coldfusion, -811px -127px);
+.icon(page_white_compressed, -811px -145px);
+.icon(page_white_copy, -811px -163px);
+.icon(page_white_cplusplus, -811px -181px);
+.icon(page_white_csharp, -811px -199px);
+.icon(page_white_cup, -811px -217px);
+.icon(page_white_database, -811px -235px);
+.icon(page_white_delete, -829px -1px);
+.icon(page_white_dvd, -829px -19px);
+.icon(page_white_edit, -829px -37px);
+.icon(page_white_error, -829px -55px);
+.icon(page_white_excel, -829px -73px);
+.icon(page_white_find, -829px -91px);
+.icon(page_white_flash, -829px -109px);
+.icon(page_white_freehand, -829px -127px);
+.icon(page_white_gear, -829px -145px);
+.icon(page_white_get, -829px -163px);
+.icon(page_white_go, -829px -181px);
+.icon(page_white_h, -829px -199px);
+.icon(page_white_horizontal, -829px -217px);
+.icon(page_white_key, -829px -235px);
+.icon(page_white_lightning, -847px -1px);
+.icon(page_white_link, -847px -19px);
+.icon(page_white_magnify, -847px -37px);
+.icon(page_white_medal, -847px -55px);
+.icon(page_white_office, -847px -73px);
+.icon(page_white_paint, -847px -91px);
+.icon(page_white_paintbrush, -847px -109px);
+.icon(page_white_paste, -847px -127px);
+.icon(page_white_php, -847px -145px);
+.icon(page_white_picture, -847px -163px);
+.icon(page_white_powerpoint, -847px -181px);
+.icon(page_white_put, -847px -199px);
+.icon(page_white_ruby, -847px -217px);
+.icon(page_white_stack, -847px -235px);
+.icon(page_white_star, -865px -1px);
+.icon(page_white_swoosh, -865px -19px);
+.icon(page_white_text, -865px -37px);
+.icon(page_white_text_width, -865px -55px);
+.icon(page_white_tux, -865px -73px);
+.icon(page_white_vector, -865px -91px);
+.icon(page_white_visualstudio, -865px -109px);
+.icon(page_white_width, -865px -127px);
+.icon(page_white_word, -865px -145px);
+.icon(page_white_world, -865px -163px);
+.icon(page_white_wrench, -865px -181px);
+.icon(page_white_zip, -865px -199px);
+.icon(page_word, -865px -217px);
+.icon(page_world, -865px -235px);
+.icon(paintbrush, -883px -1px);
+.icon(paintcan, -883px -19px);
+.icon(palette, -883px -37px);
+.icon(paste_plain, -883px -55px);
+.icon(paste_word, -883px -73px);
+.icon(pencil, -883px -91px);
+.icon(pencil_add, -883px -109px);
+.icon(pencil_delete, -883px -127px);
+.icon(pencil_go, -883px -145px);
+.icon(phone, -883px -163px);
+.icon(phone_add, -883px -181px);
+.icon(phone_delete, -883px -199px);
+.icon(phone_sound, -883px -217px);
+.icon(photo, -883px -235px);
+.icon(photo_add, -901px -1px);
+.icon(photo_delete, -901px -19px);
+.icon(photo_link, -901px -37px);
+.icon(photos, -901px -55px);
+.icon(picture, -901px -73px);
+.icon(picture_add, -901px -91px);
+.icon(picture_delete, -901px -109px);
+.icon(picture_edit, -901px -127px);
+.icon(picture_empty, -901px -145px);
+.icon(picture_error, -901px -163px);
+.icon(picture_go, -901px -181px);
+.icon(picture_key, -901px -199px);
+.icon(picture_link, -901px -217px);
+.icon(picture_save, -901px -235px);
+.icon(pictures, -919px -1px);
+.icon(pilcrow, -919px -19px);
+.icon(pill, -919px -37px);
+.icon(pill_add, -919px -55px);
+.icon(pill_delete, -919px -73px);
+.icon(pill_go, -919px -91px);
+.icon(plugin, -919px -109px);
+.icon(plugin_add, -919px -127px);
+.icon(plugin_delete, -919px -145px);
+.icon(plugin_disabled, -919px -163px);
+.icon(plugin_edit, -919px -181px);
+.icon(plugin_error, -919px -199px);
+.icon(plugin_go, -919px -217px);
+.icon(plugin_link, -919px -235px);
+.icon(printer, -937px -1px);
+.icon(printer_add, -937px -19px);
+.icon(printer_delete, -937px -37px);
+.icon(printer_empty, -937px -55px);
+.icon(printer_error, -937px -73px);
+.icon(rainbow, -937px -91px);
+.icon(report, -937px -109px);
+.icon(report_add, -937px -127px);
+.icon(report_delete, -937px -145px);
+.icon(report_disk, -937px -163px);
+.icon(report_edit, -937px -181px);
+.icon(report_go, -937px -199px);
+.icon(report_key, -937px -217px);
+.icon(report_link, -937px -235px);
+.icon(report_magnify, -955px -1px);
+.icon(report_picture, -955px -19px);
+.icon(report_user, -955px -37px);
+.icon(report_word, -955px -55px);
+.icon(resultset_first, -955px -73px);
+.icon(resultset_last, -955px -91px);
+.icon(resultset_next, -955px -109px);
+.icon(resultset_previous, -955px -127px);
+.icon(rosette, -955px -145px);
+.icon(rss, -955px -163px);
+.icon(rss_add, -955px -181px);
+.icon(rss_delete, -955px -199px);
+.icon(rss_go, -955px -217px);
+.icon(rss_valid, -955px -235px);
+.icon(ruby, -973px -1px);
+.icon(ruby_add, -973px -19px);
+.icon(ruby_delete, -973px -37px);
+.icon(ruby_gear, -973px -55px);
+.icon(ruby_get, -973px -73px);
+.icon(ruby_go, -973px -91px);
+.icon(ruby_key, -973px -109px);
+.icon(ruby_link, -973px -127px);
+.icon(ruby_put, -973px -145px);
+.icon(script, -973px -163px);
+.icon(script_add, -973px -181px);
+.icon(script_code, -973px -199px);
+.icon(script_code_red, -973px -217px);
+.icon(script_delete, -973px -235px);
+.icon(script_edit, -991px -1px);
+.icon(script_error, -991px -19px);
+.icon(script_gear, -991px -37px);
+.icon(script_go, -991px -55px);
+.icon(script_key, -991px -73px);
+.icon(script_lightning, -991px -91px);
+.icon(script_link, -991px -109px);
+.icon(script_palette, -991px -127px);
+.icon(script_save, -991px -145px);
+.icon(server, -991px -163px);
+.icon(server_add, -991px -181px);
+.icon(server_chart, -991px -199px);
+.icon(server_compressed, -991px -217px);
+.icon(server_connect, -991px -235px);
+.icon(server_database, -1009px -1px);
+.icon(server_delete, -1009px -19px);
+.icon(server_edit, -1009px -37px);
+.icon(server_error, -1009px -55px);
+.icon(server_go, -1009px -73px);
+.icon(server_key, -1009px -91px);
+.icon(server_lightning, -1009px -109px);
+.icon(server_link, -1009px -127px);
+.icon(server_uncompressed, -1009px -145px);
+.icon(shading, -1009px -163px);
+.icon(shape_align_bottom, -1009px -181px);
+.icon(shape_align_center, -1009px -199px);
+.icon(shape_align_left, -1009px -217px);
+.icon(shape_align_middle, -1009px -235px);
+.icon(shape_align_right, -1027px -1px);
+.icon(shape_align_top, -1027px -19px);
+.icon(shape_flip_horizontal, -1027px -37px);
+.icon(shape_flip_vertical, -1027px -55px);
+.icon(shape_group, -1027px -73px);
+.icon(shape_handles, -1027px -91px);
+.icon(shape_move_back, -1027px -109px);
+.icon(shape_move_backwards, -1027px -127px);
+.icon(shape_move_forwards, -1027px -145px);
+.icon(shape_move_front, -1027px -163px);
+.icon(shape_rotate_anticlockwise, -1027px -181px);
+.icon(shape_rotate_clockwise, -1027px -199px);
+.icon(shape_square, -1027px -217px);
+.icon(shape_square_add, -1027px -235px);
+.icon(shape_square_delete, -1045px -1px);
+.icon(shape_square_edit, -1045px -19px);
+.icon(shape_square_error, -1045px -37px);
+.icon(shape_square_go, -1045px -55px);
+.icon(shape_square_key, -1045px -73px);
+.icon(shape_square_link, -1045px -91px);
+.icon(shape_ungroup, -1045px -109px);
+.icon(shield, -1045px -127px);
+.icon(shield_add, -1045px -145px);
+.icon(shield_delete, -1045px -163px);
+.icon(shield_go, -1045px -181px);
+.icon(sitemap, -1045px -199px);
+.icon(sitemap_color, -1045px -217px);
+.icon(sound, -1045px -235px);
+.icon(sound_add, -1063px -1px);
+.icon(sound_delete, -1063px -19px);
+.icon(sound_low, -1063px -37px);
+.icon(sound_mute, -1063px -55px);
+.icon(sound_none, -1063px -73px);
+.icon(spellcheck, -1063px -91px);
+.icon(sport_8ball, -1063px -109px);
+.icon(sport_basketball, -1063px -127px);
+.icon(sport_football, -1063px -145px);
+.icon(sport_golf, -1063px -163px);
+.icon(sport_raquet, -1063px -181px);
+.icon(sport_shuttlecock, -1063px -199px);
+.icon(sport_soccer, -1063px -217px);
+.icon(sport_tennis, -1063px -235px);
+.icon(star, -1081px -1px);
+.icon(status_away, -1081px -19px);
+.icon(status_busy, -1081px -37px);
+.icon(status_offline, -1081px -55px);
+.icon(status_online, -1081px -73px);
+.icon(stop, -1081px -91px);
+.icon(style, -1081px -109px);
+.icon(style_add, -1081px -127px);
+.icon(style_delete, -1081px -145px);
+.icon(style_edit, -1081px -163px);
+.icon(style_go, -1081px -181px);
+.icon(sum, -1081px -199px);
+.icon(tab, -1081px -217px);
+.icon(tab_add, -1081px -235px);
+.icon(tab_delete, -1099px -1px);
+.icon(tab_edit, -1099px -19px);
+.icon(tab_go, -1099px -37px);
+.icon(table_normal, -1099px -55px);
+.icon(table_add, -1099px -73px);
+.icon(table_delete, -1099px -91px);
+.icon(table_edit, -1099px -109px);
+.icon(table_error, -1099px -127px);
+.icon(table_gear, -1099px -145px);
+.icon(table_go, -1099px -163px);
+.icon(table_key, -1099px -181px);
+.icon(table_lightning, -1099px -199px);
+.icon(table_link, -1099px -217px);
+.icon(table_multiple, -1099px -235px);
+.icon(table_refresh, -1117px -1px);
+.icon(table_relationship, -1117px -19px);
+.icon(table_row_delete, -1117px -37px);
+.icon(table_row_insert, -1117px -55px);
+.icon(table_save, -1117px -73px);
+.icon(table_sort, -1117px -91px);
+.icon(tag, -1117px -109px);
+.icon(tag_blue, -1117px -127px);
+.icon(tag_blue_add, -1117px -145px);
+.icon(tag_blue_delete, -1117px -163px);
+.icon(tag_blue_edit, -1117px -181px);
+.icon(tag_green, -1117px -199px);
+.icon(tag_orange, -1117px -217px);
+.icon(tag_pink, -1117px -235px);
+.icon(tag_purple, -1135px -1px);
+.icon(tag_red, -1135px -19px);
+.icon(tag_yellow, -1135px -37px);
+.icon(telephone, -1135px -55px);
+.icon(telephone_add, -1135px -73px);
+.icon(telephone_delete, -1135px -91px);
+.icon(telephone_edit, -1135px -109px);
+.icon(telephone_error, -1135px -127px);
+.icon(telephone_go, -1135px -145px);
+.icon(telephone_key, -1135px -163px);
+.icon(telephone_link, -1135px -181px);
+.icon(television, -1135px -199px);
+.icon(television_add, -1135px -217px);
+.icon(television_delete, -1135px -235px);
+.icon(text_align_center, -1153px -1px);
+.icon(text_align_justify, -1153px -19px);
+.icon(text_align_left, -1153px -37px);
+.icon(text_align_right, -1153px -55px);
+.icon(text_allcaps, -1153px -73px);
+.icon(text_bold, -1153px -91px);
+.icon(text_columns, -1153px -109px);
+.icon(text_dropcaps, -1153px -127px);
+.icon(text_heading_1, -1153px -145px);
+.icon(text_heading_2, -1153px -163px);
+.icon(text_heading_3, -1153px -181px);
+.icon(text_heading_4, -1153px -199px);
+.icon(text_heading_5, -1153px -217px);
+.icon(text_heading_6, -1153px -235px);
+.icon(text_horizontalrule, -1171px -1px);
+.icon(text_indent, -1171px -19px);
+.icon(text_indent_remove, -1171px -37px);
+.icon(text_italic, -1171px -55px);
+.icon(text_kerning, -1171px -73px);
+.icon(text_letter_omega, -1171px -91px);
+.icon(text_letterspacing, -1171px -109px);
+.icon(text_linespacing, -1171px -127px);
+.icon(text_list_bullets, -1171px -145px);
+.icon(text_list_numbers, -1171px -163px);
+.icon(text_lowercase, -1171px -181px);
+.icon(text_padding_bottom, -1171px -199px);
+.icon(text_padding_left, -1171px -217px);
+.icon(text_padding_right, -1171px -235px);
+.icon(text_padding_top, -1189px -1px);
+.icon(text_replace, -1189px -19px);
+.icon(text_signature, -1189px -37px);
+.icon(text_smallcaps, -1189px -55px);
+.icon(text_strikethrough, -1189px -73px);
+.icon(text_subscript, -1189px -91px);
+.icon(text_superscript, -1189px -109px);
+.icon(text_underline, -1189px -127px);
+.icon(text_uppercase, -1189px -145px);
+.icon(textfield, -1189px -163px);
+.icon(textfield_add, -1189px -181px);
+.icon(textfield_delete, -1189px -199px);
+.icon(textfield_key, -1189px -217px);
+.icon(textfield_rename, -1189px -235px);
+.icon(thumb_down, -1207px -1px);
+.icon(thumb_up, -1207px -19px);
+.icon(tick, -1207px -37px);
+.icon(time, -1207px -55px);
+.icon(time_add, -1207px -73px);
+.icon(time_delete, -1207px -91px);
+.icon(time_go, -1207px -109px);
+.icon(timeline_marker, -1207px -127px);
+.icon(transmit, -1207px -145px);
+.icon(transmit_add, -1207px -163px);
+.icon(transmit_blue, -1207px -181px);
+.icon(transmit_delete, -1207px -199px);
+.icon(transmit_edit, -1207px -217px);
+.icon(transmit_error, -1207px -235px);
+.icon(transmit_go, -1225px -1px);
+.icon(tux, -1225px -19px);
+.icon(user, -1225px -37px);
+.icon(user_add, -1225px -55px);
+.icon(user_comment, -1225px -73px);
+.icon(user_delete, -1225px -91px);
+.icon(user_edit, -1225px -109px);
+.icon(user_female, -1225px -127px);
+.icon(user_go, -1225px -145px);
+.icon(user_gray, -1225px -163px);
+.icon(user_green, -1225px -181px);
+.icon(user_orange, -1225px -199px);
+.icon(user_red, -1225px -217px);
+.icon(user_suit, -1225px -235px);
+.icon(vcard, -1243px -1px);
+.icon(vcard_add, -1243px -19px);
+.icon(vcard_delete, -1243px -37px);
+.icon(vcard_edit, -1243px -55px);
+.icon(vector, -1243px -73px);
+.icon(vector_add, -1243px -91px);
+.icon(vector_delete, -1243px -109px);
+.icon(wand, -1243px -127px);
+.icon(weather_clouds, -1243px -145px);
+.icon(weather_cloudy, -1243px -163px);
+.icon(weather_lightning, -1243px -181px);
+.icon(weather_rain, -1243px -199px);
+.icon(weather_snow, -1243px -217px);
+.icon(weather_sun, -1243px -235px);
+.icon(webcam, -1261px -1px);
+.icon(webcam_add, -1261px -19px);
+.icon(webcam_delete, -1261px -37px);
+.icon(webcam_error, -1261px -55px);
+.icon(world, -1261px -73px);
+.icon(world_add, -1261px -91px);
+.icon(world_delete, -1261px -109px);
+.icon(world_edit, -1261px -127px);
+.icon(world_go, -1261px -145px);
+.icon(world_link, -1261px -163px);
+.icon(wrench, -1261px -181px);
+.icon(wrench_orange, -1261px -199px);
+.icon(xhtml, -1261px -217px);
+.icon(xhtml_add, -1261px -235px);
+.icon(xhtml_delete, -1279px -1px);
+.icon(xhtml_go, -1279px -19px);
+.icon(xhtml_valid, -1279px -37px);
+.icon(zoom, -1279px -55px);
+.icon(zoom_in, -1279px -73px);
+.icon(zoom_out, -1279px -91px);


### PR DESCRIPTION
Soms wordt je een beetje afgeleid en denk je dat icoontjes beter kunnen.

Het grote voordeel van het op deze manier doen is dat je makkelijk verschillende versies van icoontjes kan hebben, bijvoorbeeld icoontjes die in een span zitten, of icoontjes die in de `::before` van een span moeten zitten.

Ik het dit voor `.dt-button-ico` alvast gedaan. ~Binnenkort komt hier een pr voor.~ Zie #206  Dit zou er dan als volgt uit zien om een icoontje vóór de tekst te krijgen.

```html
<div class='dt-button dt-button-ico dt-ico-linux'>
  <span>Linux is cool</span>
</div>
```