### PR TITLE
Lijn resultaat van de peiling links uit i.p.v. rechts

### DIFF
--- a/resources/assets/js/components/common/ProgressBar.vue
+++ b/resources/assets/js/components/common/ProgressBar.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :class="{'progress': true, 'flex-row-reverse': reverse}">
+	<div class="progress">
 		<div class="progress-bar" :style="{width: progress + '%'}">
 			<slot/>
 		</div>
@@ -16,13 +16,6 @@
 			type: [Number, String],
 		})
 		private progress: number | string; // Liever een nummer, maar een string kunnen we ook mee overweg.
-
-		@Prop({
-			default: () => false,
-			required: false,
-			type: Boolean,
-		})
-		private reverse: boolean;
 	}
 </script>
 

--- a/resources/assets/js/components/peilingen/PeilingOptie.vue
+++ b/resources/assets/js/components/peilingen/PeilingOptie.vue
@@ -3,7 +3,7 @@
 			 class="row">
 		<div class="col-md-4">{{titel}}</div>
 		<div class="col-md-6">
-			<ProgressBar :progress="progress" :reverse="true"></ProgressBar>
+			<ProgressBar :progress="progress"></ProgressBar>
 		</div>
 		<div class="col-md-2">{{progressText}}</div>
 		<div ref="beschrijving_gestemd" class="col text-muted pt-2" v-html="beschrijving"></div>


### PR DESCRIPTION
Lost verwarring bij peilingresultaten op

![image](https://user-images.githubusercontent.com/8656358/53561335-e52e1080-3b4e-11e9-8919-174e3b7fca91.png)
