### PR TITLE
Voeg update-prod composer script toe

### DIFF
--- a/bin/prod/onderhoud.sh
+++ b/bin/prod/onderhoud.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+lib_dir="${BASH_SOURCE%/*}/../../lib"
+grep -P "define\\((['\"])ONDERHOUD\1, ?(true|false)\\);" ${lib_dir}/defines.include.php > /dev/null
+in_bestand=$?
+if [[ -z "$1" ]] || [[ $1 = true ]]; then
+	echo "Stek in onderhoudsmodus aan het zetten"
+	if [[ $in_bestand -eq 0 ]]; then # ONDERHOUD define staat al in defines.include.php
+		sed -ri "s/define\\((['\"])ONDERHOUD\1, ?(true|false)\\);/define(\1ONDERHOUD\1, true);/" ${lib_dir}/defines.include.php
+	else # ONDERHOUD define staat nog niet in defines.include.php
+		echo -e "\ndefine('ONDERHOUD', true);" >> ${lib_dir}/defines.include.php
+	fi
+	echo "Stek in onderhoudsmodus gezet"
+else
+	echo "Stek uit onderhoudsmodus aan het halen"
+	if [[ $in_bestand -eq 0 ]]; then # ONDERHOUD define staat al in defines.include.php
+		sed -ri "s/define\\((['\"])ONDERHOUD\1, ?(true|false)\\);/define(\1ONDERHOUD\1, false);/" ${lib_dir}/defines.include.php
+	else # ONDERHOUD define staat nog niet in defines.include.php
+		echo -e "\ndefine('ONDERHOUD', false);" >> ${lib_dir}/defines.include.php
+	fi
+	echo "Stek uit onderhoudsmodus gehaald"
+fi

--- a/composer.json
+++ b/composer.json
@@ -40,11 +40,19 @@
 		"phpunit/phpunit": "^6.5"
 	},
 	"scripts": {
-		"migrate": "vendor/bin/phinx migrate",
-		"generator": "php ./bin/dev/generate.php",
-		"production": "php ./bin/ci/compile.php",
-		"flushcache": "php ./bin/flushcache.php",
+		"migrate": "@php vendor/bin/phinx migrate",
+		"generator": "@php bin/dev/generate.php",
+		"production": "@php bin/ci/compile.php",
+		"flushcache": "@php bin/flushcache.php",
 		"analyse": "vendor/bin/phpstan --memory-limit=1000M analyse -l 4 -c phpstan.neon lib htdocs",
-		"test": "./vendor/bin/phpunit --bootstrap phpunit.init.php tests"
+		"test": "vendor/bin/phpunit --bootstrap phpunit.init.php tests",
+		"update-prod": [
+			"bin/prod/onderhoud.sh true",
+			"git pull",
+			"@composer install --no-dev",
+			"@migrate",
+			"@flushcache",
+			"bin/prod/onderhoud.sh false"
+		]
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -40,19 +40,20 @@
 		"phpunit/phpunit": "^6.5"
 	},
 	"scripts": {
-		"migrate": "@php vendor/bin/phinx migrate",
+		"migrate": "vendor/bin/phinx migrate",
 		"generator": "@php bin/dev/generate.php",
 		"production": "@php bin/ci/compile.php",
 		"flushcache": "@php bin/flushcache.php",
+		"onderhoud": "bin/prod/onderhoud.sh",
 		"analyse": "vendor/bin/phpstan --memory-limit=1000M analyse -l 4 -c phpstan.neon lib htdocs",
 		"test": "vendor/bin/phpunit --bootstrap phpunit.init.php tests",
 		"update-prod": [
-			"bin/prod/onderhoud.sh true",
+			"@onderhoud true",
 			"git pull",
 			"@composer install --no-dev",
 			"@migrate",
 			"@flushcache",
-			"bin/prod/onderhoud.sh false"
+			"@onderhoud false"
 		]
 	}
 }

--- a/lib/configuratie.include.php
+++ b/lib/configuratie.include.php
@@ -10,9 +10,11 @@
  * Configure sessions.
  * Boot framework.
  */
-// Uncomment de volgende twee regels om de boel in onderhoudsmode te ketzen:
-//header('location: https://csrdelft.nl/onderhoud.html');
-//exit;
+require_once 'defines.defaults.php';
+if (ONDERHOUD) {
+	header('location: https://csrdelft.nl/onderhoud.html');
+	exit;
+}
 
 use CsrDelft\common\Ini;
 use CsrDelft\common\ShutdownHandler;
@@ -25,7 +27,6 @@ use CsrDelft\model\security\AccountModel;
 use CsrDelft\model\security\LoginModel;
 
 require __DIR__ . '/../vendor/autoload.php';
-require_once 'defines.defaults.php';
 require_once 'common/common.functions.php';
 require_once 'common/common.view.functions.php';
 require_once 'autoload.php';

--- a/lib/defines.defaults.php
+++ b/lib/defines.defaults.php
@@ -23,6 +23,9 @@ if (!defined('DB_DROP')) define('DB_DROP', false); # heb je een backup gemaakt?
 # debug modus
 if (!defined('DEBUG')) define('DEBUG', false);
 #
+# onderhoud modus
+if (!defined('ONDERHOUD')) define('ONDERHOUD', false);
+#
 # measure time
 if (!defined('TIME_MEASURE')) define('TIME_MEASURE', false);
 #


### PR DESCRIPTION
Maakt het mogelijk om met `composer run-script update-prod` de productie gestroomlijnd te updaten.
Het vervangt de handelingen:
- stek in onderhoudsmodus zetten
- git pull
- composer install
- phinx migrate
- flush orm memcache
- stek uit onderhoudsmodus halen