### PR TITLE
Pin verwijderen

### DIFF
--- a/db/migrations/20181016152200_pin_transactie_verwijderd.php
+++ b/db/migrations/20181016152200_pin_transactie_verwijderd.php
@@ -1,0 +1,13 @@
+<?php
+
+
+use Phinx\Migration\AbstractMigration;
+
+class PinTransactieVerwijderd extends AbstractMigration {
+
+	public function change() {
+		$this->table('pin_transactie_match')
+			->changeColumn('status', 'enum', ['values' => ['match','verwijderd','verkeerd bedrag','missende transactie','missende bestelling']])
+			->save();
+    }
+}

--- a/lib/model/entity/fiscaat/pin/PinTransactieMatchStatusEnum.php
+++ b/lib/model/entity/fiscaat/pin/PinTransactieMatchStatusEnum.php
@@ -14,6 +14,7 @@ class PinTransactieMatchStatusEnum extends PersistentEnum {
 	 * PinTransactieMatchStatus opties.
 	 */
 	const STATUS_MATCH = 'match';
+	const STATUS_VERWIJDERD = 'verwijderd';
 	const STATUS_VERKEERD_BEDRAG = 'verkeerd bedrag';
 	const STATUS_MISSENDE_TRANSACTIE = 'missende transactie';
 	const STATUS_MISSENDE_BESTELLING = 'missende bestelling';
@@ -23,6 +24,7 @@ class PinTransactieMatchStatusEnum extends PersistentEnum {
 	 */
 	protected static $supportedChoices = [
 		self::STATUS_MATCH => self::STATUS_MATCH,
+		self::STATUS_VERWIJDERD => self::STATUS_VERWIJDERD,
 		self::STATUS_VERKEERD_BEDRAG => self::STATUS_VERKEERD_BEDRAG,
 		self::STATUS_MISSENDE_TRANSACTIE => self::STATUS_MISSENDE_TRANSACTIE,
 		self::STATUS_MISSENDE_BESTELLING => self::STATUS_MISSENDE_BESTELLING,
@@ -33,6 +35,7 @@ class PinTransactieMatchStatusEnum extends PersistentEnum {
 	 */
 	protected static $mapChoiceToDescription = [
 		self::STATUS_MATCH => 'Match',
+		self::STATUS_VERWIJDERD => 'Verwijderd',
 		self::STATUS_VERKEERD_BEDRAG => 'Verkeerd bedrag',
 		self::STATUS_MISSENDE_TRANSACTIE => 'Missende transactie',
 		self::STATUS_MISSENDE_BESTELLING => 'Missende bestelling',

--- a/lib/view/fiscaat/pin/PinTransactieMatchTable.php
+++ b/lib/view/fiscaat/pin/PinTransactieMatchTable.php
@@ -27,7 +27,7 @@ class PinTransactieMatchTable extends DataTable {
 		$this->addKnop(new ConfirmDataTableKnop(Multiplicity::One(), '/fiscaat/pin/ontkoppel', 'Ontkoppel', 'Ontkoppel bestelling en transactie', 'arrow_divide'));
 		$this->addKnop(new DataTableKnop(Multiplicity::Two(), '/fiscaat/pin/koppel', 'Koppel', 'Koppel een bestelling en transactie', 'arrow_join'));
 		$this->addKnop(new DataTableKnop(Multiplicity::One(), '/fiscaat/pin/info', 'Info', 'Bekijk informatie over de gekoppelde bestelling', 'magnifier'));
-		$this->addKnop(new DataTableKnop(Multiplicity::Any(), '/fiscaat/pin/verwijderen', 'Verwijder', 'Verwijder matches', 'delete'));
+		$this->addKnop(new DataTableKnop(Multiplicity::Any(), '/fiscaat/pin/verwijder_transactie', 'Verwijder', 'Verwijder matches', 'delete'));
 		$this->addKnop(new DataTableKnop(Multiplicity::None(), '/fiscaat/pin/heroverweeg', 'Heroverweeg', 'Controleer op veranderingen in andere systemen', 'cart_go'));
 
 		$this->addColumn('moment');
@@ -38,5 +38,10 @@ class PinTransactieMatchTable extends DataTable {
 		$this->hideColumn('bestelling_id');
 
 		$this->setOrder(['moment' => 'desc']);
+
+		$this->searchColumn('status');
+		$this->searchColumn('moment');
+		$this->searchColumn('transactie');
+		$this->searchColumn('bestelling');
 	}
 }

--- a/lib/view/fiscaat/pin/PinTransactieMatchTable.php
+++ b/lib/view/fiscaat/pin/PinTransactieMatchTable.php
@@ -28,6 +28,7 @@ class PinTransactieMatchTable extends DataTable {
 		$this->addKnop(new DataTableKnop(Multiplicity::Two(), '/fiscaat/pin/koppel', 'Koppel', 'Koppel een bestelling en transactie', 'arrow_join'));
 		$this->addKnop(new DataTableKnop(Multiplicity::One(), '/fiscaat/pin/info', 'Info', 'Bekijk informatie over de gekoppelde bestelling', 'magnifier'));
 		$this->addKnop(new DataTableKnop(Multiplicity::Any(), '/fiscaat/pin/verwijderen', 'Verwijder', 'Verwijder matches', 'delete'));
+		$this->addKnop(new DataTableKnop(Multiplicity::None(), '/fiscaat/pin/heroverweeg', 'Heroverweeg', 'Controleer op veranderingen in andere systemen', 'cart_go'));
 
 		$this->addColumn('moment');
 		$this->addColumn('transactie');

--- a/lib/view/fiscaat/pin/PinTransactieMatchTable.php
+++ b/lib/view/fiscaat/pin/PinTransactieMatchTable.php
@@ -27,6 +27,7 @@ class PinTransactieMatchTable extends DataTable {
 		$this->addKnop(new ConfirmDataTableKnop(Multiplicity::One(), '/fiscaat/pin/ontkoppel', 'Ontkoppel', 'Ontkoppel bestelling en transactie', 'arrow_divide'));
 		$this->addKnop(new DataTableKnop(Multiplicity::Two(), '/fiscaat/pin/koppel', 'Koppel', 'Koppel een bestelling en transactie', 'arrow_join'));
 		$this->addKnop(new DataTableKnop(Multiplicity::One(), '/fiscaat/pin/info', 'Info', 'Bekijk informatie over de gekoppelde bestelling', 'magnifier'));
+		$this->addKnop(new DataTableKnop(Multiplicity::Any(), '/fiscaat/pin/verwijderen', 'Verwijder', 'Verwijder matches', 'delete'));
 
 		$this->addColumn('moment');
 		$this->addColumn('transactie');


### PR DESCRIPTION
Twee toevoegingen aan dit systeem.
 - Soms wordt vanuit het socciesysteem een probleem opgelost, het pintransactiecontrole systeem staat hier los van, dit kan problemen veroorzaken. Er is nu een knop om dit systeem te verversen.
 - Soms wordt de pinautomaat gebruikt voor andere doeleinden dan de SocCie, hier moet de mogelijkheid zijn om te zeggen dat een pintransactie niet gekoppeld is aan een bestelling.