### PR TITLE
Zet mysql versie naar 5.5, Syrinx draait hier op.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ./:/app # Docker composer start in /app
 
   stekdb:
-    image: mariadb
+    image: mysql:5.5
     environment:
       MYSQL_ROOT_PASSWORD: bl44t
       MYSQL_USER: csrdelft


### PR DESCRIPTION
Easypeasy, corrupt helaas wel de stekdb image... Er moet dan een nieuwe dump op geladen worden. Fixes #301.

@Manduro 