### PR TITLE
Maak de API toegankelijk vanaf bepaalde externe domeinen

### DIFF
--- a/conf/dev/defines.include.php
+++ b/conf/dev/defines.include.php
@@ -40,6 +40,9 @@ define('JWT_SECRET', 'BjG\0_;,OY5k)w-frmSpgleH"*^6Q_t{M=uh.<:nH8n<Xrs!FZY=TGhi}{
 # JWT lifetime for API, in seconds
 define('JWT_LIFETIME', 3600);
 
+# Toegestane API origins
+define('API_ORIGINS', 'http://localhost:8080,https://csrdelft.github.io');
+
 # paden MET trailing slash
 define('BASE_PATH', realpath(dirname(__FILE__)) . "/../");
 define('ETC_PATH', BASE_PATH . 'etc/');

--- a/htdocs/API/2.0/index.php
+++ b/htdocs/API/2.0/index.php
@@ -8,6 +8,25 @@ use CsrDelft\controller\api\ApiLedenController;
 use CsrDelft\controller\api\ApiMaaltijdenController;
 use Jacwright\RestServer\RestServer;
 
+/**
+ * Maak de API toegankelijk vanaf bepaalde externe Origins.
+ */
+$enabledOrigins = array(
+	'http://localhost:8100', // Nodig voor de iOS app
+	'https://csrdelft.github.io' // Gebruikt voor app staging
+);
+if (in_array($_SERVER['HTTP_ORIGIN'], $enabledOrigins, true)) {
+	header('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
+	header('Access-Control-Max-Age: 1440');
+	header('Access-Control-Allow-Headers: Accept, Origin, Content-Type, X-Csr-Authorization');
+	header('Access-Control-Allow-Methods: PUT, GET, POST, DELETE, OPTIONS');
+
+	if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+		http_response_code(204);
+		exit;
+	}
+}
+
 require_once 'configuratie.include.php';
 
 $mode = DEBUG ? 'debug' : 'production';

--- a/htdocs/API/2.0/index.php
+++ b/htdocs/API/2.0/index.php
@@ -8,14 +8,12 @@ use CsrDelft\controller\api\ApiLedenController;
 use CsrDelft\controller\api\ApiMaaltijdenController;
 use Jacwright\RestServer\RestServer;
 
+require_once 'configuratie.include.php';
+
 /**
- * Maak de API toegankelijk vanaf bepaalde externe Origins.
+ * Maak de API toegankelijk vanaf bepaalde externe domeinen.
  */
-$enabledOrigins = array(
-	'http://localhost:8100', // Nodig voor de iOS app
-	'https://csrdelft.github.io' // Gebruikt voor app staging
-);
-if (in_array($_SERVER['HTTP_ORIGIN'], $enabledOrigins, true)) {
+if (in_array($_SERVER['HTTP_ORIGIN'], explode(',', API_ORIGINS), true)) {
 	header('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
 	header('Access-Control-Max-Age: 1440');
 	header('Access-Control-Allow-Headers: Accept, Origin, Content-Type, X-Csr-Authorization');
@@ -26,8 +24,6 @@ if (in_array($_SERVER['HTTP_ORIGIN'], $enabledOrigins, true)) {
 		exit;
 	}
 }
-
-require_once 'configuratie.include.php';
 
 $mode = DEBUG ? 'debug' : 'production';
 $server = new RestServer($mode);

--- a/lib/defines.include.php.sample
+++ b/lib/defines.include.php.sample
@@ -40,6 +40,9 @@ define('JWT_SECRET', '$3Wb@IRhmTnf6msM$RV6fJ6fao%nm%2Td2ixabLf_8rv%-#H5a1Qtr$gxj
 # JWT lifetime for API, in seconds
 define('JWT_LIFETIME', 3600);
 
+# Toegestane API origins
+define('API_ORIGINS', 'http://localhost:8080,https://csrdelft.github.io');
+
 define('CAPTCHA_SECRET', '<Zet mij>');
 define('GOOGLE_CLIENT_ID', '<Zet mij>');
 define('GOOGLE_CLIENT_SECRET', '<Zet mij>');


### PR DESCRIPTION
Tot nu toe is de API niet beschikbaar vanaf andere domeinen dan csrdelft.nl. Requests die door een browser worden gedaan naar een ander domein (cross-origin), moeten daar in bepaalde gevallen toestemming voor vragen. Dit heet CORS (Cross-origin resource sharing) en is bedoeld als veiligheidsmaatregel tegen CSRF aanvallen (Cross-site request forgery). In dit geval moet er toestemming gevraagd worden omdat er een authenticatie header gebruikt wordt.

Hiermee wordt toegang gegeven aan twee externe domeinen:
- http://localhost:8100: deze is nodig voor een flinke performance upgrade voor iOS. Die nieuwere webview ondersteunt CORS ook lokaal, dus heeft dit nodig om te werken. Dit is een lokaal domein dus geen toegevoegd veiligheidsrisico.
- https://csrdelft.github.io: omdat de app alleen maar statische files zijn, kan ik met github pages op https://csrdelft.github.io/lustrum een staging versie krijgen om de web versie beter te testen op offline support ed. Dit is een domein met enkel statische files, dus dit is ook geen toegevoegd veiligheidsrisico.