### PR TITLE
Gebruik class ipv string in models

### DIFF
--- a/lib/model/AgendaModel.class.php
+++ b/lib/model/AgendaModel.class.php
@@ -18,7 +18,7 @@ require_once 'model/maalcie/CorveeTakenModel.class.php';
  */
 class AgendaModel extends PersistenceModel {
 
-	const ORM = 'AgendaItem';
+	const ORM = AgendaItem::class;
 	const DIR = 'agenda/';
 
 	protected static $instance;
@@ -231,7 +231,7 @@ class AgendaModel extends PersistenceModel {
 
 class AgendaVerbergenModel extends PersistenceModel {
 
-	const ORM = 'AgendaVerbergen';
+	const ORM = AgendaVerbergen::class;
 	const DIR = 'agenda/';
 
 	protected static $instance;

--- a/lib/model/BijbelroosterModel.class.php
+++ b/lib/model/BijbelroosterModel.class.php
@@ -9,7 +9,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class BijbelroosterModel extends PersistenceModel {
 
-	const ORM = 'Bijbelrooster';
+	const ORM = Bijbelrooster::class;
 
 	protected static $instance;
 

--- a/lib/model/ChangeLogModel.class.php
+++ b/lib/model/ChangeLogModel.class.php
@@ -10,7 +10,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class ChangeLogModel extends PersistenceModel {
 
-	const ORM = 'ChangeLogEntry';
+	const ORM = ChangeLogEntry::class;
 
 	protected static $instance;
 

--- a/lib/model/CmsPaginaModel.class.php
+++ b/lib/model/CmsPaginaModel.class.php
@@ -11,7 +11,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class CmsPaginaModel extends PersistenceModel {
 
-	const ORM = 'CmsPagina';
+	const ORM = CmsPagina::class;
 
 	protected static $instance;
 

--- a/lib/model/DebugLogModel.class.php
+++ b/lib/model/DebugLogModel.class.php
@@ -10,7 +10,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class DebugLogModel extends PersistenceModel {
 
-	const ORM = 'DebugLogEntry';
+	const ORM = DebugLogEntry::class;
 
 	protected static $instance;
 

--- a/lib/model/EetplanModel.class.php
+++ b/lib/model/EetplanModel.class.php
@@ -18,7 +18,7 @@ require_once 'model/EetplanFactory.class.php';
 class EetplanModel extends PersistenceModel {
     protected static $instance;
 
-    const ORM = 'Eetplan';
+    const ORM = Eetplan::class;
 
     public function getEetplanVoorAvond($avond) {
         return $this->find('avond = ?', array($avond));

--- a/lib/model/ForumModel.class.php
+++ b/lib/model/ForumModel.class.php
@@ -15,7 +15,7 @@ require_once 'model/Paging.interface.php';
  */
 class ForumModel extends CachedPersistenceModel {
 
-	const ORM = 'ForumCategorie';
+	const ORM = ForumCategorie::class;
 	const DIR = 'forum/';
 
 	protected static $instance;
@@ -116,7 +116,7 @@ class ForumModel extends CachedPersistenceModel {
 
 class ForumDelenModel extends CachedPersistenceModel {
 
-	const ORM = 'ForumDeel';
+	const ORM = ForumDeel::class;
 	const DIR = 'forum/';
 
 	protected static $instance;
@@ -310,7 +310,7 @@ class ForumDelenModel extends CachedPersistenceModel {
 
 class ForumDradenReagerenModel extends PersistenceModel {
 
-	const ORM = 'ForumDraadReageren';
+	const ORM = ForumDraadReageren::class;
 	const DIR = 'forum/';
 
 	protected static $instance;
@@ -409,7 +409,7 @@ class ForumDradenReagerenModel extends PersistenceModel {
 
 class ForumDradenGelezenModel extends CachedPersistenceModel {
 
-	const ORM = 'ForumDraadGelezen';
+	const ORM = ForumDraadGelezen::class;
 	const DIR = 'forum/';
 
 	protected static $instance;
@@ -471,7 +471,7 @@ class ForumDradenGelezenModel extends CachedPersistenceModel {
 
 class ForumDradenVerbergenModel extends CachedPersistenceModel {
 
-	const ORM = 'ForumDraadVerbergen';
+	const ORM = ForumDraadVerbergen::class;
 	const DIR = 'forum/';
 
 	protected static $instance;
@@ -521,7 +521,7 @@ class ForumDradenVerbergenModel extends CachedPersistenceModel {
 
 class ForumDradenVolgenModel extends CachedPersistenceModel {
 
-	const ORM = 'ForumDraadVolgen';
+	const ORM = ForumDraadVolgen::class;
 	const DIR = 'forum/';
 
 	protected static $instance;
@@ -575,7 +575,7 @@ class ForumDradenVolgenModel extends CachedPersistenceModel {
 
 class ForumDradenModel extends CachedPersistenceModel implements Paging {
 
-	const ORM = 'ForumDraad';
+	const ORM = ForumDraad::class;
 	const DIR = 'forum/';
 
 	protected static $instance;
@@ -891,7 +891,7 @@ class ForumDradenModel extends CachedPersistenceModel implements Paging {
 
 class ForumPostsModel extends CachedPersistenceModel implements Paging {
 
-	const ORM = 'ForumPost';
+	const ORM = ForumPost::class;
 	const DIR = 'forum/';
 
 	protected static $instance;

--- a/lib/model/FotoAlbumModel.class.php
+++ b/lib/model/FotoAlbumModel.class.php
@@ -10,7 +10,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class FotoAlbumModel extends PersistenceModel {
 
-	const ORM = 'FotoAlbum';
+	const ORM = FotoAlbum::class;
 	const DIR = 'fotoalbum/';
 
 	protected static $instance;
@@ -244,7 +244,7 @@ HTML;
 
 class FotoModel extends PersistenceModel {
 
-	const ORM = 'Foto';
+	const ORM = Foto::class;
 	const DIR = 'fotoalbum/';
 
 	protected static $instance;
@@ -313,7 +313,7 @@ class FotoModel extends PersistenceModel {
 
 class FotoTagsModel extends PersistenceModel {
 
-	const ORM = 'FotoTag';
+	const ORM = FotoTag::class;
 	const DIR = 'fotoalbum/';
 
 	protected static $instance;

--- a/lib/model/GeoLocationModel.class.php
+++ b/lib/model/GeoLocationModel.class.php
@@ -9,7 +9,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class GeoLocationModel extends PersistenceModel {
 
-	const ORM = 'GeoLocation';
+	const ORM = GeoLocation::class;
 
 	protected static $instance;
 	/**

--- a/lib/model/GesprekkenModel.class.php
+++ b/lib/model/GesprekkenModel.class.php
@@ -9,7 +9,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class GesprekkenModel extends PersistenceModel {
 
-	const ORM = 'Gesprek';
+	const ORM = Gesprek::class;
 	const DIR = 'gesprekken/';
 
 	protected static $instance;
@@ -51,7 +51,7 @@ class GesprekkenModel extends PersistenceModel {
  */
 class GesprekDeelnemersModel extends PersistenceModel {
 
-	const ORM = 'GesprekDeelnemer';
+	const ORM = GesprekDeelnemer::class;
 	const DIR = 'gesprekken/';
 
 	protected static $instance;
@@ -127,7 +127,7 @@ class GesprekDeelnemersModel extends PersistenceModel {
  */
 class GesprekBerichtenModel extends PersistenceModel {
 
-	const ORM = 'GesprekBericht';
+	const ORM = GesprekBericht::class;
 	const DIR = 'gesprekken/';
 
 	protected static $instance;

--- a/lib/model/GroepLedenModel.abstract.php
+++ b/lib/model/GroepLedenModel.abstract.php
@@ -89,7 +89,7 @@ abstract class AbstractGroepLedenModel extends CachedPersistenceModel {
 
 class RechtenGroepLedenModel extends AbstractGroepLedenModel {
 
-	const ORM = 'RechtenGroepLid';
+	const ORM = RechtenGroepLid::class;
 
 	protected static $instance;
 
@@ -97,7 +97,7 @@ class RechtenGroepLedenModel extends AbstractGroepLedenModel {
 
 class OnderverenigingsLedenModel extends AbstractGroepLedenModel {
 
-	const ORM = 'OnderverenigingsLid';
+	const ORM = OnderverenigingsLid::class;
 
 	protected static $instance;
 
@@ -105,7 +105,7 @@ class OnderverenigingsLedenModel extends AbstractGroepLedenModel {
 
 class BewonersModel extends AbstractGroepLedenModel {
 
-	const ORM = 'Bewoner';
+	const ORM = Bewoner::class;
 
 	protected static $instance;
 
@@ -113,7 +113,7 @@ class BewonersModel extends AbstractGroepLedenModel {
 
 class LichtingLedenModel extends AbstractGroepLedenModel {
 
-	const ORM = 'LichtingsLid';
+	const ORM = LichtingsLid::class;
 
 	protected static $instance;
 
@@ -156,7 +156,7 @@ class LichtingLedenModel extends AbstractGroepLedenModel {
 
 class VerticaleLedenModel extends AbstractGroepLedenModel {
 
-	const ORM = 'VerticaleLid';
+	const ORM = VerticaleLid::class;
 
 	protected static $instance;
 
@@ -208,7 +208,7 @@ class VerticaleLedenModel extends AbstractGroepLedenModel {
 
 class KringLedenModel extends AbstractGroepLedenModel {
 
-	const ORM = 'KringLid';
+	const ORM = KringLid::class;
 
 	protected static $instance;
 
@@ -216,7 +216,7 @@ class KringLedenModel extends AbstractGroepLedenModel {
 
 class CommissieLedenModel extends AbstractGroepLedenModel {
 
-	const ORM = 'CommissieLid';
+	const ORM = CommissieLid::class;
 
 	protected static $instance;
 
@@ -224,7 +224,7 @@ class CommissieLedenModel extends AbstractGroepLedenModel {
 
 class BestuursLedenModel extends AbstractGroepLedenModel {
 
-	const ORM = 'BestuursLid';
+	const ORM = BestuursLid::class;
 
 	protected static $instance;
 
@@ -232,7 +232,7 @@ class BestuursLedenModel extends AbstractGroepLedenModel {
 
 class KetzerDeelnemersModel extends AbstractGroepLedenModel {
 
-	const ORM = 'KetzerDeelnemer';
+	const ORM = KetzerDeelnemer::class;
 
 	protected static $instance;
 
@@ -240,7 +240,7 @@ class KetzerDeelnemersModel extends AbstractGroepLedenModel {
 
 class WerkgroepDeelnemersModel extends KetzerDeelnemersModel {
 
-	const ORM = 'WerkgroepDeelnemer';
+	const ORM = WerkgroepDeelnemer::class;
 
 	protected static $instance;
 
@@ -248,7 +248,7 @@ class WerkgroepDeelnemersModel extends KetzerDeelnemersModel {
 
 class ActiviteitDeelnemersModel extends KetzerDeelnemersModel {
 
-	const ORM = 'ActiviteitDeelnemer';
+	const ORM = ActiviteitDeelnemer::class;
 
 	protected static $instance;
 

--- a/lib/model/GroepenModel.abstract.php
+++ b/lib/model/GroepenModel.abstract.php
@@ -238,7 +238,7 @@ abstract class AbstractGroepenModel extends CachedPersistenceModel {
 
 class RechtenGroepenModel extends AbstractGroepenModel {
 
-	const ORM = 'RechtenGroep';
+	const ORM = RechtenGroep::class;
 
 	protected static $instance;
 
@@ -252,7 +252,7 @@ class RechtenGroepenModel extends AbstractGroepenModel {
 
 class OnderverenigingenModel extends AbstractGroepenModel {
 
-	const ORM = 'Ondervereniging';
+	const ORM = Ondervereniging::class;
 
 	protected static $instance;
 
@@ -267,7 +267,7 @@ class OnderverenigingenModel extends AbstractGroepenModel {
 
 class WoonoordenModel extends AbstractGroepenModel {
 
-	const ORM = 'Woonoord';
+	const ORM = Woonoord::class;
 
 	protected static $instance;
 
@@ -282,7 +282,7 @@ class WoonoordenModel extends AbstractGroepenModel {
 
 class LichtingenModel extends AbstractGroepenModel {
 
-	const ORM = 'Lichting';
+	const ORM = Lichting::class;
 
 	protected static $instance;
 
@@ -337,7 +337,7 @@ class LichtingenModel extends AbstractGroepenModel {
 
 class VerticalenModel extends AbstractGroepenModel {
 
-	const ORM = 'Verticale';
+	const ORM = Verticale::class;
 
 	protected static $instance;
 	/**
@@ -366,7 +366,7 @@ class VerticalenModel extends AbstractGroepenModel {
 
 class KringenModel extends AbstractGroepenModel {
 
-	const ORM = 'Kring';
+	const ORM = Kring::class;
 
 	protected static $instance;
 	/**
@@ -394,7 +394,7 @@ class KringenModel extends AbstractGroepenModel {
 
 class CommissiesModel extends AbstractGroepenModel {
 
-	const ORM = 'Commissie';
+	const ORM = Commissie::class;
 
 	protected static $instance;
 
@@ -411,7 +411,7 @@ class CommissiesModel extends AbstractGroepenModel {
 
 class BesturenModel extends AbstractGroepenModel {
 
-	const ORM = 'Bestuur';
+	const ORM = Bestuur::class;
 
 	protected static $instance;
 
@@ -425,7 +425,7 @@ class BesturenModel extends AbstractGroepenModel {
 
 class KetzersModel extends AbstractGroepenModel {
 
-	const ORM = 'Ketzer';
+	const ORM = Ketzer::class;
 
 	protected static $instance;
 
@@ -443,7 +443,7 @@ class KetzersModel extends AbstractGroepenModel {
 
 class WerkgroepenModel extends KetzersModel {
 
-	const ORM = 'Werkgroep';
+	const ORM = Werkgroep::class;
 
 	protected static $instance;
 
@@ -451,7 +451,7 @@ class WerkgroepenModel extends KetzersModel {
 
 class ActiviteitenModel extends KetzersModel {
 
-	const ORM = 'Activiteit';
+	const ORM = Activiteit::class;
 
 	protected static $instance;
 
@@ -471,7 +471,7 @@ class ActiviteitenModel extends KetzersModel {
 
 class KetzerSelectorsModel extends AbstractGroepenModel {
 
-	const ORM = 'KetzerSelector';
+	const ORM = KetzerSelector::class;
 
 	protected static $instance;
 
@@ -483,7 +483,7 @@ class KetzerSelectorsModel extends AbstractGroepenModel {
 
 class KetzerOptiesModel extends AbstractGroepenModel {
 
-	const ORM = 'KetzerOptie';
+	const ORM = KetzerOptie::class;
 
 	protected static $instance;
 
@@ -495,7 +495,7 @@ class KetzerOptiesModel extends AbstractGroepenModel {
 
 class KetzerKeuzesModel extends AbstractGroepenModel {
 
-	const ORM = 'KetzerKeuze';
+	const ORM = KetzerKeuze::class;
 
 	protected static $instance;
 

--- a/lib/model/InstellingenModel.class.php
+++ b/lib/model/InstellingenModel.class.php
@@ -9,7 +9,7 @@ use CsrDelft\Orm\CachedPersistenceModel;
  */
 class Instellingen extends CachedPersistenceModel {
 
-	const ORM = 'Instelling';
+	const ORM = Instelling::class;
 
 	protected static $instance;
 	/**

--- a/lib/model/LedenMemoryScoresModel.class.php
+++ b/lib/model/LedenMemoryScoresModel.class.php
@@ -10,7 +10,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class LedenMemoryScoresModel extends PersistenceModel {
 
-	const ORM = 'LedenMemoryScore';
+	const ORM = LedenMemoryScore::class;
 
 	protected static $instance;
 	/**

--- a/lib/model/LidInstellingenModel.class.php
+++ b/lib/model/LidInstellingenModel.class.php
@@ -15,7 +15,7 @@ require_once 'model/InstellingenModel.class.php';
  */
 class LidInstellingen extends Instellingen {
 
-	const ORM = 'LidInstelling';
+	const ORM = LidInstelling::class;
 
 	protected static $instance;
 	/**

--- a/lib/model/LogModel.class.php
+++ b/lib/model/LogModel.class.php
@@ -10,7 +10,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class LogModel extends PersistenceModel {
 
-    const ORM = 'LogEntry';
+    const ORM = LogEntry::class;
 
     protected static $instance;
 

--- a/lib/model/MenuModel.class.php
+++ b/lib/model/MenuModel.class.php
@@ -11,7 +11,7 @@ use CsrDelft\Orm\Entity\PersistentEntity;
  */
 class MenuModel extends CachedPersistenceModel {
 
-	const ORM = 'MenuItem';
+	const ORM = MenuItem::class;
 
 	protected static $instance;
 	/**

--- a/lib/model/PeilingenModel.class.php
+++ b/lib/model/PeilingenModel.class.php
@@ -18,7 +18,7 @@ require_once 'model/entity/peilingen/PeilingStem.class.php';
  */
 class PeilingenModel extends PersistenceModel {
 
-	const ORM = 'Peiling';
+	const ORM = Peiling::class;
 	const DIR = 'peilingen/';
 
 	protected static $instance;
@@ -109,7 +109,7 @@ class PeilingenModel extends PersistenceModel {
 
 class PeilingOptiesModel extends PersistenceModel {
 
-	const ORM = 'PeilingOptie';
+	const ORM = PeilingOptie::class;
 	const DIR = 'peilingen/';
 
 	protected static $instance;
@@ -118,7 +118,7 @@ class PeilingOptiesModel extends PersistenceModel {
 
 class PeilingStemmenModel extends PersistenceModel {
 
-	const ORM = 'PeilingStem';
+	const ORM = PeilingStem::class;
 	const DIR = 'peilingen/';
 
 	protected static $instance;

--- a/lib/model/ProfielModel.class.php
+++ b/lib/model/ProfielModel.class.php
@@ -15,7 +15,7 @@ require_once 'model/entity/Mail.class.php';
  */
 class ProfielModel extends CachedPersistenceModel {
 
-	const ORM = 'Profiel';
+	const ORM = Profiel::class;
 
 	protected static $instance;
 

--- a/lib/model/TimerModel.class.php
+++ b/lib/model/TimerModel.class.php
@@ -9,7 +9,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class TimerModel extends PersistenceModel {
 
-	const ORM = 'ExecutionTime';
+	const ORM = ExecutionTime::class;
 
 	protected static $instance;
 	/**

--- a/lib/model/fiscaal/SaldoModel.class.php
+++ b/lib/model/fiscaal/SaldoModel.class.php
@@ -5,7 +5,7 @@ use CsrDelft\Orm\DynamicEntityModel;
 use CsrDelft\Orm\PersistenceModel;
 
 class SaldoModel extends PersistenceModel {
-    const ORM = 'Saldo';
+    const ORM = Saldo::class;
     const DIR = 'fiscaal/';
 
     protected static $instance;

--- a/lib/model/maalcie/ArchiefMaaltijdModel.class.php
+++ b/lib/model/maalcie/ArchiefMaaltijdModel.class.php
@@ -3,7 +3,7 @@
 use CsrDelft\Orm\PersistenceModel;
 
 class ArchiefMaaltijdModel extends PersistenceModel {
-    const ORM = 'ArchiefMaaltijd';
+    const ORM = ArchiefMaaltijd::class;
     const DIR = 'maalcie/';
 
     protected static $instance;

--- a/lib/model/maalcie/CorveeRepetitiesModel.class.php
+++ b/lib/model/maalcie/CorveeRepetitiesModel.class.php
@@ -12,7 +12,7 @@ require_once 'model/maalcie/CorveeVoorkeurenModel.class.php';
  * 
  */
 class CorveeRepetitiesModel extends PersistenceModel {
-	const ORM = 'CorveeRepetitie';
+	const ORM = CorveeRepetitie::class;
 	const DIR = 'maalcie/';
 
 	protected static $instance;

--- a/lib/model/maalcie/CorveeTakenModel.class.php
+++ b/lib/model/maalcie/CorveeTakenModel.class.php
@@ -12,7 +12,7 @@ require_once 'model/maalcie/CorveePuntenModel.class.php';
  * 
  */
 class CorveeTakenModel extends PersistenceModel {
-	const ORM = 'CorveeTaak';
+	const ORM = CorveeTaak::class;
 	const DIR = 'maalcie/';
 
 	protected static $instance;

--- a/lib/model/maalcie/FunctiesModel.class.php
+++ b/lib/model/maalcie/FunctiesModel.class.php
@@ -12,7 +12,7 @@ require_once 'model/maalcie/KwalificatiesModel.class.php';
  */
 class FunctiesModel extends CachedPersistenceModel {
 
-	const ORM = 'CorveeFunctie';
+	const ORM = CorveeFunctie::class;
 	const DIR = 'maalcie/';
 
 	protected static $instance;

--- a/lib/model/maalcie/KwalificatiesModel.class.php
+++ b/lib/model/maalcie/KwalificatiesModel.class.php
@@ -9,7 +9,7 @@ use CsrDelft\Orm\CachedPersistenceModel;
  */
 class KwalificatiesModel extends CachedPersistenceModel {
 
-	const ORM = 'CorveeKwalificatie';
+	const ORM = CorveeKwalificatie::class;
 	const DIR = 'maalcie/';
 
 	protected static $instance;

--- a/lib/model/maalcie/MaaltijdAanmeldingenModel.class.php
+++ b/lib/model/maalcie/MaaltijdAanmeldingenModel.class.php
@@ -12,7 +12,7 @@ require_once 'model/maalcie/MaaltijdenModel.class.php';
  */
 class MaaltijdAanmeldingenModel extends PersistenceModel  {
 
-    const ORM = 'MaaltijdAanmelding';
+    const ORM = MaaltijdAanmelding::class;
     const DIR = 'maalcie/';
 
     protected static $instance;

--- a/lib/model/maalcie/MaaltijdAbonnementenModel.class.php
+++ b/lib/model/maalcie/MaaltijdAbonnementenModel.class.php
@@ -13,7 +13,7 @@ require_once 'model/maalcie/MaaltijdRepetitiesModel.class.php';
  */
 class MaaltijdAbonnementenModel extends PersistenceModel {
 
-    const ORM = 'MaaltijdAbonnement';
+    const ORM = MaaltijdAbonnement::class;
     const DIR = 'maalcie/';
 
     protected static $instance;

--- a/lib/model/maalcie/MaaltijdBeoordelingenModel.class.php
+++ b/lib/model/maalcie/MaaltijdBeoordelingenModel.class.php
@@ -10,7 +10,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class MaaltijdBeoordelingenModel extends PersistenceModel {
 
-	const ORM = 'MaaltijdBeoordeling';
+	const ORM = MaaltijdBeoordeling::class;
 	const DIR = 'maalcie/';
 
 	protected static $instance;

--- a/lib/model/maalcie/MaaltijdRepetitiesModel.class.php
+++ b/lib/model/maalcie/MaaltijdRepetitiesModel.class.php
@@ -12,7 +12,7 @@ require_once 'model/maalcie/CorveeRepetitiesModel.class.php';
  */
 class MaaltijdRepetitiesModel extends PersistenceModel {
 
-    const ORM = 'MaaltijdRepetitie';
+    const ORM = MaaltijdRepetitie::class;
     const DIR = 'maalcie/';
 
     protected $default_order = '(periode_in_dagen = 0) ASC, periode_in_dagen ASC, dag_vd_week ASC, standaard_titel ASC';

--- a/lib/model/maalcie/MaaltijdenModel.class.php
+++ b/lib/model/maalcie/MaaltijdenModel.class.php
@@ -14,7 +14,7 @@ require_once 'model/maalcie/MaaltijdAbonnementenModel.class.php';
  */
 class MaaltijdenModel extends PersistenceModel {
 
-    const ORM = 'Maaltijd';
+    const ORM = Maaltijd::class;
     const DIR = 'maalcie/';
 
     protected $default_order = 'datum ASC, tijd ASC';

--- a/lib/model/mededelingen/MededelingCategorieenModel.class.php
+++ b/lib/model/mededelingen/MededelingCategorieenModel.class.php
@@ -10,7 +10,7 @@ use CsrDelft\Orm\CachedPersistenceModel;
  */
 class MededelingCategorieenModel extends CachedPersistenceModel {
 
-	const ORM = 'MededelingCategorie';
+	const ORM = MededelingCategorie::class;
 	const DIR = 'mededelingen/';
 
 	protected static $instance;

--- a/lib/model/mededelingen/MededelingenModel.class.php
+++ b/lib/model/mededelingen/MededelingenModel.class.php
@@ -13,7 +13,7 @@ require_once 'model/mededelingen/MededelingCategorieenModel.class.php';
  */
 class MededelingenModel extends PersistenceModel {
 
-	const ORM = 'Mededeling';
+	const ORM = Mededeling::class;
 	const DIR = 'mededelingen/';
 	const defaultPrioriteit = 255;
 

--- a/lib/model/security/AccessModel.class.php
+++ b/lib/model/security/AccessModel.class.php
@@ -21,7 +21,7 @@ require_once 'model/GroepenModel.abstract.php';
  */
 class AccessModel extends CachedPersistenceModel {
 
-	const ORM = 'AccessControl';
+	const ORM = AccessControl::class;
 	const DIR = 'security/';
 
 	protected static $instance;

--- a/lib/model/security/AccountModel.class.php
+++ b/lib/model/security/AccountModel.class.php
@@ -12,7 +12,7 @@ use CsrDelft\Orm\Persistence\Database;
  */
 class AccountModel extends CachedPersistenceModel {
 
-	const ORM = 'Account';
+	const ORM = Account::class;
 	const DIR = 'security/';
 
 	protected static $instance;

--- a/lib/model/security/LoginModel.class.php
+++ b/lib/model/security/LoginModel.class.php
@@ -21,7 +21,7 @@ require_once 'model/ProfielModel.class.php';
  */
 class LoginModel extends PersistenceModel implements Validator {
 
-	const ORM = 'LoginSession';
+	const ORM = LoginSession::class;
 	const DIR = 'security/';
 
 	protected static $instance;

--- a/lib/model/security/OneTimeTokensModel.class.php
+++ b/lib/model/security/OneTimeTokensModel.class.php
@@ -11,7 +11,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class OneTimeTokensModel extends PersistenceModel {
 
-	const ORM = 'OneTimeToken';
+	const ORM = OneTimeToken::class;
 	const DIR = 'security/';
 
 	protected static $instance;

--- a/lib/model/security/RememberLoginModel.class.php
+++ b/lib/model/security/RememberLoginModel.class.php
@@ -9,7 +9,7 @@ use CsrDelft\Orm\PersistenceModel;
  */
 class RememberLoginModel extends PersistenceModel {
 
-	const ORM = 'RememberLogin';
+	const ORM = RememberLogin::class;
 	const DIR = 'security/';
 
 	protected static $instance;


### PR DESCRIPTION
Zorgt ervoor dat je makkelijker kan doorklikken.

Sinds php 5.6 is dit te doen, tot voor kort draaide de stek op 5.4 en toen werd dit nog niet ondersteund.