### PR TITLE
Achtergrond van dropdown menu op extern subforum blauwig maken

### DIFF
--- a/resources/assets/sass/extern.scss
+++ b/resources/assets/sass/extern.scss
@@ -300,3 +300,7 @@ hr {
 .white-background {
 	background: white;
 }
+
+optgroup {
+	background-color: #414262;
+}


### PR DESCRIPTION
Veranderd witte achtergrond waardoor tekst onleesbaar was naar een blauwige achtergrond op een dropdown menu van het externe subforum.

Zo ziet het er nu uit:
![fixed extern](https://user-images.githubusercontent.com/24373899/48497492-7ee9e000-e834-11e8-958c-944cc3071ecb.png)

closes #443 