### PR TITLE
Doe redirect na login via GET parameter inplaats van via cookie

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -35,8 +35,7 @@ switch ($class) {
     // de rest alleen voor ingelogde gebruikers:
     default:
         if (!LoginModel::mag('P_LOGGED_IN')) {
-            setGoBackCookie(REQUEST_URI);
-            redirect(CSR_ROOT . "#login");
+			redirect_via_login(REQUEST_URI);
         }
 }
 

--- a/lib/common.functions.php
+++ b/lib/common.functions.php
@@ -107,20 +107,6 @@ function group_by_distinct($prop, $in, $del = true) {
 }
 
 /**
- * Set cookie with url to go back to after login.
- *
- * @param string $url
- */
-function setGoBackCookie($url) {
-	if ($url == null) {
-		unset($_COOKIE['goback']);
-		setcookie('goback', null, -1, '/', CSR_DOMAIN, FORCE_HTTPS, true);
-	} else {
-		setcookie('goback', $url, time() + (int)InstellingenModel::get('beveiliging', 'session_lifetime_seconds'), '/', CSR_DOMAIN, FORCE_HTTPS, true);
-	}
-}
-
-/**
  * Set cookie with token to automatically login.
  *
  * @param string $token
@@ -161,12 +147,19 @@ function redirect($url = null, $refresh = true) {
 		$url = CSR_ROOT;
 	}
 	if (!startsWith($url, CSR_ROOT)) {
-		$url = CSR_ROOT . $url;
+		if (preg_match("/^[\?#\/]/", $url) === 1) {
+			$url = CSR_ROOT . $url;
+		} else {
+			$url = CSR_ROOT;
+		}
 	}
 	header('location: ' . $url);
 	exit;
 }
 
+function redirect_via_login($url) {
+	redirect(CSR_ROOT . "?redirect=".urlencode($url)."#login");
+}
 /**
  * rawurlencode() met uitzondering van slashes.
  *

--- a/lib/controller/LoginController.class.php
+++ b/lib/controller/LoginController.class.php
@@ -123,10 +123,8 @@ class LoginController extends AclController {
 				$this->view = new CsrLayoutPage($body, array(), $form);
 				return;
 			}
-			if (isset($_COOKIE['goback'])) {
-				$url = $_COOKIE['goback'];
-				setGoBackCookie(null);
-				redirect($url);
+			if ($values['redirect']) {
+				redirect($values['redirect']);
 			}
 			redirect(CSR_ROOT);
 		} else {
@@ -443,10 +441,7 @@ class LoginController extends AclController {
 			if (isset($_POST['DataTableId'])) {
 				$this->view = new RememberLoginData(array($remember));
 			} // after login
-			elseif (isset($_COOKIE['goback'])) {
-				$this->view = new JsonResponse($_COOKIE['goback']);
-				setGoBackCookie(null);
-			} else {
+			else {
 				$this->view = new JsonResponse(CSR_ROOT);
 			}
 		} else {

--- a/lib/controller/LoginController.class.php
+++ b/lib/controller/LoginController.class.php
@@ -115,7 +115,7 @@ class LoginController extends AclController {
 			// Remember login form
 			if ($values['remember']) {
 				$remember = RememberLoginModel::instance()->nieuw();
-				$form = new RememberAfterLoginForm($remember);
+				$form = new RememberAfterLoginForm($remember, $values['redirect']);
 				$form->css_classes[] = 'redirect';
 
 
@@ -440,7 +440,9 @@ class LoginController extends AclController {
 			}
 			if (isset($_POST['DataTableId'])) {
 				$this->view = new RememberLoginData(array($remember));
-			} // after login
+			} else if (isset($_POST['redirect'])) {
+				$this->view = new JsonResponse($_POST['redirect']);
+			}
 			else {
 				$this->view = new JsonResponse(CSR_ROOT);
 			}

--- a/lib/controller/framework/Controller.abstract.php
+++ b/lib/controller/framework/Controller.abstract.php
@@ -202,8 +202,7 @@ abstract class Controller {
 			die($response_code);
 		} // Redirect to login form
 		elseif (LoginModel::getUid() === 'x999') {
-			setGoBackCookie(REQUEST_URI);
-			redirect(CSR_ROOT . "#login");
+			redirect_via_login(REQUEST_URI);
 		}
 		// GUI 403
 		$body = new CmsPaginaView(CmsPaginaModel::get($response_code));

--- a/lib/view/formulier/invoervelden/HiddenField.class.php
+++ b/lib/view/formulier/invoervelden/HiddenField.class.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: sander
+ * Date: 29-6-18
+ * Time: 14:54
+ */
+
+namespace CsrDelft\view\formulier\invoervelden;
+
+
+class HiddenField extends InputField {
+
+	public function __construct($name, $value, $model = null) {
+		parent::__construct($name, $value, null, $model);
+		$this->type = "hidden";
+	}
+
+}

--- a/lib/view/login/LoginForm.php
+++ b/lib/view/login/LoginForm.php
@@ -5,6 +5,8 @@ namespace CsrDelft\view\login;
 use CsrDelft\model\security\LoginModel;
 use CsrDelft\view\formulier\elementen\HtmlComment;
 use CsrDelft\view\formulier\Formulier;
+use CsrDelft\view\formulier\invoervelden\HiddenField;
+use CsrDelft\view\formulier\invoervelden\InputField;
 use CsrDelft\view\formulier\invoervelden\TextField;
 use CsrDelft\view\formulier\invoervelden\WachtwoordField;
 use CsrDelft\view\formulier\keuzevelden\CheckboxField;
@@ -15,6 +17,9 @@ class LoginForm extends Formulier {
 		parent::__construct(null, '/login');
 		$this->formId = 'loginform';
 		$this->showMelding = $showMelding;
+
+		$redirectUri = filter_input(INPUT_GET, 'redirect', FILTER_UNSAFE_RAW);
+		$fields['redirect'] = new HiddenField('redirect', $redirectUri);
 
 		$fields['user'] = new TextField('user', null, null);
 		$fields['user']->placeholder = 'Bijnaam of lidnummer';

--- a/lib/view/login/RememberAfterLoginForm.php
+++ b/lib/view/login/RememberAfterLoginForm.php
@@ -3,12 +3,14 @@
 namespace CsrDelft\view\login;
 
 use CsrDelft\model\entity\security\RememberLogin;
+use CsrDelft\view\formulier\invoervelden\HiddenField;
 
 class RememberAfterLoginForm extends RememberLoginForm {
 
-	public function __construct(RememberLogin $remember) {
+	public function __construct(RememberLogin $remember, string $redirectUri) {
 		parent::__construct($remember);
 		$this->dataTableId = false; // same as parent but without data table
+		$this->addFields([new HiddenField('redirect', $redirectUri)]);
 	}
 
 }


### PR DESCRIPTION
In de huidige situatie komt het regelmatig voor dat ik inlog en  geredirect word naar een json-response of een afbeelding. Wat er dan gebeurt is dat bijvoorbeeld in een ander tabblad de stek nog open staat en daar probeert een API-request te doen of een afbeelding te laden. Daardoor komt die url in de goback cookie terecht. Door deze refactor zou dit verholpen moeten zijn.