### PR TITLE
Fix geneste bb img in een url

### DIFF
--- a/htdocs/assets/layout-owee/js/main.js
+++ b/htdocs/assets/layout-owee/js/main.js
@@ -43,8 +43,9 @@
 					content.on('load', function () {
 						var foto = content.attr('src').indexOf('/plaetjes/fotoalbum/') >= 0;
 						var video = $(this).parent().parent().hasClass('bb-video-preview');
+						var hasAnchor = $(this).closest('a').length !== 0;
 						$(this).parent().replaceWith($(this));
-						if (!foto && !video) {
+						if (!foto && !video && !hasAnchor) {
 							$(this).wrap('<a class="lightbox-link" href="' + $(this).attr('src') + '" data-lightbox="page-lightbox"></a>');
 						}
 					});

--- a/htdocs/assets/layout/js/csrdelft.js
+++ b/htdocs/assets/layout/js/csrdelft.js
@@ -179,8 +179,9 @@ function init_lazy_images(parent) {
 		content.on('load', function () {
 			var foto = content.attr('src').indexOf('/plaetjes/fotoalbum/') >= 0;
 			var video = $(this).parent().parent().hasClass('bb-video-preview');
+			var hasAnchor = $(this).closest('a').length !== 0;
 			$(this).parent().replaceWith($(this));
-			if (!foto && !video) {
+			if (!foto && !video && !hasAnchor) {
 				$(this).wrap('<a class="lightbox-link" href="' + $(this).attr('src') + '" data-lightbox="page-lightbox"></a>');
 			}
 		});

--- a/lib/view/bbcode/CsrBB.class.php
+++ b/lib/view/bbcode/CsrBB.class.php
@@ -158,7 +158,6 @@ class CsrBB extends Parser {
 	 * Templates for light mode
 	 */
 	private function lightLinkInline($tag, $url, $content) {
-		$content = htmlspecialchars($content);
 		return <<<HTML
 			<a class="bb-link-inline bb-tag-{$tag}" href="{$url}">{$content}</a>
 HTML;


### PR DESCRIPTION
Wanneer een img al een a als parent heeft, wordt er geen lightbox link van gemaakt.

Closes #27