### PR TITLE
Schakel veegacties uit in fotoablum

### DIFF
--- a/resources/assets/js/main-menu.ts
+++ b/resources/assets/js/main-menu.ts
@@ -160,7 +160,11 @@ $(() => {
 
 	const hammertime = new Hammer(document, {inputClass: Hammer.TouchInput});
 
-	hammertime.on('swiperight', () => {
+	hammertime.on('swiperight', (e) => {
+		if ($(e.target).closest('.disable-swipe').length > 0) {
+			return;
+		}
+
 		if (isVisible('#zijbalk') || isVisible('#menu')) {
 			reset();
 		} else {
@@ -168,7 +172,11 @@ $(() => {
 		}
 	});
 
-	hammertime.on('swipeleft', () => {
+	hammertime.on('swipeleft', (e) => {
+		if ($(e.target).closest('.disable-swipe').length > 0) {
+			return;
+		}
+
 		if (isVisible('#zijbalk') || isVisible('#menu')) {
 			reset();
 		} else {

--- a/resources/views/fotoalbum/album.blade.php
+++ b/resources/views/fotoalbum/album.blade.php
@@ -52,7 +52,7 @@
 		</div>
 		<h1 class="inline">{{ucfirst($album->dirname)}}</h1>
 		@if($album->hasFotos())
-			<div id="gallery" class="gallery">
+			<div id="gallery" class="gallery disable-swipe">
 			</div>
 		@else
 			<div class="subalbums">


### PR DESCRIPTION
Controleert of plek waar geveegd wordt een (kind van) een blok met de class `disable-swipe` is. Dit heb ik toegepast op de gallerij, waardoor nu vrijelijk geveegd zou moeten kunnen worden door de foto's.

Het lukte mij niet om het fotoalbum lokaal draaiend te krijgen, dus ik heb het met specifiek de gallerij kunnen testen. Wel met andere blokken.