### PR TITLE
Sponsorkliks Scrapen

### DIFF
--- a/bin/cron.php
+++ b/bin/cron.php
@@ -88,6 +88,12 @@ try {
 	DebugLogModel::instance()->log('cron.php', 'php pin_transactie_download.php', array(), $e);
 }
 
+try {
+	passthru('php ../bin/sponsorkliks_affiliates_download.php');
+} catch (Exception $e) {
+	DebugLogModel::instance()->log('cron.php', 'php sponsorkliks_affiliates_download.php', array(), $e);
+}
+
 $finish = microtime(true) - $start;
 if (DEBUG) {
 	echo getDateTime() . ' Finished in ' . (int)$finish . " seconds.\r\n";

--- a/bin/sponsorkliks_affiliates_download.php
+++ b/bin/sponsorkliks_affiliates_download.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * sponsorkliks_affiliate_download.php
+ *
+ * @author J. Rijsdijk <jorairijsdijk@gmail.com>
+ * @date 26/10/2017
+ */
+
+use function CsrDelft\curl_follow_location;
+use function CsrDelft\curl_request;
+use function CsrDelft\init_xpath;
+
+/**
+ * Settings constants.
+ */
+const SETTINGS_CLUBID = 'clubid';
+
+/**
+ * Url constants.
+ */
+const SK_HOST = 'https://www.sponsorkliks.com';
+const PAGE_URL = SK_HOST . '/products/shops.php?club=';
+
+require_once __DIR__ . '/../lib/configuratie.include.php';
+
+//Steps
+$settings = parse_ini_file(__DIR__ . '/../etc/sponsorkliks_affiliates_download.ini');
+
+$clubId = $settings[SETTINGS_CLUBID];
+$scrapeUrl = PAGE_URL . $clubId;
+
+//1. GET affiliates pagina
+$result = curl_request($scrapeUrl);
+
+//2. Retrieve affiliate boxes
+$xpath = init_xpath($result);
+$affiliateBoxes = $xpath->query('//div[@class = "ibox-content product-box"]');
+$affiliates = [];
+
+//3. Follow links to final destination
+foreach ($affiliateBoxes as $affiliate) {
+	$element = $xpath->query('div/a[@class="product-name orderlink"]', $affiliate)->item(0);
+	$href = $element->getAttribute('href');
+
+	$sponsorUrl = curl_follow_location(SK_HOST . $href);
+	$affiliates[parse_url($sponsorUrl, PHP_URL_HOST)] = ["name" => $element->nodeValue, "link" => $href];
+}
+
+//4. Save results to sponsorkliks.json in data folder (overwriting existing)
+$json = json_encode($affiliates);
+$outputFile = fopen(DATA_PATH . 'sponsorkliks.json', 'w');
+fwrite($outputFile, $json);
+fclose($outputFile);
+

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "tedivm/jshrink": "^1.1",
         "tubalmartin/cssmin": "^4.0",
         "oyejorge/less.php": "v1.7.0.14",
-        "maknz/slack": "^1.7"
+        "maknz/slack": "^1.7",
+        "jakeasmith/http_build_url": "^1"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9d5c72d9a12d20395bec7379ee5f41f3",
-    "content-hash": "049c4d539911da04b23439101c263c77",
+    "hash": "7acc137548636340a8c06e78469410f1",
+    "content-hash": "f4cc090153647768b80e130cfbae5f42",
     "packages": [
         {
             "name": "csrdelft/orm",
@@ -551,6 +551,39 @@
                 "rest-server"
             ],
             "time": "2017-08-22 23:45:00"
+        },
+        {
+            "name": "jakeasmith/http_build_url",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jakeasmith/http_build_url.git",
+                "reference": "93c273e77cb1edead0cf8bcf8cd2003428e74e37"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jakeasmith/http_build_url/zipball/93c273e77cb1edead0cf8bcf8cd2003428e74e37",
+                "reference": "93c273e77cb1edead0cf8bcf8cd2003428e74e37",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/http_build_url.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jake A. Smith",
+                    "email": "theman@jakeasmith.com"
+                }
+            ],
+            "description": "Provides functionality for http_build_url() to environments without pecl_http.",
+            "time": "2017-05-01 15:36:40"
         },
         {
             "name": "maknz/slack",

--- a/etc/sponsorkliks_affiliates_download.ini.sample
+++ b/etc/sponsorkliks_affiliates_download.ini.sample
@@ -1,0 +1,6 @@
+;
+; Dit is onze sponsorkliks clubid
+;
+
+[sponsorkliks]
+clubid = ;

--- a/htdocs/API/2.0/index.php
+++ b/htdocs/API/2.0/index.php
@@ -6,6 +6,7 @@ use CsrDelft\controller\api\ApiAuthController;
 use CsrDelft\controller\api\ApiForumController;
 use CsrDelft\controller\api\ApiLedenController;
 use CsrDelft\controller\api\ApiMaaltijdenController;
+use CsrDelft\controller\api\ApiSponsorkliksController;
 use Jacwright\RestServer\RestServer;
 
 require_once 'configuratie.include.php';
@@ -36,5 +37,6 @@ $server->addClass(ApiAuthController::class, '/auth');
 $server->addClass(ApiForumController::class, '/forum');
 $server->addClass(ApiLedenController::class, '/leden');
 $server->addClass(ApiMaaltijdenController::class, '/maaltijden');
+$server->addClass(ApiSponsorkliksController::class, '/sponsorkliks');
 
 $server->handle();

--- a/lib/common.functions.php
+++ b/lib/common.functions.php
@@ -872,10 +872,10 @@ function url2absolute($baseurl, $relativeurl) {
  * @return mixed The curl_exec result
  */
 function curl_request($url, $options = []) {
-	$ch = curl_init($url);
-	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-	curl_setopt_array($ch, $options);
-	return curl_exec($ch);
+	$curl = curl_init($url);
+	curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt_array($curl, $options);
+	return curl_exec($curl);
 }
 
 /**
@@ -886,12 +886,12 @@ function curl_request($url, $options = []) {
  * @return String The final url location
  */
 function curl_follow_location($url, $options = []) {
-	$ch = curl_init($url);
-	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-	curl_setopt_array($ch, $options);
-	$xpath = init_xpath(curl_exec($ch));
-	$location = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+	$curl = curl_init($url);
+	curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+	curl_setopt_array($curl, $options);
+	$xpath = init_xpath(curl_exec($curl));
+	$location = curl_getinfo($curl, CURLINFO_EFFECTIVE_URL);
 
 	$refresh = $xpath->query('//meta[translate(@http-equiv, "abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ")="REFRESH"]');
 	if ($refresh->length > 0) {

--- a/lib/common.functions.php
+++ b/lib/common.functions.php
@@ -864,3 +864,63 @@ function url2absolute($baseurl, $relativeurl) {
 	}
 	return implode('/', $returnpath);
 }
+
+/**
+ * Shorthand for a curl request.
+ * @param $url String The url for the request
+ * @param array $options curl options
+ * @return mixed The curl_exec result
+ */
+function curl_request($url, $options = []) {
+	$ch = curl_init($url);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt_array($ch, $options);
+	return curl_exec($ch);
+}
+
+/**
+ * Follow an url to its final location taking http redirects and meta refreshes into account.
+ *
+ * @param String $url The url to follow to its final location
+ * @param array $options A curl_setopt_array compatible array
+ * @return String The final url location
+ */
+function curl_follow_location($url, $options = []) {
+	$ch = curl_init($url);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+	curl_setopt_array($ch, $options);
+	$xpath = init_xpath(curl_exec($ch));
+	$location = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+
+	$refresh = $xpath->query('//meta[translate(@http-equiv, "abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ")="REFRESH"]');
+	if ($refresh->length > 0) {
+		preg_match('/(?<=url=)(.*)/i', $refresh->item(0)->getAttribute('content'), $matches);
+		$refreshUrl = trim($matches[0]);
+
+		// clk.tradedoubler.com specific meta-refresh workaround
+		if (endsWith($location, 'f=0')) {
+			return curl_follow_location(str_replace('f=0', '&f=0', $location));
+		}
+
+		if (!startsWith($refreshUrl, 'http')) {
+			$refreshUrl = http_build_url($location, $refreshUrl, HTTP_URL_REPLACE | HTTP_URL_JOIN_PATH);
+		}
+
+		return curl_follow_location($refreshUrl, $options);
+	}
+
+	return $location;
+}
+
+/**
+ * Create an xpath object from an HTML string.
+ *
+ * @param $html String the HTML string to create the xpath object from
+ * @return \DOMXPath The xpath object
+ */
+function init_xpath($html) {
+	$xml = new \DOMDocument();
+	$xml->loadHTML($html);
+	return new \DOMXPath($xml);
+}

--- a/lib/controller/api/ApiSponsorkliksController.php
+++ b/lib/controller/api/ApiSponsorkliksController.php
@@ -1,14 +1,12 @@
 <?php
-/**
- * Created by IntelliJ IDEA.
- * User: jorai
- * Date: 11/4/17
- * Time: 5:34 PM
- */
 
 namespace CsrDelft\controller\api;
 
 
+/**
+ * @author J. Rijsdijk <jorairijsdijk@gmail.com>
+ * @date 04/11/2017
+ */
 class ApiSponsorkliksController {
 	/**
 	 * @url GET /

--- a/lib/controller/api/ApiSponsorkliksController.php
+++ b/lib/controller/api/ApiSponsorkliksController.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: jorai
+ * Date: 11/4/17
+ * Time: 5:34 PM
+ */
+
+namespace CsrDelft\controller\api;
+
+
+class ApiSponsorkliksController {
+	/**
+	 * @url GET /
+	 */
+	public function getSponsorkliks() {
+		$json = file(DATA_PATH . 'sponsorkliks.json', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		return ['data' => json_decode($json[0], true)];
+	}
+}


### PR DESCRIPTION
Voegt een cron job toe die de top 35 sponsorkliks aanbiedingen ophaalt en via /API/2.0/sponsorkliks aanbiedt.
Backend onderdeel van #348 