### PR TITLE
Manifest assets

### DIFF
--- a/bin/ci/.gitignore.prod
+++ b/bin/ci/.gitignore.prod
@@ -14,6 +14,7 @@ etc/*.csr
 etc/*.htpasswd
 etc/*.kdbx
 lib/defines.include.php
+htdocs/dist/manifest.json
 
 # installatie
 vendor/*

--- a/bin/ci/.gitignore.prod
+++ b/bin/ci/.gitignore.prod
@@ -14,7 +14,6 @@ etc/*.csr
 etc/*.htpasswd
 etc/*.kdbx
 lib/defines.include.php
-htdocs/dist/manifest.json
 
 # installatie
 vendor/*

--- a/lib/common/common.view.functions.php
+++ b/lib/common/common.view.functions.php
@@ -18,6 +18,7 @@ function view(string $template, array $variables) {
 	return new TemplateView($template, $variables);
 }
 
+$manifest = null;
 /**
  * Genereer een unieke url voor een asset.
  *
@@ -25,7 +26,14 @@ function view(string $template, array $variables) {
  * @return string
  */
 function asset(string $asset) {
-	if (file_exists(HTDOCS_PATH . $asset)) {
+	global $manifest;
+	if ($manifest == null) {
+		$manifest = json_decode(file_get_contents(HTDOCS_PATH . 'dist/manifest.json'), true);
+	}
+
+	if (isset($manifest[$asset])) {
+		return CSR_ROOT . $manifest[$asset];
+	} elseif (file_exists(HTDOCS_PATH . $asset)) {
 		return CSR_ROOT . $asset . "?" . filemtime(HTDOCS_PATH . $asset);
 	} else {
 		return '';

--- a/lib/common/common.view.functions.php
+++ b/lib/common/common.view.functions.php
@@ -18,7 +18,6 @@ function view(string $template, array $variables) {
 	return new TemplateView($template, $variables);
 }
 
-$manifest = null;
 /**
  * Genereer een unieke url voor een asset.
  *
@@ -26,10 +25,7 @@ $manifest = null;
  * @return string
  */
 function asset(string $asset) {
-	global $manifest;
-	if ($manifest == null) {
-		$manifest = json_decode(file_get_contents(HTDOCS_PATH . 'dist/manifest.json'), true);
-	}
+	$manifest = json_decode(file_get_contents(HTDOCS_PATH . 'dist/manifest.json'), true);
 
 	if (isset($manifest[$asset])) {
 		return CSR_ROOT . $manifest[$asset];

--- a/lib/templates/html_head.tpl
+++ b/lib/templates/html_head.tpl
@@ -19,10 +19,10 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="alternate" title="C.S.R. Delft RSS" type="application/rss+xml" href="{$smarty.const.CSR_ROOT}/forum/rss.xml" />
 {foreach from=$stylesheets item=sheet}
-<link rel="stylesheet" href="{$sheet}" type="text/css" />
+<link rel="stylesheet" href="{asset($sheet)}" type="text/css" />
 {/foreach}
 {foreach from=$scripts item=script}
-<script type="text/javascript" src="{$script}"></script>
+<script type="text/javascript" src="{asset($script)}"></script>
 {/foreach}
 <!-- Google Analytics -->
 {literal}

--- a/lib/templates/layout/fx-trein.tpl
+++ b/lib/templates/layout/fx-trein.tpl
@@ -1,3 +1,3 @@
-<script type="text/javascript" src="{asset("/dist/js/fxtrein.js")}"></script>
-<link rel="stylesheet" href="{asset("/dist/css/effect-trein.css")}"/>
+<script type="text/javascript" src="{asset("fxtrein.js")}"></script>
+<link rel="stylesheet" href="{asset("fxtrein.css")}"/>
 <div class="rails"></div>

--- a/lib/view/CompressedLayout.abstract.php
+++ b/lib/view/CompressedLayout.abstract.php
@@ -22,7 +22,7 @@ abstract class CompressedLayout extends HtmlPage {
 		parent::__construct($body, $titel);
 
 		foreach (static::getUserModules() as $module) {
-		    parent::addStylesheet('/dist/css/' . $module . '.css');
+		    parent::addStylesheet($module . '.css');
 		}
 	}
 

--- a/lib/view/CsrLayoutPage.class.php
+++ b/lib/view/CsrLayoutPage.class.php
@@ -37,7 +37,7 @@ class CsrLayoutPage extends CompressedLayout {
 		parent::__construct($body, $body->getTitel());
 		$this->zijbalk = $zijbalk;
 		$this->modal = $modal;
-		$this->addScript('/dist/js/app.js');
+		$this->addScript('app.js');
 	}
 
 	public function getBreadcrumbs() {

--- a/lib/view/renderer/BladeRenderer.php
+++ b/lib/view/renderer/BladeRenderer.php
@@ -43,9 +43,16 @@ class BladeRenderer implements Renderer {
 				$asset = trim($expr, "()");
 				return '<link rel="stylesheet" href="' . asset($asset) . '" type="text/css"/>';
 			});
+			$this->bladeOne->directive('script', function ($expr) {
+				$asset = trim($expr, "()");
+				return '<script type="text/javascript" src="' . asset($asset) . '"></script>';
+			});
 		} else {
 			$this->bladeOne->directive('stylesheet', function ($expr) {
 				return '<link rel="stylesheet" href="<?php echo asset' . $expr . '; ?>" type="text/css"/>';
+			});
+			$this->bladeOne->directive('script', function ($expr) {
+				return '<script type="text/javascript" src="<?php echo asset' . $expr . '?>"></script>';
 			});
 		}
 

--- a/lib/view/renderer/BladeRenderer.php
+++ b/lib/view/renderer/BladeRenderer.php
@@ -36,12 +36,12 @@ class BladeRenderer implements Renderer {
 			$this->bladeOne->authCallBack = [LoginModel::class, 'mag'];
 		}
 
+		// In mode fast (productie) wordt de stylesheet in de html gehangen,
+		// in andere modi wordt een aanroep naar asset gedaan.
 		if ($this->bladeOne->getMode() === BladeOne::MODE_FAST) {
 			$this->bladeOne->directive('stylesheet', function ($expr) {
-				$options = trim($expr, "()");
-				$filename = asset($options);
-
-				return '<link rel="stylesheet" href="' . $filename . '" type="text/css"/>';
+				$asset = trim($expr, "()");
+				return '<link rel="stylesheet" href="' . asset($asset) . '" type="text/css"/>';
 			});
 		} else {
 			$this->bladeOne->directive('stylesheet', function ($expr) {

--- a/lib/view/renderer/BladeRenderer.php
+++ b/lib/view/renderer/BladeRenderer.php
@@ -36,6 +36,19 @@ class BladeRenderer implements Renderer {
 			$this->bladeOne->authCallBack = [LoginModel::class, 'mag'];
 		}
 
+		if ($this->bladeOne->getMode() === BladeOne::MODE_FAST) {
+			$this->bladeOne->directive('stylesheet', function ($expr) {
+				$options = trim($expr, "()");
+				$filename = asset($options);
+
+				return '<link rel="stylesheet" href="' . $filename . '" type="text/css"/>';
+			});
+		} else {
+			$this->bladeOne->directive('stylesheet', function ($expr) {
+				return '<link rel="stylesheet" href="<?php echo asset' . $expr . '; ?>" type="text/css"/>';
+			});
+		}
+
 		$this->bladeOne->directive('icon', function ($expr) {
 			$options = trim($expr, "()");
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
 		"vue-loader": "^15.4.1",
 		"vue-template-compiler": "^2.5.17",
 		"webpack": "^4.16.5",
-		"webpack-cli": "^3.1.0"
+		"webpack-cli": "^3.1.0",
+		"webpack-manifest-plugin": "^2.0.4"
 	},
 	"dependencies": {
 		"autosize": "^1.18.13",

--- a/resources/views/documenten/base.blade.php
+++ b/resources/views/documenten/base.blade.php
@@ -1,9 +1,5 @@
 @extends('layout')
 
-@push('styles')
-	<link rel="stylesheet" href="{{asset("/dist/css/module-documenten.css")}}"/>
-@endpush
-
 @section('breadcrumbs')
 	<a href="/documenten" title="Documenten"><span class="fa fa-file-text module-icon"></span></a>
 @endsection

--- a/resources/views/effect/trein.blade.php
+++ b/resources/views/effect/trein.blade.php
@@ -1,3 +1,3 @@
-<script type="text/javascript" src="{{asset("/dist/js/fxtrein.js")}}"></script>
-<link rel="stylesheet" href="{{asset("/dist/css/effect-trein.css")}}"/>
+<script type="text/javascript" src="{{asset("fxtrein.js")}}"></script>
+@stylesheet('fxtrein.css')
 <div class="rails"></div>

--- a/resources/views/forum/base.blade.php
+++ b/resources/views/forum/base.blade.php
@@ -1,16 +1,12 @@
 @auth
 	@extends('layout')
-
-	@push('styles')
-		<link rel="stylesheet" href="{{asset("/dist/css/module-forum.css")}}"/>
-	@endpush
 @endauth
 @guest
 	@extends('layout-owee.layout')
 
 	@section('styles')
-		<link rel="stylesheet" href="{{asset("/dist/css/extern.css")}}" type="text/css"/>
-		<link rel="stylesheet" href="{{asset("/dist/css/extern-forum.css")}}" type="text/css"/>
+		@stylesheet('extern.css')
+		@stylesheet('extern-forum.css')
 	@endsection
 @endguest
 

--- a/resources/views/head.blade.php
+++ b/resources/views/head.blade.php
@@ -22,7 +22,7 @@
 <link rel="stylesheet" href="{{asset("$sheet.css")}}" type="text/css" />
 @endforeach
 @stack('styles')
-<script type="text/javascript" src="/dist/js/app.js"></script>
+@script('app.js')
 @stack('scripts')
 <!-- Google Analytics -->
 <script>

--- a/resources/views/head.blade.php
+++ b/resources/views/head.blade.php
@@ -19,7 +19,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="alternate" title="C.S.R. Delft RSS" type="application/rss+xml" href="{{CSR_ROOT}}/forum/rss.xml" />
 @foreach(\CsrDelft\view\CompressedLayout::getUserModules() as $sheet)
-<link rel="stylesheet" href="{{asset("/dist/css/$sheet.css")}}" type="text/css" />
+<link rel="stylesheet" href="{{asset("$sheet.css")}}" type="text/css" />
 @endforeach
 @stack('styles')
 <script type="text/javascript" src="/dist/js/app.js"></script>

--- a/resources/views/layout-owee/content.blade.php
+++ b/resources/views/layout-owee/content.blade.php
@@ -3,7 +3,7 @@
 @section('titel', $titel)
 
 @section('styles')
-	<link rel="stylesheet" href="{{asset("/dist/css/extern.css")}}" type="text/css"/>
+	@stylesheet('extern.css')
 @endsection
 
 @section('content')

--- a/resources/views/layout-owee/fotoalbum.blade.php
+++ b/resources/views/layout-owee/fotoalbum.blade.php
@@ -3,8 +3,8 @@
 @section('titel', $titel)
 
 @section('styles')
-	<link rel="stylesheet" href="{{asset("/dist/css/extern.css")}}" type="text/css"/>
-	<link rel="stylesheet" href="{{asset("/dist/css/extern-fotoalbum.css")}}" type="text/css"/>
+	@stylesheet('extern.css')
+	@stylesheet('extern-fotoalbum.css')
 @endsection
 
 @section('content')

--- a/resources/views/layout-owee/index.blade.php
+++ b/resources/views/layout-owee/index.blade.php
@@ -3,7 +3,7 @@
 @section('titel', $titel)
 
 @section('styles')
-	<link rel="stylesheet" href="{{asset("/dist/css/extern.css")}}" type="text/css"/>
+	@stylesheet('extern.css')
 @endsection
 
 @section('body')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const ManifestPlugin = require('webpack-manifest-plugin');
 const { VueLoaderPlugin } = require('vue-loader');
 const path = require('path');
 const glob = require('glob');
@@ -47,8 +48,8 @@ module.exports = {
 		// De map waarin alle bestanden geplaatst worden.
 		path: path.resolve(__dirname, 'htdocs/dist'),
 		// Alle javascript bestanden worden in de map js geplaatst.
-		filename: 'js/[name].js',
-		chunkFilename: 'js/[id].js',
+		filename: 'js/[name].[chunkhash].js',
+		chunkFilename: 'js/[id].[chunkhash].js',
 		publicPath: '/dist/',
 	},
 	devtool: 'source-map',
@@ -68,9 +69,10 @@ module.exports = {
 	plugins: [
 		new MiniCssExtractPlugin({
 			// Css bestanden komen in de map css terecht.
-			filename: 'css/[name].css'
+			filename: 'css/[name].[chunkhash].css'
 		}),
 		new VueLoaderPlugin(),
+		new ManifestPlugin(),
 	],
 	module: {
 		// Regels voor bestanden die webpack tegenkomt, als `test` matcht wordt de rule uitgevoerd.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,6 +2540,14 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -2662,7 +2670,7 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
 
@@ -3273,6 +3281,12 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -3497,7 +3511,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -5682,6 +5696,10 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+
 unquote@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
@@ -5836,6 +5854,14 @@ webpack-cli@^3.1.0:
     supports-color "^5.5.0"
     v8-compile-cache "^2.0.2"
     yargs "^12.0.2"
+
+webpack-manifest-plugin@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz#e4ca2999b09557716b8ba4475fb79fab5986f0cd"
+  dependencies:
+    fs-extra "^7.0.0"
+    lodash ">=3.5 <5"
+    tapable "^1.0.0"
 
 webpack-sources@^1.1.0, webpack-sources@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Webpack genereerd een manifest.json bestand, deze wordt gebruikt door blade om css en js bestanden te resolven.

Dit gebeurt tijdens development door `htdocs/dist/manifest.json` uit te lezen (een map van entry naar bestand).

Bij de build wordt dit bestand ook uitgelezen en wordt op plekken waar dat al mogelijk is de daadwerkelijke locatie van de asset in de html geplaatst. Als dat niet mogelijk is wordt tijdens runtime uit dit bestand de locatie gelezen.