### PR TITLE
Fix invoegen documentverwijzing wiki

### DIFF
--- a/lib/controller/DocumentenController.class.php
+++ b/lib/controller/DocumentenController.class.php
@@ -210,7 +210,8 @@ class DocumentenController extends AclController {
 				$result[] = array(
 					'url' => '/documenten/bekijken/' . $doc->id . '/' . $doc->filename,
 					'label' => $this->model->getCategorieModel()->find('id = ?', [$doc->categorie_id])->fetch()->naam,
-					'value' => $doc->naam
+					'value' => $doc->naam,
+					'id' => $doc->id
 				);
 			}
 		}


### PR DESCRIPTION
Werkte niet meer omdat nog gebruik gemaakt werd van /tools/suggesties.php terwijl die niet meer bestaat.