### PR TITLE
Autocompleet lid/citaat in BB-code

### DIFF
--- a/htdocs/tools/naamsuggesties.php
+++ b/htdocs/tools/naamsuggesties.php
@@ -32,6 +32,12 @@ if (isset($_GET['limit'])) {
 	$limiet = (int) $_GET['limit'];
 }
 
+$toegestaneNaamVormen = ['user', 'volledig', 'streeplijst', 'voorletters', 'bijnaam', 'Duckstad', 'civitas', 'aaidrom'];
+$vorm = 'volledig';
+if (isset($_GET['vorm']) && in_array($_GET['vorm'], $toegestaneNaamVormen)) {
+	$vorm = $_GET['vorm'];
+}
+
 $profielen = ProfielService::instance()->zoekLeden($query, 'naam', 'alle', 'achternaam', $zoekin, $limiet);
 
 $result = array();
@@ -42,7 +48,7 @@ foreach ($profielen as $profiel) {
 	$result[] = array(
 		'url'	 => '/profiel/' . $profiel->uid,
 		'label'	 => $profiel->uid,
-		'value'	 => $profiel->getNaam('volledig')
+		'value'	 => $profiel->getNaam($vorm)
 	);
 }
 /*

--- a/htdocs/tools/naamsuggesties.php
+++ b/htdocs/tools/naamsuggesties.php
@@ -23,6 +23,10 @@ $toegestanezoekfilters = array('leden', 'oudleden', 'novieten', 'alleleden', 'al
 if (isset($_GET['zoekin']) AND in_array($_GET['zoekin'], $toegestanezoekfilters)) {
 	$zoekin = $_GET['zoekin'];
 }
+if (isset($_GET['zoekin']) && $_GET['zoekin'] === 'voorkeur') {
+	$zoekin = \CsrDelft\model\LidInstellingenModel::get('forum', 'lidSuggesties');
+}
+
 $query = '';
 if (isset($_GET['q'])) {
 	$query = $_GET['q'];

--- a/lib/model/LidInstellingenModel.class.php
+++ b/lib/model/LidInstellingenModel.class.php
@@ -159,6 +159,16 @@ class LidInstellingenModel extends InstellingenModel {
 				'civitas',
 				'Weergave van namen in het forum.'
 			],
+			'lidSuggesties' => [
+				'Lidsuggesties',
+				T::Enumeration,
+				[
+					'leden' => 'Novieten & leden',
+					'alleleden' => 'Iedereen'
+				],
+				'leden',
+				'Of ook oud- en ereleden als suggestie worden getoond op het forum.'
+			],
 			'datumWeergave' => [
 				'Datumweergave',
 				T::Enumeration,

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"parallax-js": "^3.1.0",
 		"popper.js": "^1.12",
 		"raty-js": "^2.8.0",
+		"textcomplete": "^0.17.1",
 		"three": "^0.99.0",
 		"timeago": "^1.6.3",
 		"uglifyjs-webpack-plugin": "^2.1.1",

--- a/resources/assets/js/bbcode-hints.ts
+++ b/resources/assets/js/bbcode-hints.ts
@@ -28,17 +28,13 @@ export function activeerLidHints(textarea: HTMLElement) {
             textcomplete.dropdown.items[0].activate();
         }
     });
-
-    textcomplete.on('selected', function () {
-        console.log('heuj');
-    });
 }
 
 function search(term: string, callback: Function) {
     if (!term || term.length === 1) {
         callback([]);
     } else {
-        $.ajax('/tools/naamsuggesties.php?vorm=user&q=' + encodeURI(term))
+        $.ajax('/tools/naamsuggesties.php?vorm=user&zoekin=voorkeur&q=' + encodeURI(term))
             .done(function (data) {
                 callback(data);
             })

--- a/resources/assets/js/bbcode-hints.ts
+++ b/resources/assets/js/bbcode-hints.ts
@@ -1,0 +1,53 @@
+let { Textcomplete, Textarea } = require('textcomplete');
+
+export function activeerLidHints(textarea: HTMLElement) {
+    let editor = new Textarea(textarea);
+    let textcomplete = new Textcomplete(editor);
+
+    textcomplete.register([{
+        // @...
+        search: search,
+        template: template,
+        match: /(^|\s|])@((?:[^ ]+ ?){1,5})$/,
+        replace: function (data: any) {
+            return '$1[lid=' + data.label + ']';
+        }
+    }, {
+        // [citaat=... of [lid=...
+        search: search,
+        template: template,
+        match: /(^|\s|])\[(citaat|lid)=(?:[0-9]{4}|([^\]]+))$/,
+        index: 3,
+        replace: function (data: any) {
+            return '$1[$2=' + data.label;
+        }
+    }]);
+    textcomplete.on('rendered', function () {
+        if (textcomplete.dropdown.items.length >= 1) {
+            // Activeer eerste keuze standaard
+            textcomplete.dropdown.items[0].activate();
+        }
+    });
+
+    textcomplete.on('selected', function () {
+        console.log('heuj');
+    });
+}
+
+function search(term: string, callback: Function) {
+    if (!term || term.length === 1) {
+        callback([]);
+    } else {
+        $.ajax('/tools/naamsuggesties.php?vorm=user&q=' + encodeURI(term))
+            .done(function (data) {
+                callback(data);
+            })
+            .fail(function() {
+                callback([]);
+            });
+    }
+}
+
+function template(data: any, term: string) {
+    return data.value;
+}

--- a/resources/assets/js/context.js
+++ b/resources/assets/js/context.js
@@ -8,6 +8,7 @@ import {bbCodeSet} from './bbcode-set';
 import {fnAjaxUpdateCallback, fnGetLastUpdate} from './datatable/datatable';
 import render from './datatable/render';
 import {initSaldoGrafiek, initDeelnamegrafiek} from './grafiek';
+import {activeerLidHints} from './bbcode-hints';
 
 function initButtons(parent) {
     $(parent).find('.spoiler').bind('click.spoiler', function (event) {
@@ -61,6 +62,12 @@ function initTimeago(parent) {
 
 function initMarkitup(parent) {
     $(parent).find('textarea.BBCodeField').markItUp(bbCodeSet);
+}
+
+function initLidHints(parent) {
+    let textarea = $(parent).find('textarea.BBCodeField').get(0);
+    if (textarea === undefined) return;
+    activeerLidHints(textarea);
 }
 
 function initTooltips(parent) {
@@ -143,6 +150,7 @@ export default function initContext(parent) {
     initForms(parent);
     initTimeago(parent);
     initMarkitup(parent);
+    initLidHints(parent);
     initTooltips(parent);
     initHoverIntents(parent);
     initLazyImages(parent);

--- a/resources/assets/js/forum.js
+++ b/resources/assets/js/forum.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import {CsrBBPreview} from './bbcode';
 import {domUpdate} from './context';
 import {bbCodeSet} from './bbcode-set';
+import {activeerLidHints} from './bbcode-hints';
 
 function toggleForumConceptBtn(enable) {
 	let $concept = $('#forumConcept');
@@ -92,6 +93,7 @@ export function forumBewerken(postId) {
 		$forumBewerkBericht.val(data);
 		$forumBewerkBericht.autosize();
 		$forumBewerkBericht.markItUp(bbCodeSet);
+		activeerLidHints($forumBewerkBericht.get(0));
 		$(bewerkContainer).parent().children('td.auteur:first').append('<div id="bewerk-melding" class="alert alert-warning">Als u dingen aanpast zet er dan even bij w&aacute;t u aanpast! Gebruik bijvoorbeeld [s]...[/s]</div>');
 		$('#bewerk-melding').slideDown(200);
 		$('#forumPosten').css('visibility', 'hidden');

--- a/resources/assets/sass/module/_forum.scss
+++ b/resources/assets/sass/module/_forum.scss
@@ -339,6 +339,11 @@ span.curpage {
 	height: 100%;
 }
 
+// Suggesties
+.textcomplete-item.active {
+	background: #e9ecef;
+}
+
 @media screen and (max-width: 576px) { // sm
 	.forum-header, .forum-footer {
 		h1 {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2349,6 +2349,11 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+eventemitter3@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+  integrity sha1-teEHm1n7XhuidxwKmTvgYKWMmbo=
+
 events@^1.0.0:
   version "1.1.1"
   resolved "http://registry.npmjs.org/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -5576,6 +5581,20 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
+textarea-caret@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/textarea-caret/-/textarea-caret-3.1.0.tgz#5d5a35bb035fd06b2ff0e25d5359e97f2655087f"
+  integrity sha512-cXAvzO9pP5CGa6NKx0WYHl+8CHKZs8byMkt3PCJBCmq2a34YA9pO1NrQET5pzeqnBjBdToF5No4rrmkDUgQC2Q==
+
+textcomplete@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/textcomplete/-/textcomplete-0.17.1.tgz#7f72626a6783c29e62297740f21d762c665fbd49"
+  integrity sha512-vxHXk8h/pPh5GW5L872H7Ui/uxhoLn5fh9FNYrOW9sNpRVuLs53QiTTLDwfEjK6lOuUb7AA26DsRPhwBl1QFiA==
+  dependencies:
+    eventemitter3 "^2.0.3"
+    textarea-caret "^3.0.1"
+    undate "^0.2.3"
+
 three@^0.99.0:
   version "0.99.0"
   resolved "https://registry.yarnpkg.com/three/-/three-0.99.0.tgz#65711fda7a16501da83948121437d824df1fea19"
@@ -5733,6 +5752,11 @@ uglifyjs-webpack-plugin@^2.1.1:
     uglify-js "^3.0.0"
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
+
+undate@^0.2.3:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/undate/-/undate-0.2.4.tgz#ccb2a8cf38edc035d1006fcb2909c4c6024a8400"
+  integrity sha512-k1WTRVhI076HYqP6e3pZPzS7K2xNAcuhCcWOPjHmR8SwU3byyKYvyNZ4XTEAd7Ofe40+wrEjNq6WmmO8WoUVNg==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Geeft lidsuggesties tijdens het typen in BBCode-velden. Pakt volgende dingen op:

- [lid=...
- [citaat=... 
- @... _(wordt omgezet naar [lid=...])_

Bij een tab, enter of klik plaatst hij het lidnummer van het geselecteerde lid in de bewerker.

Ik heb de naamsuggesties die door typeahead gebruikt worden hergebruikt. Hierbij heb ik de vorm als parameter toegevoegd, zodat leden op het forum hun eigen voorkeursvorm te zien krijgen.

Voorbeelden:
![image](https://user-images.githubusercontent.com/8656358/51388157-dd7b5500-1b28-11e9-9e12-75953355141d.png)
![image](https://user-images.githubusercontent.com/8656358/51388170-e4a26300-1b28-11e9-9961-ec9a336e79e6.png)
![image](https://user-images.githubusercontent.com/8656358/51388186-ecfa9e00-1b28-11e9-8a40-3f78d98f1162.png)
