### PR TITLE
Installeer hash met php in docker

### DIFF
--- a/conf/stek.dockerfile
+++ b/conf/stek.dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # install php extensions
-RUN docker-php-ext-install mysqli pdo pdo_mysql
+RUN docker-php-ext-install mysqli pdo pdo_mysql hash
 RUN pecl install xdebug && docker-php-ext-enable xdebug
 
 # enable apache mods


### PR DESCRIPTION
Is nodig om de mhash functies te kunnen uitvoeren voor wachtwoord reset.