### PR TITLE
Fix scripts in models

### DIFF
--- a/resources/assets/js/util.ts
+++ b/resources/assets/js/util.ts
@@ -155,7 +155,7 @@ export function html(strings: TemplateStringsArray, ...values: string[]): HTMLEl
 }
 
 export function htmlParse(htmlString: string) {
-	return new DOMParser().parseFromString(htmlString, 'text/html').body.children;
+	return jQuery.parseHTML(htmlString, null, true);
 }
 
 export function preloadImage(url: string, callback: () => void) {


### PR DESCRIPTION
`parseFromString` [schakelt scripts uit](https://stackoverflow.com/questions/28112807/why-script-elements-created-through-domparser-do-not-execute). Nu vervangen door [jQuery-variant `parseHTML`](https://api.jquery.com/jquery.parsehtml/), die een optie heeft om scripts te behouden.

Fixes #514 