### PR TITLE
Implementeer beginnetje symfony router

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ trim_trailing_whitespace = true
 
 [*.yml]
 indent_style = space
+
+[*.yaml]
+indent_style = space

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,6 @@
 		"ext-dom": "*",
 		"symfony/routing": "^3.4",
 		"symfony/http-foundation": "^3.4",
-		"symfony/expression-language": "^3.4",
-		"symfony/framework-bundle": "^3.4",
 		"php-di/invoker": "^2.0"
 	},
 	"config": {

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,16 @@
 		"ext-hash": "*",
 		"ext-json": "*",
 		"ext-curl": "*",
-		"ext-dom": "*"
+		"ext-dom": "*",
+		"symfony/routing": "^3.4",
+		"symfony/http-foundation": "^3.4",
+		"symfony/expression-language": "^3.4",
+		"symfony/framework-bundle": "^3.4",
+		"php-di/invoker": "^2.0"
 	},
 	"config": {
 		"platform": {
-			"php": "7.0.27"
+			"php": "7.0.33"
 		}
 	},
 	"include-path": ["lib/"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "13341e9785327dd2c873689bde97112a",
+    "content-hash": "1f370f59dc65fb943a77257d11a71035",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -1846,132 +1846,6 @@
             "time": "2018-09-12T20:54:16+00:00"
         },
         {
-            "name": "symfony/cache",
-            "version": "v3.4.24",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/cache.git",
-                "reference": "669270dc501fe3c5addcc306962958334c19652c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/669270dc501fe3c5addcc306962958334c19652c",
-                "reference": "669270dc501fe3c5addcc306962958334c19652c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/cache": "~1.0",
-                "psr/log": "~1.0",
-                "psr/simple-cache": "^1.0",
-                "symfony/polyfill-apcu": "~1.1"
-            },
-            "conflict": {
-                "symfony/var-dumper": "<3.3"
-            },
-            "provide": {
-                "psr/cache-implementation": "1.0",
-                "psr/simple-cache-implementation": "1.0"
-            },
-            "require-dev": {
-                "cache/integration-tests": "dev-master",
-                "doctrine/cache": "~1.6",
-                "doctrine/dbal": "~2.4",
-                "predis/predis": "~1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Cache\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Cache component with PSR-6, PSR-16, and tags",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "caching",
-                "psr6"
-            ],
-            "time": "2019-04-01T07:08:40+00:00"
-        },
-        {
-            "name": "symfony/class-loader",
-            "version": "v3.4.24",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/class-loader.git",
-                "reference": "4459eef5298dedfb69f771186a580062b8516497"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/4459eef5298dedfb69f771186a580062b8516497",
-                "reference": "4459eef5298dedfb69f771186a580062b8516497",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "require-dev": {
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/polyfill-apcu": "~1.1"
-            },
-            "suggest": {
-                "symfony/polyfill-apcu": "For using ApcClassLoader on HHVM"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\ClassLoader\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony ClassLoader Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-01-16T09:39:14+00:00"
-        },
-        {
             "name": "symfony/config",
             "version": "v3.4.24",
             "source": {
@@ -2164,190 +2038,6 @@
             "time": "2019-03-10T17:07:42+00:00"
         },
         {
-            "name": "symfony/dependency-injection",
-            "version": "v3.4.24",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "85172cca352fe0790fa6f485ad194862a8ac57ee"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/85172cca352fe0790fa6f485ad194862a8ac57ee",
-                "reference": "85172cca352fe0790fa6f485ad194862a8ac57ee",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/container": "^1.0"
-            },
-            "conflict": {
-                "symfony/config": "<3.3.7",
-                "symfony/finder": "<3.3",
-                "symfony/proxy-manager-bridge": "<3.4",
-                "symfony/yaml": "<3.4"
-            },
-            "provide": {
-                "psr/container-implementation": "1.0"
-            },
-            "require-dev": {
-                "symfony/config": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/yaml": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/config": "",
-                "symfony/expression-language": "For using expressions in service container configuration",
-                "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
-                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
-                "symfony/yaml": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\DependencyInjection\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony DependencyInjection Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-03-25T07:48:46+00:00"
-        },
-        {
-            "name": "symfony/event-dispatcher",
-            "version": "v3.4.24",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "a088aafcefb4eef2520a290ed82e4374092a6dff"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a088aafcefb4eef2520a290ed82e4374092a6dff",
-                "reference": "a088aafcefb4eef2520a290ed82e4374092a6dff",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<3.3"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony EventDispatcher Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-04-02T08:51:52+00:00"
-        },
-        {
-            "name": "symfony/expression-language",
-            "version": "v3.4.24",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/expression-language.git",
-                "reference": "74631d47774cfa59bfb4a0de18cdf700fb98d658"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/expression-language/zipball/74631d47774cfa59bfb4a0de18cdf700fb98d658",
-                "reference": "74631d47774cfa59bfb4a0de18cdf700fb98d658",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/cache": "~3.1|~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\ExpressionLanguage\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony ExpressionLanguage Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-01-16T12:52:19+00:00"
-        },
-        {
             "name": "symfony/filesystem",
             "version": "v3.4.24",
             "source": {
@@ -2396,169 +2086,6 @@
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
             "time": "2019-02-04T21:34:32+00:00"
-        },
-        {
-            "name": "symfony/finder",
-            "version": "v3.4.24",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "fcdde4aa38f48190ce70d782c166f23930084f9b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/fcdde4aa38f48190ce70d782c166f23930084f9b",
-                "reference": "fcdde4aa38f48190ce70d782c166f23930084f9b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Finder Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-02-22T14:44:53+00:00"
-        },
-        {
-            "name": "symfony/framework-bundle",
-            "version": "v3.4.24",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "5993c7947fd534fc1c366b96292ff61f99148bd6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/5993c7947fd534fc1c366b96292ff61f99148bd6",
-                "reference": "5993c7947fd534fc1c366b96292ff61f99148bd6",
-                "shasum": ""
-            },
-            "require": {
-                "ext-xml": "*",
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/cache": "~3.4|~4.0",
-                "symfony/class-loader": "~3.2",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/dependency-injection": "^3.4.24|^4.2.5",
-                "symfony/event-dispatcher": "~3.4|~4.0",
-                "symfony/filesystem": "~2.8|~3.0|~4.0",
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/http-foundation": "^3.4.24|^4.2.5",
-                "symfony/http-kernel": "~3.4|~4.0",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/routing": "^3.4.5|^4.0.5"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "<3.0",
-                "phpdocumentor/type-resolver": "<0.2.1",
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-                "symfony/asset": "<3.3",
-                "symfony/console": "<3.4",
-                "symfony/form": "<3.4",
-                "symfony/property-info": "<3.3",
-                "symfony/serializer": "<3.3",
-                "symfony/stopwatch": "<3.4",
-                "symfony/translation": "<3.4",
-                "symfony/validator": "<3.4",
-                "symfony/workflow": "<3.3"
-            },
-            "require-dev": {
-                "doctrine/annotations": "~1.0",
-                "doctrine/cache": "~1.0",
-                "fig/link-util": "^1.0",
-                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
-                "symfony/asset": "~3.3|~4.0",
-                "symfony/browser-kit": "~2.8|~3.0|~4.0",
-                "symfony/console": "~3.4|~4.0",
-                "symfony/css-selector": "~2.8|~3.0|~4.0",
-                "symfony/dom-crawler": "~2.8|~3.0|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/form": "^3.4.22|~4.1.11|^4.2.3",
-                "symfony/lock": "~3.4|~4.0",
-                "symfony/polyfill-intl-icu": "~1.0",
-                "symfony/process": "~2.8|~3.0|~4.0",
-                "symfony/property-info": "~3.3|~4.0",
-                "symfony/security-core": "~3.2|~4.0",
-                "symfony/security-csrf": "^2.8.31|^3.3.13|~4.0",
-                "symfony/serializer": "~3.3|~4.0",
-                "symfony/stopwatch": "~3.4|~4.0",
-                "symfony/templating": "~2.8|~3.0|~4.0",
-                "symfony/translation": "~3.4|~4.0",
-                "symfony/validator": "~3.4|~4.0",
-                "symfony/var-dumper": "~3.3|~4.0",
-                "symfony/web-link": "~3.3|~4.0",
-                "symfony/workflow": "~3.3|~4.0",
-                "symfony/yaml": "~3.2|~4.0",
-                "twig/twig": "~1.34|~2.4"
-            },
-            "suggest": {
-                "ext-apcu": "For best performance of the system caches",
-                "symfony/console": "For using the console commands",
-                "symfony/form": "For using forms",
-                "symfony/property-info": "For using the property_info service",
-                "symfony/serializer": "For using the serializer service",
-                "symfony/validator": "For using validation",
-                "symfony/web-link": "For using web links, features such as preloading, prefetching or prerendering",
-                "symfony/yaml": "For using the debug:config and lint:yaml commands"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Bundle\\FrameworkBundle\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony FrameworkBundle",
-            "homepage": "https://symfony.com",
-            "time": "2019-04-01T07:08:40+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -2613,151 +2140,6 @@
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
             "time": "2019-03-25T07:48:46+00:00"
-        },
-        {
-            "name": "symfony/http-kernel",
-            "version": "v3.4.24",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "30a9e48839413e6a6a8dc8989da0e7dd76c8fcf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/30a9e48839413e6a6a8dc8989da0e7dd76c8fcf8",
-                "reference": "30a9e48839413e6a6a8dc8989da0e7dd76c8fcf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/log": "~1.0",
-                "symfony/debug": "^3.3.3|~4.0",
-                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-                "symfony/http-foundation": "~3.4.12|~4.0.12|^4.1.1",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "conflict": {
-                "symfony/config": "<2.8",
-                "symfony/dependency-injection": "<3.4.10|<4.0.10,>=4",
-                "symfony/var-dumper": "<3.3",
-                "twig/twig": "<1.34|<2.4,>=2"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0"
-            },
-            "require-dev": {
-                "psr/cache": "~1.0",
-                "symfony/browser-kit": "~2.8|~3.0|~4.0",
-                "symfony/class-loader": "~2.8|~3.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/console": "~2.8|~3.0|~4.0",
-                "symfony/css-selector": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "^3.4.10|^4.0.10",
-                "symfony/dom-crawler": "~2.8|~3.0|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/process": "~2.8|~3.0|~4.0",
-                "symfony/routing": "~3.4|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0",
-                "symfony/templating": "~2.8|~3.0|~4.0",
-                "symfony/translation": "~2.8|~3.0|~4.0",
-                "symfony/var-dumper": "~3.3|~4.0"
-            },
-            "suggest": {
-                "symfony/browser-kit": "",
-                "symfony/config": "",
-                "symfony/console": "",
-                "symfony/dependency-injection": "",
-                "symfony/finder": "",
-                "symfony/var-dumper": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\HttpKernel\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony HttpKernel Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-04-02T13:47:51+00:00"
-        },
-        {
-            "name": "symfony/polyfill-apcu",
-            "version": "v1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-apcu.git",
-                "reference": "a502face1da6a53289480166f24de2c3c68e5c3c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/a502face1da6a53289480166f24de2c3c68e5c3c",
-                "reference": "a502face1da6a53289480166f24de2c3c68e5c3c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Apcu\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting apcu_* functions to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "apcu",
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5467,6 +4849,55 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
+            "name": "symfony/finder",
+            "version": "v3.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "fcdde4aa38f48190ce70d782c166f23930084f9b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/fcdde4aa38f48190ce70d782c166f23930084f9b",
+                "reference": "fcdde4aa38f48190ce70d782c166f23930084f9b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-02-22T14:44:53+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.1.2",
             "source": {
@@ -5579,6 +5010,6 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.0.27"
+        "php": "7.0.33"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,28 +1,29 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2e655a1ba2bca97523656c3b9bcf978",
+    "content-hash": "13341e9785327dd2c873689bde97112a",
     "packages": [
         {
             "name": "cakephp/cache",
-            "version": "3.7.2",
+            "version": "3.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/cache.git",
-                "reference": "173502b262b62612763297b9b3a73a5a88492425"
+                "reference": "238209c7f7242f5c670efc27b6f1e259da111dbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cache/zipball/173502b262b62612763297b9b3a73a5a88492425",
-                "reference": "173502b262b62612763297b9b3a73a5a88492425",
+                "url": "https://api.github.com/repos/cakephp/cache/zipball/238209c7f7242f5c670efc27b6f1e259da111dbc",
+                "reference": "238209c7f7242f5c670efc27b6f1e259da111dbc",
                 "shasum": ""
             },
             "require": {
                 "cakephp/core": "^3.6.0",
-                "php": ">=5.6.0"
+                "php": ">=5.6.0",
+                "psr/simple-cache": "^1.0.0"
             },
             "type": "library",
             "autoload": {
@@ -47,20 +48,20 @@
                 "caching",
                 "cakephp"
             ],
-            "time": "2018-12-27T20:11:28+00:00"
+            "time": "2019-04-09T19:27:04+00:00"
         },
         {
             "name": "cakephp/collection",
-            "version": "3.7.2",
+            "version": "3.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/collection.git",
-                "reference": "5e28b596c85d163f8c8350c213c34b6102b641ec"
+                "reference": "4c3b790d4703cc88cb75815b0e7f02a1a82b8d57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/collection/zipball/5e28b596c85d163f8c8350c213c34b6102b641ec",
-                "reference": "5e28b596c85d163f8c8350c213c34b6102b641ec",
+                "url": "https://api.github.com/repos/cakephp/collection/zipball/4c3b790d4703cc88cb75815b0e7f02a1a82b8d57",
+                "reference": "4c3b790d4703cc88cb75815b0e7f02a1a82b8d57",
                 "shasum": ""
             },
             "require": {
@@ -93,20 +94,20 @@
                 "collections",
                 "iterators"
             ],
-            "time": "2018-12-14T09:39:58+00:00"
+            "time": "2019-01-08T15:11:44+00:00"
         },
         {
             "name": "cakephp/core",
-            "version": "3.7.2",
+            "version": "3.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/core.git",
-                "reference": "02b4d6579246d7011e5062058c50c041ab542fa9"
+                "reference": "9742e7b325566df2e5ffcbdadc41049b9fa505fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/core/zipball/02b4d6579246d7011e5062058c50c041ab542fa9",
-                "reference": "02b4d6579246d7011e5062058c50c041ab542fa9",
+                "url": "https://api.github.com/repos/cakephp/core/zipball/9742e7b325566df2e5ffcbdadc41049b9fa505fe",
+                "reference": "9742e7b325566df2e5ffcbdadc41049b9fa505fe",
                 "shasum": ""
             },
             "require": {
@@ -114,6 +115,7 @@
                 "php": ">=5.6.0"
             },
             "suggest": {
+                "cakephp/cache": "To use Configure::store() and restore().",
                 "cakephp/event": "To use PluginApplicationInterface or plugin applications."
             },
             "type": "library",
@@ -142,20 +144,20 @@
                 "core",
                 "framework"
             ],
-            "time": "2018-12-13T23:20:56+00:00"
+            "time": "2019-03-14T15:11:58+00:00"
         },
         {
             "name": "cakephp/database",
-            "version": "3.7.2",
+            "version": "3.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/database.git",
-                "reference": "8fc79e5b65c250c0a82e2c20425ff65e28076bd8"
+                "reference": "9347f2edfbc98426e1cd8a9f94a6c879a03d2cb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/database/zipball/8fc79e5b65c250c0a82e2c20425ff65e28076bd8",
-                "reference": "8fc79e5b65c250c0a82e2c20425ff65e28076bd8",
+                "url": "https://api.github.com/repos/cakephp/database/zipball/9347f2edfbc98426e1cd8a9f94a6c879a03d2cb7",
+                "reference": "9347f2edfbc98426e1cd8a9f94a6c879a03d2cb7",
                 "shasum": ""
             },
             "require": {
@@ -190,20 +192,20 @@
                 "database abstraction",
                 "pdo"
             ],
-            "time": "2019-01-02T15:03:36+00:00"
+            "time": "2019-03-04T17:27:24+00:00"
         },
         {
             "name": "cakephp/datasource",
-            "version": "3.7.2",
+            "version": "3.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/datasource.git",
-                "reference": "d98a1675da0b62da834f86c976b2337db38adb49"
+                "reference": "08b5367426f4ee0388bd598fcf2bb994cd0f92c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/datasource/zipball/d98a1675da0b62da834f86c976b2337db38adb49",
-                "reference": "d98a1675da0b62da834f86c976b2337db38adb49",
+                "url": "https://api.github.com/repos/cakephp/datasource/zipball/08b5367426f4ee0388bd598fcf2bb994cd0f92c4",
+                "reference": "08b5367426f4ee0388bd598fcf2bb994cd0f92c4",
                 "shasum": ""
             },
             "require": {
@@ -240,20 +242,20 @@
                 "entity",
                 "query"
             ],
-            "time": "2018-12-13T23:20:56+00:00"
+            "time": "2019-02-14T16:36:35+00:00"
         },
         {
             "name": "cakephp/log",
-            "version": "3.7.2",
+            "version": "3.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/log.git",
-                "reference": "45682ac6707d6d341dae6470fe356fe60325022e"
+                "reference": "f2132d585e848f5273a36ca1b62dfbd56c1557b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/log/zipball/45682ac6707d6d341dae6470fe356fe60325022e",
-                "reference": "45682ac6707d6d341dae6470fe356fe60325022e",
+                "url": "https://api.github.com/repos/cakephp/log/zipball/f2132d585e848f5273a36ca1b62dfbd56c1557b9",
+                "reference": "f2132d585e848f5273a36ca1b62dfbd56c1557b9",
                 "shasum": ""
             },
             "require": {
@@ -285,20 +287,20 @@
                 "log",
                 "logging"
             ],
-            "time": "2018-04-24T11:15:51+00:00"
+            "time": "2019-02-05T13:29:41+00:00"
         },
         {
             "name": "cakephp/utility",
-            "version": "3.7.2",
+            "version": "3.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/utility.git",
-                "reference": "1a4d271d9a3ad6e0096eabf5778342c8b5f81978"
+                "reference": "329654495c4cf966ac75832e502ec939542928fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/utility/zipball/1a4d271d9a3ad6e0096eabf5778342c8b5f81978",
-                "reference": "1a4d271d9a3ad6e0096eabf5778342c8b5f81978",
+                "url": "https://api.github.com/repos/cakephp/utility/zipball/329654495c4cf966ac75832e502ec939542928fb",
+                "reference": "329654495c4cf966ac75832e502ec939542928fb",
                 "shasum": ""
             },
             "require": {
@@ -338,7 +340,7 @@
                 "string",
                 "utility"
             ],
-            "time": "2018-09-14T01:26:50+00:00"
+            "time": "2019-03-14T14:41:29+00:00"
         },
         {
             "name": "csrdelft/orm",
@@ -687,16 +689,16 @@
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.80",
+            "version": "v0.93",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "cb86c0001e6b757753b6a2efed837e4b899bddb3"
+                "reference": "c40ae41ebde3a0f5435ddd855ecbdf04c1783de0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/cb86c0001e6b757753b6a2efed837e4b899bddb3",
-                "reference": "cb86c0001e6b757753b6a2efed837e4b899bddb3",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/c40ae41ebde3a0f5435ddd855ecbdf04c1783de0",
+                "reference": "c40ae41ebde3a0f5435ddd855ecbdf04c1783de0",
                 "shasum": ""
             },
             "require": {
@@ -720,7 +722,7 @@
             "keywords": [
                 "google"
             ],
-            "time": "2019-01-07T00:22:56+00:00"
+            "time": "2019-04-06T00:22:58+00:00"
         },
         {
             "name": "google/auth",
@@ -1302,17 +1304,60 @@
             "time": "2018-07-02T15:55:56+00:00"
         },
         {
-            "name": "phpseclib/phpseclib",
-            "version": "2.0.13",
+            "name": "php-di/invoker",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "42603ce3f42a27f7e14e54feab95db7b680ad473"
+                "url": "https://github.com/PHP-DI/Invoker.git",
+                "reference": "540c27c86f663e20fe39a24cd72fa76cdb21d41a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/42603ce3f42a27f7e14e54feab95db7b680ad473",
-                "reference": "42603ce3f42a27f7e14e54feab95db7b680ad473",
+                "url": "https://api.github.com/repos/PHP-DI/Invoker/zipball/540c27c86f663e20fe39a24cd72fa76cdb21d41a",
+                "reference": "540c27c86f663e20fe39a24cd72fa76cdb21d41a",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "~1.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Invoker\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Generic and extensible callable invoker",
+            "homepage": "https://github.com/PHP-DI/Invoker",
+            "keywords": [
+                "callable",
+                "dependency",
+                "dependency-injection",
+                "injection",
+                "invoke",
+                "invoker"
+            ],
+            "time": "2017-03-20T19:28:22+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "2.0.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "11cf67cf78dc4acb18dc9149a57be4aee5036ce0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/11cf67cf78dc4acb18dc9149a57be4aee5036ce0",
+                "reference": "11cf67cf78dc4acb18dc9149a57be4aee5036ce0",
                 "shasum": ""
             },
             "require": {
@@ -1391,7 +1436,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2018-12-16T17:45:25+00:00"
+            "time": "2019-03-10T16:53:45+00:00"
         },
         {
             "name": "psr/cache",
@@ -1438,6 +1483,55 @@
                 "psr-6"
             ],
             "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/http-message",
@@ -1535,6 +1629,54 @@
                 "psr-3"
             ],
             "time": "2018-11-20T15:27:04+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -1704,17 +1846,143 @@
             "time": "2018-09-12T20:54:16+00:00"
         },
         {
-            "name": "symfony/config",
-            "version": "v3.4.21",
+            "name": "symfony/cache",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/config.git",
-                "reference": "17c5d8941eb75a03d19bc76a43757738632d87b3"
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "669270dc501fe3c5addcc306962958334c19652c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/17c5d8941eb75a03d19bc76a43757738632d87b3",
-                "reference": "17c5d8941eb75a03d19bc76a43757738632d87b3",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/669270dc501fe3c5addcc306962958334c19652c",
+                "reference": "669270dc501fe3c5addcc306962958334c19652c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/cache": "~1.0",
+                "psr/log": "~1.0",
+                "psr/simple-cache": "^1.0",
+                "symfony/polyfill-apcu": "~1.1"
+            },
+            "conflict": {
+                "symfony/var-dumper": "<3.3"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/cache": "~1.6",
+                "doctrine/dbal": "~2.4",
+                "predis/predis": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Cache component with PSR-6, PSR-16, and tags",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "time": "2019-04-01T07:08:40+00:00"
+        },
+        {
+            "name": "symfony/class-loader",
+            "version": "v3.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/class-loader.git",
+                "reference": "4459eef5298dedfb69f771186a580062b8516497"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/4459eef5298dedfb69f771186a580062b8516497",
+                "reference": "4459eef5298dedfb69f771186a580062b8516497",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "require-dev": {
+                "symfony/finder": "~2.8|~3.0|~4.0",
+                "symfony/polyfill-apcu": "~1.1"
+            },
+            "suggest": {
+                "symfony/polyfill-apcu": "For using ApcClassLoader on HHVM"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ClassLoader\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ClassLoader Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-01-16T09:39:14+00:00"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v3.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "177a276c01575253c95cefe0866e3d1b57637fe0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/177a276c01575253c95cefe0866e3d1b57637fe0",
+                "reference": "177a276c01575253c95cefe0866e3d1b57637fe0",
                 "shasum": ""
             },
             "require": {
@@ -1765,20 +2033,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-01T13:45:19+00:00"
+            "time": "2019-02-23T15:06:07+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.21",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a700b874d3692bc8342199adfb6d3b99f62cc61a"
+                "reference": "98ae3cdc4bec48fe7ee24afc81dbb4a242186c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a700b874d3692bc8342199adfb6d3b99f62cc61a",
-                "reference": "a700b874d3692bc8342199adfb6d3b99f62cc61a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/98ae3cdc4bec48fe7ee24afc81dbb4a242186c9e",
+                "reference": "98ae3cdc4bec48fe7ee24afc81dbb4a242186c9e",
                 "shasum": ""
             },
             "require": {
@@ -1790,6 +2058,9 @@
                 "symfony/dependency-injection": "<3.4",
                 "symfony/process": "<3.3"
             },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~3.3|~4.0",
@@ -1799,7 +2070,7 @@
                 "symfony/process": "~3.3|~4.0"
             },
             "suggest": {
-                "psr/log-implementation": "For using the console logger",
+                "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -1834,20 +2105,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-04T04:42:43+00:00"
+            "time": "2019-03-31T11:33:18+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.21",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186"
+                "reference": "adbdd5d66342fb0a0bce7422ba68181842b6610d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186",
-                "reference": "26d7f23b9bd0b93bee5583e4d6ca5cb1ab31b186",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/adbdd5d66342fb0a0bce7422ba68181842b6610d",
+                "reference": "adbdd5d66342fb0a0bce7422ba68181842b6610d",
                 "shasum": ""
             },
             "require": {
@@ -1890,20 +2161,204 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-01T13:45:19+00:00"
+            "time": "2019-03-10T17:07:42+00:00"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v3.4.21",
+            "name": "symfony/dependency-injection",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde"
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "85172cca352fe0790fa6f485ad194862a8ac57ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde",
-                "reference": "c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/85172cca352fe0790fa6f485ad194862a8ac57ee",
+                "reference": "85172cca352fe0790fa6f485ad194862a8ac57ee",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "symfony/config": "<3.3.7",
+                "symfony/finder": "<3.3",
+                "symfony/proxy-manager-bridge": "<3.4",
+                "symfony/yaml": "<3.4"
+            },
+            "provide": {
+                "psr/container-implementation": "1.0"
+            },
+            "require-dev": {
+                "symfony/config": "~3.3|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/expression-language": "For using expressions in service container configuration",
+                "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
+                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-03-25T07:48:46+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v3.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "a088aafcefb4eef2520a290ed82e4374092a6dff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a088aafcefb4eef2520a290ed82e4374092a6dff",
+                "reference": "a088aafcefb4eef2520a290ed82e4374092a6dff",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/stopwatch": "~2.8|~3.0|~4.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-04-02T08:51:52+00:00"
+        },
+        {
+            "name": "symfony/expression-language",
+            "version": "v3.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/expression-language.git",
+                "reference": "74631d47774cfa59bfb4a0de18cdf700fb98d658"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/74631d47774cfa59bfb4a0de18cdf700fb98d658",
+                "reference": "74631d47774cfa59bfb4a0de18cdf700fb98d658",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/cache": "~3.1|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ExpressionLanguage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ExpressionLanguage Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-01-16T12:52:19+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v3.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "acf99758b1df8e9295e6b85aa69f294565c9fedb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/acf99758b1df8e9295e6b85aa69f294565c9fedb",
+                "reference": "acf99758b1df8e9295e6b85aa69f294565c9fedb",
                 "shasum": ""
             },
             "require": {
@@ -1940,20 +2395,382 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-01T13:45:19+00:00"
+            "time": "2019-02-04T21:34:32+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "name": "symfony/finder",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "fcdde4aa38f48190ce70d782c166f23930084f9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/fcdde4aa38f48190ce70d782c166f23930084f9b",
+                "reference": "fcdde4aa38f48190ce70d782c166f23930084f9b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-02-22T14:44:53+00:00"
+        },
+        {
+            "name": "symfony/framework-bundle",
+            "version": "v3.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/framework-bundle.git",
+                "reference": "5993c7947fd534fc1c366b96292ff61f99148bd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/5993c7947fd534fc1c366b96292ff61f99148bd6",
+                "reference": "5993c7947fd534fc1c366b96292ff61f99148bd6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-xml": "*",
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/class-loader": "~3.2",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "^3.4.24|^4.2.5",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/filesystem": "~2.8|~3.0|~4.0",
+                "symfony/finder": "~2.8|~3.0|~4.0",
+                "symfony/http-foundation": "^3.4.24|^4.2.5",
+                "symfony/http-kernel": "~3.4|~4.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/routing": "^3.4.5|^4.0.5"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<3.0",
+                "phpdocumentor/type-resolver": "<0.2.1",
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
+                "symfony/asset": "<3.3",
+                "symfony/console": "<3.4",
+                "symfony/form": "<3.4",
+                "symfony/property-info": "<3.3",
+                "symfony/serializer": "<3.3",
+                "symfony/stopwatch": "<3.4",
+                "symfony/translation": "<3.4",
+                "symfony/validator": "<3.4",
+                "symfony/workflow": "<3.3"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.0",
+                "fig/link-util": "^1.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+                "symfony/asset": "~3.3|~4.0",
+                "symfony/browser-kit": "~2.8|~3.0|~4.0",
+                "symfony/console": "~3.4|~4.0",
+                "symfony/css-selector": "~2.8|~3.0|~4.0",
+                "symfony/dom-crawler": "~2.8|~3.0|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/form": "^3.4.22|~4.1.11|^4.2.3",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/polyfill-intl-icu": "~1.0",
+                "symfony/process": "~2.8|~3.0|~4.0",
+                "symfony/property-info": "~3.3|~4.0",
+                "symfony/security-core": "~3.2|~4.0",
+                "symfony/security-csrf": "^2.8.31|^3.3.13|~4.0",
+                "symfony/serializer": "~3.3|~4.0",
+                "symfony/stopwatch": "~3.4|~4.0",
+                "symfony/templating": "~2.8|~3.0|~4.0",
+                "symfony/translation": "~3.4|~4.0",
+                "symfony/validator": "~3.4|~4.0",
+                "symfony/var-dumper": "~3.3|~4.0",
+                "symfony/web-link": "~3.3|~4.0",
+                "symfony/workflow": "~3.3|~4.0",
+                "symfony/yaml": "~3.2|~4.0",
+                "twig/twig": "~1.34|~2.4"
+            },
+            "suggest": {
+                "ext-apcu": "For best performance of the system caches",
+                "symfony/console": "For using the console commands",
+                "symfony/form": "For using forms",
+                "symfony/property-info": "For using the property_info service",
+                "symfony/serializer": "For using the serializer service",
+                "symfony/validator": "For using validation",
+                "symfony/web-link": "For using web links, features such as preloading, prefetching or prerendering",
+                "symfony/yaml": "For using the debug:config and lint:yaml commands"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\FrameworkBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony FrameworkBundle",
+            "homepage": "https://symfony.com",
+            "time": "2019-04-01T07:08:40+00:00"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v3.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "61094ca72e8934c6502af5259ef6296eb09aa424"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/61094ca72e8934c6502af5259ef6296eb09aa424",
+                "reference": "61094ca72e8934c6502af5259ef6296eb09aa424",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-mbstring": "~1.1",
+                "symfony/polyfill-php70": "~1.6"
+            },
+            "require-dev": {
+                "symfony/expression-language": "~2.8|~3.0|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpFoundation Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-03-25T07:48:46+00:00"
+        },
+        {
+            "name": "symfony/http-kernel",
+            "version": "v3.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-kernel.git",
+                "reference": "30a9e48839413e6a6a8dc8989da0e7dd76c8fcf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/30a9e48839413e6a6a8dc8989da0e7dd76c8fcf8",
+                "reference": "30a9e48839413e6a6a8dc8989da0e7dd76c8fcf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/log": "~1.0",
+                "symfony/debug": "^3.3.3|~4.0",
+                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/http-foundation": "~3.4.12|~4.0.12|^4.1.1",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/config": "<2.8",
+                "symfony/dependency-injection": "<3.4.10|<4.0.10,>=4",
+                "symfony/var-dumper": "<3.3",
+                "twig/twig": "<1.34|<2.4,>=2"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/cache": "~1.0",
+                "symfony/browser-kit": "~2.8|~3.0|~4.0",
+                "symfony/class-loader": "~2.8|~3.0",
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/console": "~2.8|~3.0|~4.0",
+                "symfony/css-selector": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "^3.4.10|^4.0.10",
+                "symfony/dom-crawler": "~2.8|~3.0|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/finder": "~2.8|~3.0|~4.0",
+                "symfony/process": "~2.8|~3.0|~4.0",
+                "symfony/routing": "~3.4|~4.0",
+                "symfony/stopwatch": "~2.8|~3.0|~4.0",
+                "symfony/templating": "~2.8|~3.0|~4.0",
+                "symfony/translation": "~2.8|~3.0|~4.0",
+                "symfony/var-dumper": "~3.3|~4.0"
+            },
+            "suggest": {
+                "symfony/browser-kit": "",
+                "symfony/config": "",
+                "symfony/console": "",
+                "symfony/dependency-injection": "",
+                "symfony/finder": "",
+                "symfony/var-dumper": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpKernel\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpKernel Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-04-02T13:47:51+00:00"
+        },
+        {
+            "name": "symfony/polyfill-apcu",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-apcu.git",
+                "reference": "a502face1da6a53289480166f24de2c3c68e5c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/a502face1da6a53289480166f24de2c3c68e5c3c",
+                "reference": "a502face1da6a53289480166f24de2c3c68e5c3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Apcu\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting apcu_* functions to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "apcu",
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
                 "shasum": ""
             },
             "require": {
@@ -1965,7 +2782,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -1987,7 +2804,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1998,20 +2815,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
                 "shasum": ""
             },
             "require": {
@@ -2023,7 +2840,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -2057,20 +2874,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T13:07:52+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "ff208829fe1aa48ab9af356992bb7199fed551af"
+                "reference": "f4dddbc5c3471e1b700a147a20ae17cdb72dbe42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/ff208829fe1aa48ab9af356992bb7199fed551af",
-                "reference": "ff208829fe1aa48ab9af356992bb7199fed551af",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/f4dddbc5c3471e1b700a147a20ae17cdb72dbe42",
+                "reference": "f4dddbc5c3471e1b700a147a20ae17cdb72dbe42",
                 "shasum": ""
             },
             "require": {
@@ -2080,7 +2897,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -2113,20 +2930,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T06:26:08+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224"
+                "reference": "bc4858fb611bda58719124ca079baff854149c89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/6b88000cdd431cd2e940caa2cb569201f3f84224",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/bc4858fb611bda58719124ca079baff854149c89",
+                "reference": "bc4858fb611bda58719124ca079baff854149c89",
                 "shasum": ""
             },
             "require": {
@@ -2136,7 +2953,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -2172,20 +2989,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T06:26:08+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-util",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "3b58903eae668d348a7126f999b0da0f2f93611c"
+                "reference": "b46c6cae28a3106735323f00a0c38eccf2328897"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/3b58903eae668d348a7126f999b0da0f2f93611c",
-                "reference": "3b58903eae668d348a7126f999b0da0f2f93611c",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/b46c6cae28a3106735323f00a0c38eccf2328897",
+                "reference": "b46c6cae28a3106735323f00a0c38eccf2328897",
                 "shasum": ""
             },
             "require": {
@@ -2194,7 +3011,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -2224,20 +3041,96 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2018-09-30T16:36:12+00:00"
+            "time": "2019-02-08T14:16:39+00:00"
         },
         {
-            "name": "symfony/security-core",
-            "version": "v3.4.21",
+            "name": "symfony/routing",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/security-core.git",
-                "reference": "9a91f19208627aa41a6b536cda6979e227e7d394"
+                "url": "https://github.com/symfony/routing.git",
+                "reference": "ff11aac46d6cb8a65f2855687bb9a1ac9d860eec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/9a91f19208627aa41a6b536cda6979e227e7d394",
-                "reference": "9a91f19208627aa41a6b536cda6979e227e7d394",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/ff11aac46d6cb8a65f2855687bb9a1ac9d860eec",
+                "reference": "ff11aac46d6cb8a65f2855687bb9a1ac9d860eec",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "conflict": {
+                "symfony/config": "<3.3.1",
+                "symfony/dependency-injection": "<3.3",
+                "symfony/yaml": "<3.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "psr/log": "~1.0",
+                "symfony/config": "^3.3.1|~4.0",
+                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/http-foundation": "~2.8|~3.0|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation loader",
+                "symfony/config": "For using the all-in-one router or any loader",
+                "symfony/expression-language": "For using expression matching",
+                "symfony/http-foundation": "For using a Symfony Request object",
+                "symfony/yaml": "For using the YAML loader"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Routing\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Routing Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "router",
+                "routing",
+                "uri",
+                "url"
+            ],
+            "time": "2019-03-29T21:58:42+00:00"
+        },
+        {
+            "name": "symfony/security-core",
+            "version": "v3.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-core.git",
+                "reference": "4b59b3d15776e1eda9909e0555151bb9f785dc5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/4b59b3d15776e1eda9909e0555151bb9f785dc5e",
+                "reference": "4b59b3d15776e1eda9909e0555151bb9f785dc5e",
                 "shasum": ""
             },
             "require": {
@@ -2291,20 +3184,20 @@
             ],
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
-            "time": "2019-01-01T13:45:19+00:00"
+            "time": "2019-03-13T14:34:24+00:00"
         },
         {
             "name": "symfony/security-csrf",
-            "version": "v3.4.21",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-csrf.git",
-                "reference": "a49144ccab9f9ef17783f335bd4baf46ff57ba38"
+                "reference": "76ae1a389baca0375dd0a21c1f33fae901ad6cb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/a49144ccab9f9ef17783f335bd4baf46ff57ba38",
-                "reference": "a49144ccab9f9ef17783f335bd4baf46ff57ba38",
+                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/76ae1a389baca0375dd0a21c1f33fae901ad6cb0",
+                "reference": "76ae1a389baca0375dd0a21c1f33fae901ad6cb0",
                 "shasum": ""
             },
             "require": {
@@ -2352,20 +3245,20 @@
             ],
             "description": "Symfony Security Component - CSRF Library",
             "homepage": "https://symfony.com",
-            "time": "2019-01-01T13:45:19+00:00"
+            "time": "2019-01-16T09:39:14+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.21",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "554a59a1ccbaac238a89b19c8e551a556fd0e2ea"
+                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/554a59a1ccbaac238a89b19c8e551a556fd0e2ea",
-                "reference": "554a59a1ccbaac238a89b19c8e551a556fd0e2ea",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/212a27b731e5bfb735679d1ffaac82bd6a1dc996",
+                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996",
                 "shasum": ""
             },
             "require": {
@@ -2411,7 +3304,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-01T13:45:19+00:00"
+            "time": "2019-03-25T07:48:46+00:00"
         },
         {
             "name": "zumba/json-serializer",
@@ -2697,23 +3590,23 @@
         },
         {
             "name": "nette/di",
-            "version": "v2.4.14",
+            "version": "v2.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/di.git",
-                "reference": "923da3e2c0aa53162ef455472c0ac7787b096c5a"
+                "reference": "d0561b8f77e8ef2ed6d83328860e16c81a5a8649"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/di/zipball/923da3e2c0aa53162ef455472c0ac7787b096c5a",
-                "reference": "923da3e2c0aa53162ef455472c0ac7787b096c5a",
+                "url": "https://api.github.com/repos/nette/di/zipball/d0561b8f77e8ef2ed6d83328860e16c81a5a8649",
+                "reference": "d0561b8f77e8ef2ed6d83328860e16c81a5a8649",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
                 "nette/neon": "^2.3.3 || ~3.0.0",
-                "nette/php-generator": "^2.6.1 || ~3.0.0",
-                "nette/utils": "^2.4.3 || ~3.0.0",
+                "nette/php-generator": "^2.6.1 || ^3.0.0",
+                "nette/utils": "^2.5.0 || ~3.0.0",
                 "php": ">=5.6.0"
             },
             "conflict": {
@@ -2751,7 +3644,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "💎 Nette Dependency Injection Container: Flexible, compiled and full-featured DIC with perfectly usable autowiring and support for all new PHP 7.1 features.",
+            "description": "? Nette Dependency Injection Container: Flexible, compiled and full-featured DIC with perfectly usable autowiring and support for all new PHP 7.1 features.",
             "homepage": "https://nette.org",
             "keywords": [
                 "compiled",
@@ -2762,7 +3655,7 @@
                 "nette",
                 "static"
             ],
-            "time": "2018-09-17T15:47:40+00:00"
+            "time": "2019-01-30T13:26:05+00:00"
         },
         {
             "name": "nette/finder",
@@ -2828,31 +3721,31 @@
         },
         {
             "name": "nette/neon",
-            "version": "v2.4.3",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/neon.git",
-                "reference": "5e72b1dd3e2d34f0863c5561139a19df6a1ef398"
+                "reference": "cbff32059cbdd8720deccf9e9eace6ee516f02eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/neon/zipball/5e72b1dd3e2d34f0863c5561139a19df6a1ef398",
-                "reference": "5e72b1dd3e2d34f0863c5561139a19df6a1ef398",
+                "url": "https://api.github.com/repos/nette/neon/zipball/cbff32059cbdd8720deccf9e9eace6ee516f02eb",
+                "reference": "cbff32059cbdd8720deccf9e9eace6ee516f02eb",
                 "shasum": ""
             },
             "require": {
                 "ext-iconv": "*",
                 "ext-json": "*",
-                "php": ">=5.6.0"
+                "php": ">=7.0"
             },
             "require-dev": {
-                "nette/tester": "~2.0",
+                "nette/tester": "^2.0",
                 "tracy/tracy": "^2.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2876,7 +3769,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
+            "description": "? Nette NEON: encodes and decodes NEON file format.",
             "homepage": "http://ne-on.org",
             "keywords": [
                 "export",
@@ -2885,7 +3778,7 @@
                 "nette",
                 "yaml"
             ],
-            "time": "2018-03-21T12:12:21+00:00"
+            "time": "2019-02-05T21:30:40+00:00"
         },
         {
             "name": "nette/php-generator",
@@ -2951,16 +3844,16 @@
         },
         {
             "name": "nette/robot-loader",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/robot-loader.git",
-                "reference": "fc76c70e740b10f091e502b2e393d0be912f38d4"
+                "reference": "3e8d75d6d976e191bdf46752ca40a286671219d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/robot-loader/zipball/fc76c70e740b10f091e502b2e393d0be912f38d4",
-                "reference": "fc76c70e740b10f091e502b2e393d0be912f38d4",
+                "url": "https://api.github.com/repos/nette/robot-loader/zipball/3e8d75d6d976e191bdf46752ca40a286671219d2",
+                "reference": "3e8d75d6d976e191bdf46752ca40a286671219d2",
                 "shasum": ""
             },
             "require": {
@@ -3003,7 +3896,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🍀 Nette RobotLoader: high performance and comfortable autoloader that will search and autoload classes within your application.",
+            "description": "? Nette RobotLoader: high performance and comfortable autoloader that will search and autoload classes within your application.",
             "homepage": "https://nette.org",
             "keywords": [
                 "autoload",
@@ -3012,7 +3905,7 @@
                 "nette",
                 "trait"
             ],
-            "time": "2018-08-13T14:19:06+00:00"
+            "time": "2019-03-01T20:23:02+00:00"
         },
         {
             "name": "nette/utils",
@@ -3872,16 +4765,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.13",
+            "version": "6.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693"
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0973426fb012359b2f18d3bd1e90ef1172839693",
-                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
                 "shasum": ""
             },
             "require": {
@@ -3952,7 +4845,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-09-08T15:10:43+00:00"
+            "time": "2019-02-01T05:22:47+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -4574,66 +5467,17 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "symfony/finder",
-            "version": "v3.4.21",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e",
-                "reference": "3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Finder Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-01-01T13:45:19+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/1c42705be2b6c1de5904f8afacef5895cab44bf8",
+                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8",
                 "shasum": ""
             },
             "require": {
@@ -4660,7 +5504,7 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
+            "time": "2019-04-04T09:56:43+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -32,7 +32,6 @@ RewriteRule ^verify				index.php?c=Login [L]
 RewriteRule ^wachtwoord			index.php?c=Login [QSA,L]
 RewriteRule ^account			index.php?c=Login [L]
 
-RewriteRule ^documenten			index.php?c=Documenten	[QSA,L]
 RewriteRule ^bibliotheek		index.php?c=Bibliotheek [QSA,L]
 RewriteRule ^mededelingen       index.php?c=Mededelingen [QSA,L]
 RewriteRule ^peilingen          index.php?c=Peilingen [QSA,L]

--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -32,7 +32,6 @@ RewriteRule ^verify				index.php?c=Login [L]
 RewriteRule ^wachtwoord			index.php?c=Login [QSA,L]
 RewriteRule ^account			index.php?c=Login [L]
 
-RewriteRule ^eetplan			index.php?c=Eetplan		[QSA,L]
 RewriteRule ^documenten			index.php?c=Documenten	[QSA,L]
 RewriteRule ^bibliotheek		index.php?c=Bibliotheek [QSA,L]
 RewriteRule ^mededelingen       index.php?c=Mededelingen [QSA,L]

--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -34,7 +34,6 @@ RewriteRule ^account			index.php?c=Login [L]
 
 RewriteRule ^bibliotheek		index.php?c=Bibliotheek [QSA,L]
 RewriteRule ^mededelingen       index.php?c=Mededelingen [QSA,L]
-RewriteRule ^peilingen          index.php?c=Peilingen [QSA,L]
 
 RewriteRule ^leden				index.php?c=Profiel [QSA,L]
 RewriteRule ^profiel			index.php?c=Profiel [QSA,L]

--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -21,7 +21,7 @@ RewriteRule ^feuten				https://github.com/csrdelft/csrdelft.nl [R,L]
 
 RewriteRule ^(leden)?lijst/?(.*)$	ledenlijst.php [QSA,L]
 
-RewriteRule ^forum/rss/([0-9a-zA-Z]*)/csrdelft.xml		index.php?c=Forum&private_token=$1 [L]
+RewriteRule ^forum/rss/([0-9a-zA-Z]*)/csrdelft.xml		index.php?private_token=$1 [L]
 RewriteRule ^agenda/ical/([0-9a-zA-Z]*)/csrdelft.ics	index.php?c=Agenda&private_token=$1 [L]
 
 RewriteRule ^login				index.php?c=Login [L]
@@ -44,7 +44,6 @@ RewriteRule ^groepen			index.php?c=GroepenRouter [L]
 RewriteRule ^maaltijden			index.php?c=MaalcieRouter [L]
 RewriteRule ^corvee				index.php?c=MaalcieRouter [L]
 RewriteRule ^fiscaat            index.php?c=FiscaatRouter [L]
-RewriteRule ^forum				index.php?c=Forum [L]
 RewriteRule ^agenda				index.php?c=Agenda [L]
 RewriteRule ^courant			index.php?c=Courant [L]
 RewriteRule ^plaetjes/fotoalbum			index.php?c=FotoAlbum [L]

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -59,7 +59,7 @@ try {
 		$context->fromRequest(Request::createFromGlobals());
 
 		$matcher = new UrlMatcher($routes, $context);
-		$parameters = $matcher->match(REQUEST_URI);
+		$parameters = $matcher->match(strtok(REQUEST_URI, '?'));
 
 		$acl = $routes->get($parameters['_route'])->getOption('mag');
 

--- a/lib/config/routes.yaml
+++ b/lib/config/routes.yaml
@@ -1,0 +1,8 @@
+cms-routes: { resource: routes/cms.yml }
+forum-routes: { resource: routes/forum.yaml }
+
+default:
+  path: /{naam}/{subnaam}
+  controller: CsrDelft\controller\CmsPaginaController::bekijken
+  defaults: { naam: thuis, subnaam: "" }
+  options: { mag: P_PUBLIC }

--- a/lib/config/routes.yaml
+++ b/lib/config/routes.yaml
@@ -1,5 +1,6 @@
 cms-routes: { resource: routes/cms.yml }
 forum-routes: { resource: routes/forum.yaml }
+eetplan-routes: { resource: routes/eetplan.yaml }
 
 default:
   path: /{naam}/{subnaam}

--- a/lib/config/routes.yaml
+++ b/lib/config/routes.yaml
@@ -2,6 +2,7 @@ cms-routes: { resource: routes/cms.yml }
 forum-routes: { resource: routes/forum.yaml }
 eetplan-routes: { resource: routes/eetplan.yaml }
 documenten-routes: { resource: routes/documenten.yaml }
+peilingen-routes: { resource: routes/peilingen.yaml }
 
 default:
   path: /{naam}/{subnaam}

--- a/lib/config/routes.yaml
+++ b/lib/config/routes.yaml
@@ -1,6 +1,7 @@
 cms-routes: { resource: routes/cms.yml }
 forum-routes: { resource: routes/forum.yaml }
 eetplan-routes: { resource: routes/eetplan.yaml }
+documenten-routes: { resource: routes/documenten.yaml }
 
 default:
   path: /{naam}/{subnaam}

--- a/lib/config/routes/cms.yml
+++ b/lib/config/routes/cms.yml
@@ -1,0 +1,14 @@
+cms-bekijken:
+  path: /pagina/{naam}
+  controller: CsrDelft\controller\CmsPaginaController::bekijken
+  options: { mag: P_PUBLIC }
+
+cms-bewerken:
+  path: /pagina/bewerken/{naam}
+  controller: CsrDelft\controller\CmsPaginaController::bewerken
+  options: { mag: P_LOGGED_IN }
+
+cms-verwijderen:
+  path: /pagina/verwijderen/{naam}
+  controller: CsrDelft\controller\CmsPaginaController::verwijderen
+  options: { mag: P_ADMIN }

--- a/lib/config/routes/documenten.yaml
+++ b/lib/config/routes/documenten.yaml
@@ -1,0 +1,52 @@
+documenten:
+  path: /documenten
+  controller: CsrDelft\controller\DocumentenController::recenttonen
+  methods: GET
+  options: { mag: P_DOCS_READ }
+
+documenten-bekijken:
+  path: /documenten/bekijken/{id}/{bestandsnaam}
+  controller: CsrDelft\controller\DocumentenController::bekijken
+  methods: GET
+  requirements: { id: '\d+' }
+  options: { mag: P_DOCS_READ }
+
+documenten-download:
+  path: /documenten/download/{id}/{bestandsnaam}
+  controller: CsrDelft\controller\DocumentenController::download
+  methods: GET
+  requirements: { id: '\d+' }
+  options: { mag: P_DOCS_READ }
+
+documenten-categorie:
+  path: /documenten/categorie/{id}
+  controller: CsrDelft\controller\DocumentenController::categorie
+  methods: GET
+  requirements: { id: '\d+' }
+  options: { mag: P_DOCS_READ }
+
+documenten-zoeken:
+  path: /documenten/zoeken
+  controller: CsrDelft\controller\DocumentenController::zoeken
+  methods: [GET,POST]
+  options: { mag: P_DOCS_READ }
+
+documenten-bewerken:
+  path: /documenten/bewerken/{id}
+  controller: CsrDelft\controller\DocumentenController::bewerken
+  methods: POST
+  requirements: { id: '\d+' }
+  options: { mag: P_DOCS_MOD }
+
+documenten-toevoegen:
+  path: /documenten/toevoegen
+  controller: CsrDelft\controller\DocumentenController::toevoegen
+  methods: [GET,POST]
+  options: { mag: P_DOCS_MOD }
+
+documenten-verwijderen:
+  path: /documenten/verwijderen/{id}
+  controller: CsrDelft\controller\DocumentenController::verwijderen
+  methods: POST
+  requirements: { id: '\d+' }
+  options: { mag: P_DOCS_MOD }

--- a/lib/config/routes/eetplan.yaml
+++ b/lib/config/routes/eetplan.yaml
@@ -1,0 +1,51 @@
+eetplan:
+  path: /eetplan
+  controller: CsrDelft\controller\EetplanController::view
+  methods: GET
+  options: { mag: P_LEDEN_READ }
+
+eetplan-noviet:
+  path: /eetplan/noviet/{uid}
+  controller: CsrDelft\controller\EetplanController::noviet
+  methods: GET
+  requirements: { uid: '.{4}' }
+  options: { mag: P_LEDEN_READ }
+
+eetplan-huis:
+  path: /eetplan/huis/{id}
+  controller: CsrDelft\controller\EetplanController::huis
+  methods: GET
+  requirements: { id: '\d+' }
+  options: { mag: P_LEDEN_READ }
+
+eetplan-beheer:
+  path: /eetplan/beheer
+  controller: CsrDelft\controller\EetplanController::beheer
+  methods: [GET,POST]
+  options: { mag: P_ADMIN,commissie:NovCie }
+
+eetplan-bekendehuizen:
+  path: /eetplan/bekendehuizen/{actie}
+  controller: CsrDelft\controller\EetplanController::bekendehuizen
+  methods: [GET,POST]
+  defaults: { actie: null }
+  options: { mag: P_ADMIN,commissie:NovCie }
+
+eetplan-novietrelatie:
+  path: /eetplan/novietrelatie/{actie}
+  controller: CsrDelft\controller\EetplanController::novietrelatie
+  methods: POST
+  defaults: { actie: null }
+  options: { mag: P_ADMIN,commissie:NovCie }
+
+eetplan-nieuw:
+  path: /eetplan/nieuw
+  controller: CsrDelft\controller\EetplanController::nieuw
+  methods: POST
+  options: { mag: P_ADMIN,commissie:NovCie }
+
+eetplan-verwijderen:
+  path: /eetplan/verwijderen
+  controller: CsrDelft\controller\EetplanController::verwijderen
+  methods: POST
+  options: { mag: P_ADMIN,commissie:NovCie }

--- a/lib/config/routes/forum.yaml
+++ b/lib/config/routes/forum.yaml
@@ -1,0 +1,214 @@
+forum:
+  path: /forum
+  controller: CsrDelft\controller\ForumController::forum
+  methods: GET
+  options: { mag: P_PUBLIC }
+
+forum-deel:
+  path: /forum/deel/{forum_id}/{pagina}
+  controller: CsrDelft\controller\ForumController::deel
+  methods: [GET, POST]
+  defaults: { pagina: 1 }
+  requirements: { forum_id: '\d+', pagina: '\d+' }
+  options: { mag: P_PUBLIC }
+
+forum-zoeken:
+  path: /forum/zoeken/{query}/{pagina}
+  controller: CsrDelft\controller\ForumController::zoeken
+  methods: [GET, POST]
+  defaults: { query: null, pagina: 1}
+  requirements: { pagina: '\d+' }
+  options: { mag: P_PUBLIC }
+
+forum-public-rss:
+  path: /forum/rss/csrdelft.xml
+  controller: CsrDelft\controller\ForumController::rss
+  methods: GET
+  options: { mag: P_PUBLIC }
+
+forum-rss:
+  path: /forum/rss/{token}/csrdelft.xml
+  controller: CsrDelft\controller\ForumController::rss
+  methods: GET
+  options: { mag: P_PUBLIC }
+
+forum-recent:
+  path: /forum/recent/{pagina}/
+  controller: CsrDelft\controller\ForumController::recent
+  methods: GET
+  defaults: { pagina: 1 }
+  options: { mag: P_PUBLIC }
+
+forum-onderwerp:
+  path: /forum/onderwerp/{draad_id}/{pagina}/{statistiek}
+  controller: CsrDelft\controller\ForumController::onderwerp
+  methods: GET
+  defaults: { pagina: null, statistiek: null }
+  requirements: { draad_id: '\d+' }
+  options: { mag: P_PUBLIC }
+
+forum-reactie:
+  path: /forum/reactie/{post_id}
+  controller: CsrDelft\controller\ForumController::reactie
+  methods: GET
+  options: { mag: P_PUBLIC }
+  requirements: { post_id: '\d+' }
+
+forum-titelzoeken:
+  path: /forum/titelzoeken
+  controller: CsrDelft\controller\ForumController::titelzoeken
+  methods: GET
+  options: { mag: P_LOGGED_IN }
+
+forum-belangrijk:
+  path: /forum/belangrijk/{pagina}
+  controller: CsrDelft\controller\ForumController::belangrijk
+  methods: GET
+  defaults: { pagina: 1 }
+  requirements: { pagina: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-wacht:
+  path: /forum/wacht
+  controller: CsrDelft\controller\ForumController::wacht
+  methods: GET
+  options: { mag: P_FORUM_ADMIN }
+
+forum-posten:
+  path: /forum/posten/{forum_id}/{draad_id}
+  controller: CsrDelft\controller\ForumController::posten
+  methods: POST
+  defaults: { draad_id: null }
+  requirements: { forum_id: '\d+', draad_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-aanmaken:
+  path: /forum/aanmaken
+  controller: CsrDelft\controller\ForumController::aanmaken
+  methods: POST
+  options: { mag: P_FORUM_ADMIN }
+
+forum-beheren:
+  path: /forum/beheren/{forum_id}
+  controller: CsrDelft\controller\ForumController::beheren
+  methods: POST
+  requirements: { forum_id: '\d+' }
+  options: { mag: P_FORUM_ADMIN }
+
+forum-opheffen:
+  path: /forum/opheffen/{forum_id}
+  controller: CsrDelft\controller\ForumController::opheffen
+  methods: POST
+  requirements: { forum_id: '\d+' }
+  options: { mag: P_FORUM_ADMIN }
+
+forum-bewerken:
+  path: /forum/bewerken/{post_id}
+  controller: CsrDelft\controller\ForumController::bewerken
+  methods: POST
+  requirements: { post_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-citeren:
+  path: /forum/citeren/{post_id}
+  controller: CsrDelft\controller\ForumController::citeren
+  methods: POST
+  requirements: { post_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-bladwijzer:
+  path: /forum/bladwijzer/{draad_id}
+  controller: CsrDelft\controller\ForumController::bladwijzer
+  methods: POST
+  requirements: { draad_id: '\d+' }
+  options: { mag: P_LOGGED_IN}
+
+forum-concept:
+  path: /forum/concept/{forum_id}/{draad_id}
+  controller: CsrDelft\controller\ForumController::concept
+  methods: POST
+  defaults: { draad_id: null }
+  requirements: { forum_id: '\d+', draad_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-grafiekdata:
+  path: /forum/grafiekdata/{type}
+  controller: CsrDelft\controller\ForumController::grafiekdata
+  methods: POST
+  options: { mag: P_LOGGED_IN }
+
+forum-wijzigen:
+  path: /forum/wijzigen/{draad_id}/{property}
+  controller: CsrDelft\controller\ForumController::wijzigen
+  methods: POST
+  requirements: { draad_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-verwijderen:
+  path: /forum/verwijderen/{post_id}
+  controller: CsrDelft\controller\ForumController::verwijderen
+  methods: POST
+  requirements: { post_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-verplaatsen:
+  path: /forum/verplaatsen/{post_id}
+  controller: CsrDelft\controller\ForumController::verplaatsen
+  methods: POST
+  requirements: { post_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-offtopic:
+  path: /forum/offtopic/{post_id}
+  controller: CsrDelft\controller\ForumController::offtopic
+  methods: POST
+  requirements: { post_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-goedkeuren:
+  path: /forum/goedkeuren/{post_id}
+  controller: CsrDelft\controller\ForumController::goedkeuren
+  methods: POST
+  requirements: { post_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-meldingsniveau:
+  path: /forum/meldingsniveau/{draad_id}/{niveau}
+  controller: CsrDelft\controller\ForumController::meldingsniveau
+  methods: POST
+  requirements: { draad_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-deelmelding:
+  path: /forum/deelmelding/{forum_id}/{niveau}
+  controller: CsrDelft\controller\ForumController::deelmelding
+  methods: POST
+  requirements: { forum_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-tekst:
+  path: /forum/tekst/{post_id}
+  controller: CsrDelft\controller\ForumController::tekst
+  methods: POST
+  requirements: { post_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-verbergen:
+  path: /forum/verbergen/{draad_id}
+  controller: CsrDelft\controller\ForumController::verbergen
+  methods: POST
+  requirements: { draad_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-tonen:
+  path: /forum/tonen/{draad_id}
+  controller: CsrDelft\controller\ForumController::tonen
+  methods: POST
+  requirements: { draad_id: '\d+' }
+  options: { mag: P_LOGGED_IN }
+
+forum-toonalles:
+  path: /forum/toonalles
+  controller: CsrDelft\controller\ForumController::toonalles
+  methods: POST
+  options: { mag: P_LOGGED_IN }

--- a/lib/config/routes/peilingen.yaml
+++ b/lib/config/routes/peilingen.yaml
@@ -1,0 +1,65 @@
+peilingen-beheer:
+  path: /peilingen/beheer/{id}
+  controller: CsrDelft\controller\PeilingenController::table
+  methods: GET
+  requirements: { id: '\d+' }
+  defaults: { id: null }
+  options: { mag: P_PEILING_EDIT }
+
+peilingen-beheer-post:
+  path: /peilingen/beheer
+  controller: CsrDelft\controller\PeilingenController::lijst
+  methods: POST
+  options: { mag: P_PEILING_EDIT }
+
+peilingen-opties-table:
+  path: /peilingen/opties/{id}
+  controller: CsrDelft\controller\PeilingOptiesController::table
+  methods: GET
+  requirements: { id: '\d+' }
+  options: { mag: P_PEILING_EDIT }
+
+peilingen-opties-table-content:
+  path: /peilingen/opties/{id}
+  controller: CsrDelft\controller\PeilingOptiesController::lijst
+  methods: POST
+  requirements: { id: '\d+' }
+  options: { mag: P_PEILING_EDIT }
+
+peilingen-opties-toevoegen:
+  path: /peilingen/opties/{id}/toevoegen
+  controller: CsrDelft\controller\PeilingOptiesController::toevoegen
+  methods: POST
+  requirements: { id: '\d+' }
+  options: { mag: P_PEILING_VOTE }
+
+peilingen-opties-verwijderen:
+  path: /peilingen/opties/verwijderen
+  controller: CsrDelft\controller\PeilingOptiesController::verwijderen
+  methods: POST
+  options: { mag: P_PEILING_EDIT }
+
+peilingen-verwijderen:
+  path: /peilingen/verwijderen
+  controller: CsrDelft\controller\PeilingenController::verwijderen
+  methods: [GET,POST]
+  options: { mag: P_PEILING_MOD }
+
+peilingen-stem:
+  path: /peilingen/stem/{id}
+  controller: CsrDelft\controller\PeilingenController::stem
+  methods: POST
+  requirements: { id: '\d+' }
+  options: { mag: P_PEILING_VOTE }
+
+peilingen-bewerken:
+  path: /peilingen/bewerken
+  controller: CsrDelft\controller\PeilingenController::bewerken
+  methods: POST
+  options: { mag: P_PEILING_EDIT }
+
+peilingen-nieuw:
+  path: /peilingen/nieuw
+  controller: CsrDelft\controller\PeilingenController::nieuw
+  methods: POST
+  options: { mag: P_PEILING_EDIT }

--- a/lib/controller/CmsPaginaController.class.php
+++ b/lib/controller/CmsPaginaController.class.php
@@ -13,6 +13,7 @@ use CsrDelft\view\cms\CmsPaginaView;
 use CsrDelft\view\cms\CmsPaginaZijbalkView;
 use CsrDelft\view\CsrLayoutOweePage;
 use CsrDelft\view\CsrLayoutPage;
+use CsrDelft\view\JsonResponse;
 
 /**
  * CmsPaginaController.class.php
@@ -67,7 +68,10 @@ class CmsPaginaController extends Controller {
 		return true; // check permission on page itself
 	}
 
-	public function bekijken($naam) {
+	public function bekijken($naam, $subnaam = "") {
+		if ($subnaam) {
+			$naam = $subnaam;
+		}
 		/** @var CmsPagina $pagina */
 		$pagina = $this->model->get($naam);
 		if (!$pagina) { // 404
@@ -85,9 +89,9 @@ class CmsPaginaController extends Controller {
 			} elseif ($this->hasParam(1) AND $this->getParam(1) === 'vereniging') {
 				$menu = true;
 			}
-			$this->view = new CsrLayoutOweePage($body, $tmpl, $menu);
+			return new CsrLayoutOweePage($body, $tmpl, $menu);
 		} else {
-			$this->view = new CsrLayoutPage($body, $this->zijbalk);
+			return new CsrLayoutPage($body, $this->zijbalk);
 		}
 	}
 
@@ -110,7 +114,7 @@ class CmsPaginaController extends Controller {
 			}
 			redirect('/pagina/' . $pagina->naam);
 		} else {
-			$this->view = new CsrLayoutPage($form, $this->zijbalk);
+			return new CsrLayoutPage($form, $this->zijbalk);
 		}
 	}
 
@@ -125,7 +129,7 @@ class CmsPaginaController extends Controller {
 		} else {
 			setMelding('Verwijderen mislukt', -1);
 		}
-		$this->view = new JsonResponse(CSR_ROOT); // redirect
+		return new JsonResponse(CSR_ROOT); // redirect
 	}
 
 }

--- a/lib/controller/CmsPaginaController.class.php
+++ b/lib/controller/CmsPaginaController.class.php
@@ -28,9 +28,11 @@ class CmsPaginaController {
 	 * @var CmsPaginaZijbalkView[]
 	 */
 	private $zijbalk = array();
-  private $model;
+	/** @var CmsPaginaModel */
+	private $cmsPaginaModel;
+
 	public function __construct() {
-		$this->model = CmsPaginaModel::instance();
+		$this->cmsPaginaModel = CmsPaginaModel::instance();
 	}
 
 	public function bekijken($naam, $subnaam = "") {
@@ -38,9 +40,9 @@ class CmsPaginaController {
 			$naam = $subnaam;
 		}
 		/** @var CmsPagina $pagina */
-		$pagina = $this->model->get($naam);
+		$pagina = $this->cmsPaginaModel->get($naam);
 		if (!$pagina) { // 404
-			$pagina = $this->model->get('thuis');
+			$pagina = $this->cmsPaginaModel->get('thuis');
 		}
 		if (!$pagina->magBekijken()) { // 403
 			throw new CsrToegangException();
@@ -61,9 +63,9 @@ class CmsPaginaController {
 	}
 
 	public function bewerken($naam) {
-		$pagina = $this->model->get($naam);
+		$pagina = $this->cmsPaginaModel->get($naam);
 		if (!$pagina) {
-			$pagina = $this->model->nieuw($naam);
+			$pagina = $this->cmsPaginaModel->nieuw($naam);
 		}
 		if (!$pagina->magBewerken()) {
 			throw new CsrToegangException();
@@ -71,7 +73,7 @@ class CmsPaginaController {
 		$form = new CmsPaginaForm($pagina); // fetches POST values itself
 		if ($form->validate()) {
 			$pagina->laatst_gewijzigd = getDateTime();
-			$rowCount = $this->model->update($pagina);
+			$rowCount = $this->cmsPaginaModel->update($pagina);
 			if ($rowCount > 0) {
 				setMelding('Bijgewerkt', 1);
 			} else {
@@ -85,11 +87,11 @@ class CmsPaginaController {
 
 	public function verwijderen($naam) {
 		/** @var CmsPagina $pagina */
-		$pagina = $this->model->get($naam);
+		$pagina = $this->cmsPaginaModel->get($naam);
 		if (!$pagina OR !$pagina->magVerwijderen()) {
 			throw new CsrToegangException();
 		}
-		if ($this->model->delete($pagina)) {
+		if ($this->cmsPaginaModel->delete($pagina)) {
 			setMelding('Pagina ' . $naam . ' succesvol verwijderd', 1);
 		} else {
 			setMelding('Verwijderen mislukt', -1);

--- a/lib/controller/DocumentenController.class.php
+++ b/lib/controller/DocumentenController.class.php
@@ -4,6 +4,7 @@ namespace CsrDelft\controller;
 
 use CsrDelft\common\CsrToegangException;
 use CsrDelft\controller\framework\AclController;
+use CsrDelft\controller\framework\QueryParamTrait;
 use CsrDelft\model\documenten\DocumentCategorieModel;
 use CsrDelft\model\documenten\DocumentModel;
 use CsrDelft\model\entity\documenten\Document;
@@ -17,40 +18,16 @@ use CsrDelft\view\JsonResponse;
 use CsrDelft\view\PlainView;
 
 /**
- * DocumentenController.class.php
- *
  * @author G.J.W. Oolbekkink <g.j.w.oolbekkink@gmail.com>
- *
- * @property DocumentModel $model
  */
-class DocumentenController extends AclController {
+class DocumentenController {
+	use QueryParamTrait;
 
-	/**
-	 * querystring:
-	 *
-	 * actie[/id[/opties]]
-	 */
-	public function __construct($query) {
-		parent::__construct($query, DocumentModel::instance());
-		$this->acl = array(
-			'recenttonen' => P_DOCS_READ,
-			'bekijken' => P_DOCS_READ,
-			'download' => P_DOCS_READ,
-			'categorie' => P_DOCS_READ,
-			'zoeken' => P_DOCS_READ,
-			'bewerken' => P_DOCS_MOD,
-			'toevoegen' => P_DOCS_MOD,
-			'verwijderen' => P_DOCS_MOD
-		);
-	}
+	/** @var DocumentModel */
+	private $model;
 
-	public function performAction(array $args = array()) {
-		if ($this->hasParam(2)) {
-			$this->action = $this->getParam(2);
-		} else {
-			$this->action = 'recenttonen';
-		}
-		$this->view = parent::performAction($this->getParams(3));
+	public function __construct() {
+		$this->model = DocumentModel::instance();
 	}
 
 	/**
@@ -181,7 +158,7 @@ class DocumentenController extends AclController {
 
 	public function zoeken() {
 		if (!$this->hasParam('q')) {
-			$this->exit_http(403);
+			throw new CsrToegangException();
 		}
 		$zoekterm = $this->getParam('q');
 

--- a/lib/controller/EetplanController.class.php
+++ b/lib/controller/EetplanController.class.php
@@ -2,10 +2,9 @@
 
 namespace CsrDelft\controller;
 
-use CsrDelft\common\CsrException;
 use CsrDelft\common\CsrGebruikerException;
 use CsrDelft\common\CsrToegangException;
-use CsrDelft\controller\framework\AclController;
+use CsrDelft\controller\framework\QueryParamTrait;
 use CsrDelft\model\eetplan\EetplanBekendenModel;
 use CsrDelft\model\eetplan\EetplanModel;
 use CsrDelft\model\entity\eetplan\Eetplan;
@@ -30,57 +29,21 @@ use CsrDelft\view\eetplan\VerwijderEetplanForm;
 use CsrDelft\view\View;
 
 /**
- * EetplanController.class.php
- *
  * @author P.W.G. Brussee <brussee@live.nl>
  *
  * Controller voor eetplan.
  */
-class EetplanController extends AclController {
-	/**
-	 * @var EetplanModel
-	 */
-	protected $model;
+class EetplanController {
+	use QueryParamTrait;
+
+	/** @var string */
 	private $lichting;
+	/** @var EetplanModel */
+	private $model;
 
-	public function __construct($query) {
-		parent::__construct($query, EetplanModel::instance());
-		if ($this->getMethod() == 'GET') {
-			$this->acl = array(
-				'view' => P_LEDEN_READ,
-				'noviet' => P_LEDEN_READ,
-				'huis' => P_LEDEN_READ,
-				'beheer' => P_ADMIN . ',commissie:NovCie',
-				'bekendehuizen' => P_ADMIN . ',commissie:NovCie',
-				'json' => P_LEDEN_READ,
-			);
-		} else {
-			$this->acl = array(
-				'beheer' => P_ADMIN . ',commissie:NovCie',
-				'woonoorden' => P_ADMIN . ',commissie:NovCie',
-				'novietrelatie' => P_ADMIN . ',commissie:NovCie',
-				'bekendehuizen' => P_ADMIN . ',commissie:NovCie',
-				'nieuw' => P_ADMIN . ',commissie:NovCie',
-				'verwijderen' => P_ADMIN . ',commissie:NovCie',
-			);
-		}
-	}
-
-	/**
-	 * /eetplan/<$this->action>/<$this->lichting>|huidig/<$args>
-	 *
-	 * @param array $args
-	 * @throws CsrException
-	 */
-	public function performAction(array $args = array()) {
-		$this->action = 'view';
-		if ($this->hasParam(2)) {
-			$this->action = $this->getParam(2);
-		}
-
+	public function __construct() {
+		$this->model = EetplanModel::instance();
 		$this->lichting = substr((string)LichtingenModel::getJongsteLidjaar(), 2, 2);
-
-		$this->view = parent::performAction($this->getParams(3));
 	}
 
 	public function view() {

--- a/lib/controller/ForumController.class.php
+++ b/lib/controller/ForumController.class.php
@@ -251,7 +251,7 @@ class ForumController {
 	 * @throws CsrGebruikerException
 	 */
 	public function deel(int $forum_id, $pagina = 1) {
-		$deel = ForumDelenModel::get($forum_id);
+		$deel = $this->forumDelenModel::get($forum_id);
 		if (!$deel->magLezen()) {
 			throw new CsrToegangException();
 		}
@@ -287,7 +287,7 @@ class ForumController {
 	 * @throws CsrGebruikerException
 	 */
 	public function reactie(int $post_id) {
-		$post = ForumPostsModel::get($post_id);
+		$post = $this->forumPostsModel::get($post_id);
 		if ($post->verwijderd) {
 			setMelding('Deze reactie is verwijderd', 0);
 		}
@@ -304,7 +304,7 @@ class ForumController {
 	 * @throws CsrGebruikerException
 	 */
 	public function onderwerp(int $draad_id, $pagina = null, $statistiek = null) {
-		$draad = ForumDradenModel::get($draad_id);
+		$draad = $this->forumDradenModel::get($draad_id);
 		if (!$draad->magLezen()) {
 			throw new CsrToegangException();
 		}
@@ -377,7 +377,7 @@ class ForumController {
 	 * @throws CsrGebruikerException
 	 */
 	public function beheren(int $forum_id) {
-		$deel = ForumDelenModel::get($forum_id);
+		$deel = $this->forumDelenModel::get($forum_id);
 		$form = new ForumDeelForm($deel); // fetches POST values itself
 		if ($form->validate()) {
 			$rowCount = $this->forumDelenModel->update($deel);
@@ -399,7 +399,7 @@ class ForumController {
 	 * @throws CsrException
 	 */
 	public function opheffen(int $forum_id) {
-		$deel = ForumDelenModel::get($forum_id);
+		$deel = $this->forumDelenModel::get($forum_id);
 		$count = $this->forumDradenModel->count('forum_id = ?', array($deel->forum_id));
 		if ($count > 0) {
 			setMelding('Verwijder eerst alle ' . $count . ' draadjes van dit deelforum uit de database!', -1);
@@ -420,7 +420,7 @@ class ForumController {
 	 * @throws CsrException
 	 */
 	public function verbergen(int $draad_id) {
-		$draad = ForumDradenModel::get($draad_id);
+		$draad = $this->forumDradenModel::get($draad_id);
 		if (!$draad->magVerbergen()) {
 			throw new CsrGebruikerException('Onderwerp mag niet verborgen worden');
 		}
@@ -441,7 +441,7 @@ class ForumController {
 	 * @throws CsrException
 	 */
 	public function tonen(int $draad_id) {
-		$draad = ForumDradenModel::get($draad_id);
+		$draad = $this->forumDradenModel::get($draad_id);
 		if (!$draad->isVerborgen()) {
 			throw new CsrGebruikerException('Onderwerp is niet verborgen');
 		}
@@ -470,7 +470,7 @@ class ForumController {
 	 * @throws CsrException
 	 */
 	public function meldingsniveau(int $draad_id, $niveau) {
-		$draad = ForumDradenModel::get($draad_id);
+		$draad = $this->forumDradenModel::get($draad_id);
 		if (!$draad || !$draad->magLezen() || !$draad->magMeldingKrijgen()) {
 			throw new CsrToegangException('Onderwerp mag geen melding voor ontvangen worden');
 		}
@@ -492,7 +492,7 @@ class ForumController {
 	 * @throws CsrException
 	 */
 	public function deelmelding(int $forum_id, $niveau) {
-		$deel = ForumDelenModel::get($forum_id);
+		$deel = $this->forumDelenModel::get($forum_id);
 		if (!$deel || !$deel->magLezen() || !$deel->magMeldingKrijgen()) {
 			throw new CsrToegangException('Deel mag geen melding voor ontvangen worden');
 		}
@@ -510,7 +510,7 @@ class ForumController {
 	 * @throws CsrGebruikerException
 	 */
 	public function bladwijzer(int $draad_id) {
-		$draad = ForumDradenModel::get($draad_id);
+		$draad = $this->forumDradenModel::get($draad_id);
 		$timestamp = (int)filter_input(INPUT_POST, 'timestamp', FILTER_SANITIZE_NUMBER_INT);
 		if ($this->forumDradenGelezenModel->setWanneerGelezenDoorLid($draad, $timestamp - 1)) {
 			echo '<img id="timestamp' . $timestamp . '" src="/plaetjes/famfamfam/tick.png" class="icon" title="Bladwijzer succesvol geplaatst">';
@@ -529,7 +529,7 @@ class ForumController {
 	 * @throws CsrToegangException
 	 */
 	public function wijzigen(int $draad_id, $property) {
-		$draad = ForumDradenModel::get($draad_id);
+		$draad = $this->forumDradenModel::get($draad_id);
 		// gedeelde moderators mogen dit niet
 		if (!$draad->getForumDeel()->magModereren()) {
 			throw new CsrToegangException();
@@ -583,11 +583,11 @@ class ForumController {
 	 * @throws CsrToegangException
 	 */
 	public function posten(int $forum_id, $draad_id = null) {
-		$deel = ForumDelenModel::get($forum_id);
+		$deel = $this->forumDelenModel::get($forum_id);
 		$draad = null;
 		// post in bestaand draadje?
 		if ($draad_id !== null) {
-			$draad = ForumDradenModel::get($draad_id);
+			$draad = $this->forumDradenModel::get($draad_id);
 
 			// check draad in forum deel
 			if (!$draad OR $draad->forum_id !== $deel->forum_id OR !$draad->magPosten()) {
@@ -711,7 +711,7 @@ class ForumController {
 	 * @throws CsrToegangException
 	 */
 	public function citeren($post_id) {
-		$post = ForumPostsModel::get((int)$post_id);
+		$post = $this->forumPostsModel::get((int)$post_id);
 		if (!$post->magCiteren()) {
 			throw new CsrToegangException("Mag niet citeren", 403);
 		}
@@ -725,7 +725,7 @@ class ForumController {
 	 * @throws CsrToegangException
 	 */
 	public function tekst($post_id) {
-		$post = ForumPostsModel::get((int)$post_id);
+		$post = $this->forumPostsModel::get((int)$post_id);
 		if (!$post->magBewerken()) {
 			throw new CsrToegangException("Mag niet berwerken", 403);
 		}
@@ -740,7 +740,7 @@ class ForumController {
 	 * @throws CsrGebruikerException
 	 */
 	public function bewerken($post_id) {
-		$post = ForumPostsModel::get((int)$post_id);
+		$post = $this->forumPostsModel::get((int)$post_id);
 		if (!$post->magBewerken()) {
 			throw new CsrToegangException("Mag niet bewerken", 403);
 		}
@@ -758,7 +758,7 @@ class ForumController {
 	 * @throws CsrGebruikerException
 	 */
 	public function verplaatsen($post_id) {
-		$post = ForumPostsModel::get((int)$post_id);
+		$post = $this->forumPostsModel::get((int)$post_id);
 		$oudDraad = $post->getForumDraad();
 		if (!$oudDraad->magModereren()) {
 			throw new CsrToegangException("Geen moderator", 403);
@@ -780,7 +780,7 @@ class ForumController {
 	 * @throws CsrGebruikerException
 	 */
 	public function verwijderen($post_id) {
-		$post = ForumPostsModel::get((int)$post_id);
+		$post = $this->forumPostsModel::get((int)$post_id);
 		if (!$post->getForumDraad()->magModereren()) {
 			throw new CsrToegangException("Geen moderator", 403);
 		}
@@ -795,7 +795,7 @@ class ForumController {
 	 * @throws CsrGebruikerException
 	 */
 	public function offtopic($post_id) {
-		$post = ForumPostsModel::get((int)$post_id);
+		$post = $this->forumPostsModel::get((int)$post_id);
 		if (!$post->getForumDraad()->magModereren()) {
 			throw new CsrToegangException("Geen moderator", 403);
 		}
@@ -810,7 +810,7 @@ class ForumController {
 	 * @throws CsrGebruikerException
 	 */
 	public function goedkeuren($post_id) {
-		$post = ForumPostsModel::get((int)$post_id);
+		$post = $this->forumPostsModel::get((int)$post_id);
 		if (!$post->getForumDraad()->magModereren()) {
 			throw new CsrToegangException("Geen moderator", 403);
 		}
@@ -831,10 +831,10 @@ class ForumController {
 		$concept = trim(filter_input(INPUT_POST, 'forumBericht', FILTER_UNSAFE_RAW));
 		$ping = filter_input(INPUT_POST, 'ping', FILTER_SANITIZE_STRING);
 
-		$deel = ForumDelenModel::get((int)$forum_id);
+		$deel = $this->forumDelenModel::get((int)$forum_id);
 		// bestaand draadje?
 		if ($draad_id !== null) {
-			$draad = ForumDradenModel::get((int)$draad_id);
+			$draad = $this->forumDradenModel::get((int)$draad_id);
 			$draad_id = $draad->draad_id;
 			// check draad in forum deel
 			if (!$draad OR $draad->forum_id !== $deel->forum_id OR !$draad->magPosten()) {

--- a/lib/controller/PeilingenController.class.php
+++ b/lib/controller/PeilingenController.class.php
@@ -2,10 +2,8 @@
 
 namespace CsrDelft\controller;
 
-use CsrDelft\common\CsrException;
 use CsrDelft\common\CsrGebruikerException;
-use CsrDelft\common\CsrToegangException;
-use CsrDelft\controller\framework\AclController;
+use CsrDelft\controller\framework\QueryParamTrait;
 use CsrDelft\model\entity\peilingen\Peiling;
 use CsrDelft\model\peilingen\PeilingenLogic;
 use CsrDelft\model\peilingen\PeilingenModel;
@@ -19,41 +17,18 @@ use CsrDelft\view\View;
 
 /**
  * @author G.J.W. Oolbekkink <g.j.w.oolbekkink@gmail.com>
- *
- * @property PeilingenModel $model
  */
-class PeilingenController extends AclController {
+class PeilingenController {
+	use QueryParamTrait;
 
-	/**
-	 * @var string
-	 */
-	private $query;
+	/** @var PeilingenModel */
+	private $peilingenModel;
+	/** @var PeilingenLogic */
+	private $peilingenLogic;
 
-	public function __construct($query) {
-		parent::__construct($query, PeilingenModel::instance());
-		if ($this->getMethod() == 'GET') {
-			$this->acl = array(
-				'beheer' => P_PEILING_EDIT,
-				'opties' => P_PEILING_EDIT,
-				'verwijderen' => P_PEILING_MOD,
-			);
-		} else {
-			$this->acl = array(
-				'beheer' => P_PEILING_EDIT,
-				'stem' => P_PEILING_VOTE,
-				'bewerken' => P_PEILING_EDIT,
-				'nieuw' => P_PEILING_EDIT,
-				'verwijderen' => P_PEILING_MOD,
-				'opties' => P_PEILING_VOTE,
-			);
-		}
-		$this->query = $query;
-	}
-
-	public function performAction(array $args = array()) {
-		$this->action = $this->getParam(2);
-		$args = $this->getParams(3);
-		$this->view = parent::performAction($args);
+	public function __construct() {
+		$this->peilingenModel = PeilingenModel::instance();
+		$this->peilingenLogic = PeilingenLogic::instance();
 	}
 
 	/**
@@ -61,40 +36,33 @@ class PeilingenController extends AclController {
 	 * @return View
 	 * @throws CsrGebruikerException
 	 */
-	public function GET_beheer($id = null) {
+	public function table($id = null) {
 		// Laat een modal zien als een specifieke peiling bewerkt wordt
 		if ($id) {
 			$table = new PeilingTable();
-			$peiling = $this->model->find('id = ?', [$id])->fetch();
+			$peiling = $this->peilingenModel->find('id = ?', [$id])->fetch();
 			$table->setSearch($peiling->titel);
 			$form = new PeilingForm($peiling, false);
 			$form->setDataTableId($table->getDataTableId());
 
-			return view('default', [
-				'titel' => 'Peilingen beheer',
-				'content' => $table,
-				'modal' => $form
-			]);
+			return view('default', ['content' => $table, 'modal' => $form]);
 		} else {
-			return view('default', [
-				'titel' => 'Peilingen beheer',
-				'content' => new PeilingTable(),
-			]);
+			return view('default', ['content' => new PeilingTable()]);
 		}
 	}
 
 	/**
 	 * @return View
 	 */
-	public function POST_beheer() {
-		return new PeilingResponse($this->model->getPeilingenVoorBeheer());
+	public function lijst() {
+		return new PeilingResponse($this->peilingenModel->getPeilingenVoorBeheer());
 	}
 
 	/**
 	 * @return View
 	 * @throws CsrGebruikerException
 	 */
-	public function POST_nieuw() {
+	public function nieuw() {
 		$peiling = new Peiling();
 		$form = new PeilingForm($peiling, true);
 
@@ -103,7 +71,7 @@ class PeilingenController extends AclController {
 			$peiling->eigenaar = LoginModel::getUid();
 			$peiling->mag_bewerken = false;
 
-			$peiling->id = $this->model->create($form->getModel());
+			$peiling->id = $this->peilingenModel->create($form->getModel());
 			return new PeilingResponse([$peiling]);
 		}
 
@@ -114,13 +82,13 @@ class PeilingenController extends AclController {
 	 * @return View
 	 * @throws CsrGebruikerException
 	 */
-	public function POST_bewerken() {
-		$selection = filter_input(INPUT_POST, 'DataTableSelection', FILTER_SANITIZE_STRING, FILTER_FORCE_ARRAY);
+	public function bewerken() {
+		$selection = $this->getDataTableSelection();
 
 		if ($selection) {
-			$peiling = $this->model->retrieveByUUID($selection[0]);
+			$peiling = $this->peilingenModel->retrieveByUUID($selection[0]);
 
-			if (!$this->model->magBewerken($peiling)) {
+			if (!$this->peilingenModel->magBewerken($peiling)) {
 				throw new CsrGebruikerException('Je mag deze peiling niet bewerken!');
 			}
 		} else {
@@ -132,7 +100,7 @@ class PeilingenController extends AclController {
 		if ($form->isPosted() && $form->validate()) {
 			$peiling = $form->getModel();
 
-			$this->model->update($peiling);
+			$this->peilingenModel->update($peiling);
 			return new PeilingResponse([$peiling]);
 		}
 
@@ -141,25 +109,12 @@ class PeilingenController extends AclController {
 
 	/**
 	 * @return View
-	 * @throws CsrException
-	 * @throws CsrGebruikerException
-	 * @throws CsrToegangException
-	 */
-	public function opties() {
-		$router = new PeilingOptiesController($this->query);
-		$router->performAction();
-
-		return $router->view;
-	}
-
-	/**
-	 * @return View
 	 */
 	public function verwijderen() {
-		$selection = filter_input(INPUT_POST, 'DataTableSelection', FILTER_SANITIZE_STRING, FILTER_FORCE_ARRAY);
-		$peiling = $this->model->retrieveByUUID($selection[0]);
+		$selection = $this->getDataTableSelection();
+		$peiling = $this->peilingenModel->retrieveByUUID($selection[0]);
 
-		$this->model->delete($peiling);
+		$this->peilingenModel->delete($peiling);
 
 		return new RemoveRowsResponse([$peiling]);
 	}
@@ -169,12 +124,9 @@ class PeilingenController extends AclController {
 	 * @return View
 	 */
 	public function stem($id) {
-		$inputJSON = file_get_contents('php://input');
-		$input = json_decode($inputJSON, TRUE);
+		$ids = filter_var_array($this->getPost('opties'), FILTER_VALIDATE_INT);
 
-		$ids = filter_var_array($input['opties'], FILTER_VALIDATE_INT);
-
-		if(PeilingenLogic::instance()->stem($id, $ids, LoginModel::getUid())) {
+		if($this->peilingenLogic->stem($id, $ids, LoginModel::getUid())) {
 			return new JsonResponse(true);
 		} else {
 			return new JsonResponse(false, 400);

--- a/lib/controller/framework/Controller.abstract.php
+++ b/lib/controller/framework/Controller.abstract.php
@@ -61,10 +61,6 @@ abstract class Controller {
 		$this->methods = $methods;
 	}
 
-	public function getMethod() {
-		return $_SERVER['REQUEST_METHOD'];
-	}
-
 	public function getModel() {
 		return $this->model;
 	}

--- a/lib/controller/framework/Controller.abstract.php
+++ b/lib/controller/framework/Controller.abstract.php
@@ -27,7 +27,7 @@ use CsrDelft\view\View;
  *
  */
 abstract class Controller {
-
+	use QueryParamTrait;
 	/**
 	 * Data model
 	 * @var PersistenceModel
@@ -55,116 +55,10 @@ abstract class Controller {
 	 * @var array
 	 */
 	protected $csrfUnsafe = [];
-	/**
-	 * Query broken down to positional (REST) parameters
-	 * @var array
-	 */
-	private $queryparts;
-	/**
-	 * Query broken down to named (KVP) parameters
-	 * @var array
-	 */
-	private $kvp = array();
-	private $postVariables;
 
 	public function __construct($query, $model, $methods = array('GET', 'POST')) {
 		$this->model = $model;
 		$this->methods = $methods;
-
-		// split into REST and KVP query part
-		$queryparts = explode('?', $query, 2);
-
-		// parse REST query
-		$this->queryparts = explode('/', $queryparts[0]);
-
-		// parse KVP query
-		if (count($queryparts) > 1) {
-
-			// split into key-value-pairs
-			$parts = explode('&', $queryparts[1]);
-			foreach ($parts as $part) {
-
-				// split key-value-pair
-				$kvp = explode('=', $part, 2);
-				$key = urldecode($kvp[0]);
-				if (count($kvp) > 1) {
-					$this->kvp[$key] = urldecode($kvp[1]);
-				} else {
-					$this->kvp[$key] = $key;
-				}
-			}
-		}
-
-		// Filter input kan er niet mee overweg als de body in json formaat is axios stuurt standaard in json formaat.
-		$filter_input = filter_input(INPUT_SERVER, 'CONTENT_TYPE', FILTER_SANITIZE_STRING);
-		if (startsWith($filter_input, 'application/json')) {
-			$body = json_decode(file_get_contents('php://input'), true);
-			$this->postVariables = $body;
-		}
-	}
-
-	protected function getPost($key) {
-		if (isset($this->postVariables[$key])) {
-			return $this->postVariables[$key];
-		}
-
-		return filter_input(INPUT_POST, $key, FILTER_SANITIZE_STRING);
-	}
-
-	/**
-	 * REST: positional parameters
-	 * KVP: named parameters
-	 *
-	 * @param string|int $key
-	 * @return boolean
-	 */
-	protected function hasParam($key) {
-		// don't use empty() because 0 is allowed
-		if (isset($this->queryparts[$key]) AND $this->queryparts[$key] !== '') {
-			return true;
-		} elseif (isset($this->kvp[$key]) AND $this->kvp[$key] !== '') {
-			return true;
-		}
-		return false;
-	}
-
-	/**
-	 * REST: positional parameters
-	 * KVP: named parameters
-	 *
-	 * @param string|int $key
-	 * @return string
-	 */
-	protected function getParam($key) {
-		if (array_key_exists($key, $this->kvp)) {
-			return $this->kvp[$key];
-		}
-		return $this->queryparts[$key];
-	}
-
-	/**
-	 * Return GET query params.
-	 *
-	 * @return string[]
-	 */
-	protected function getQueryParams() {
-		return $this->kvp;
-	}
-
-	/**
-	 * Return REST query paramter values from $num onwards.
-	 *
-	 * @param int $num skip params before this
-	 * @return array
-	 */
-	protected function getParams($num = 0) {
-		$params = array_values($this->queryparts);
-		for ($i = 0; $i < $num; $i++) {
-			if (isset($params[$i])) {
-				unset($params[$i]);
-			}
-		}
-		return $params;
 	}
 
 	public function getMethod() {

--- a/lib/controller/framework/QueryParamTrait.php
+++ b/lib/controller/framework/QueryParamTrait.php
@@ -27,6 +27,13 @@ trait QueryParamTrait {
 		return $_SERVER['REQUEST_METHOD'];
 	}
 
+	/**
+	 * @return string[]
+	 */
+	protected function getDataTableSelection() {
+		return filter_input(INPUT_POST, 'DataTableSelection', FILTER_SANITIZE_STRING, FILTER_FORCE_ARRAY);
+	}
+
 	protected function getPost($key) {
 		if (!$this->initialized) {
 			$this->init();

--- a/lib/controller/framework/QueryParamTrait.php
+++ b/lib/controller/framework/QueryParamTrait.php
@@ -57,6 +57,10 @@ trait QueryParamTrait {
 		}
 	}
 
+	protected function getMethod() {
+		return $_SERVER['REQUEST_METHOD'];
+	}
+
 	protected function getPost($key) {
 		if (!$this->initialized) $this->init();
 

--- a/lib/controller/framework/QueryParamTrait.php
+++ b/lib/controller/framework/QueryParamTrait.php
@@ -1,0 +1,133 @@
+<?php
+
+
+namespace CsrDelft\controller\framework;
+
+/**
+ * Hulpdingen om query params uit te lezen.
+ *
+ * @package CsrDelft\controller\framework
+ */
+trait QueryParamTrait {
+	/**
+	 * Query broken down to positional (REST) parameters
+	 * @var array
+	 */
+	private $queryparts;
+	/**
+	 * Query broken down to named (KVP) parameters
+	 * @var array
+	 */
+	private $kvp = array();
+	private $postVariables;
+
+	private $initialized = false;
+
+	private function init() {
+		$this->initialized = true;
+		// split into REST and KVP query part
+		$queryparts = explode('?', REQUEST_URI, 2);
+
+		// parse REST query
+		$this->queryparts = explode('/', $queryparts[0]);
+
+		// parse KVP query
+		if (count($queryparts) > 1) {
+
+			// split into key-value-pairs
+			$parts = explode('&', $queryparts[1]);
+			foreach ($parts as $part) {
+
+				// split key-value-pair
+				$kvp = explode('=', $part, 2);
+				$key = urldecode($kvp[0]);
+				if (count($kvp) > 1) {
+					$this->kvp[$key] = urldecode($kvp[1]);
+				} else {
+					$this->kvp[$key] = $key;
+				}
+			}
+		}
+
+		// Filter input kan er niet mee overweg als de body in json formaat is axios stuurt standaard in json formaat.
+		$filter_input = filter_input(INPUT_SERVER, 'CONTENT_TYPE', FILTER_SANITIZE_STRING);
+		if (startsWith($filter_input, 'application/json')) {
+			$body = json_decode(file_get_contents('php://input'), true);
+			$this->postVariables = $body;
+		}
+	}
+
+	protected function getPost($key) {
+		if (!$this->initialized) $this->init();
+
+		if (isset($this->postVariables[$key])) {
+			return $this->postVariables[$key];
+		}
+
+		return filter_input(INPUT_POST, $key, FILTER_SANITIZE_STRING);
+	}
+
+	/**
+	 * REST: positional parameters
+	 * KVP: named parameters
+	 *
+	 * @param string|int $key
+	 * @return boolean
+	 */
+	protected function hasParam($key) {
+		if (!$this->initialized) $this->init();
+
+		// don't use empty() because 0 is allowed
+		if (isset($this->queryparts[$key]) AND $this->queryparts[$key] !== '') {
+			return true;
+		} elseif (isset($this->kvp[$key]) AND $this->kvp[$key] !== '') {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * REST: positional parameters
+	 * KVP: named parameters
+	 *
+	 * @param string|int $key
+	 * @return string
+	 */
+	protected function getParam($key) {
+		if (!$this->initialized) $this->init();
+
+		if (array_key_exists($key, $this->kvp)) {
+			return $this->kvp[$key];
+		}
+		return $this->queryparts[$key];
+	}
+
+	/**
+	 * Return GET query params.
+	 *
+	 * @return string[]
+	 */
+	protected function getQueryParams() {
+		if (!$this->initialized) $this->init();
+
+		return $this->kvp;
+	}
+
+	/**
+	 * Return REST query paramter values from $num onwards.
+	 *
+	 * @param int $num skip params before this
+	 * @return array
+	 */
+	protected function getParams($num = 0) {
+		if (!$this->initialized) $this->init();
+
+		$params = array_values($this->queryparts);
+		for ($i = 0; $i < $num; $i++) {
+			if (isset($params[$i])) {
+				unset($params[$i]);
+			}
+		}
+		return $params;
+	}
+}

--- a/lib/controller/framework/QueryParamTrait.php
+++ b/lib/controller/framework/QueryParamTrait.php
@@ -57,7 +57,7 @@ trait QueryParamTrait {
 		}
 	}
 
-	protected function getMethod() {
+	public function getMethod() {
 		return $_SERVER['REQUEST_METHOD'];
 	}
 

--- a/lib/controller/framework/QueryParamTrait.php
+++ b/lib/controller/framework/QueryParamTrait.php
@@ -23,6 +23,22 @@ trait QueryParamTrait {
 
 	private $initialized = false;
 
+	public function getMethod() {
+		return $_SERVER['REQUEST_METHOD'];
+	}
+
+	protected function getPost($key) {
+		if (!$this->initialized) {
+			$this->init();
+		}
+
+		if (isset($this->postVariables[$key])) {
+			return $this->postVariables[$key];
+		}
+
+		return filter_input(INPUT_POST, $key, FILTER_SANITIZE_STRING);
+	}
+
 	private function init() {
 		$this->initialized = true;
 		// split into REST and KVP query part
@@ -57,20 +73,6 @@ trait QueryParamTrait {
 		}
 	}
 
-	public function getMethod() {
-		return $_SERVER['REQUEST_METHOD'];
-	}
-
-	protected function getPost($key) {
-		if (!$this->initialized) $this->init();
-
-		if (isset($this->postVariables[$key])) {
-			return $this->postVariables[$key];
-		}
-
-		return filter_input(INPUT_POST, $key, FILTER_SANITIZE_STRING);
-	}
-
 	/**
 	 * REST: positional parameters
 	 * KVP: named parameters
@@ -79,15 +81,13 @@ trait QueryParamTrait {
 	 * @return boolean
 	 */
 	protected function hasParam($key) {
-		if (!$this->initialized) $this->init();
+		if (!$this->initialized) {
+			$this->init();
+		}
 
 		// don't use empty() because 0 is allowed
-		if (isset($this->queryparts[$key]) AND $this->queryparts[$key] !== '') {
-			return true;
-		} elseif (isset($this->kvp[$key]) AND $this->kvp[$key] !== '') {
-			return true;
-		}
-		return false;
+		return (isset($this->queryparts[$key]) && $this->queryparts[$key] !== '')
+			|| (isset($this->kvp[$key]) && $this->kvp[$key] !== '');
 	}
 
 	/**
@@ -98,7 +98,9 @@ trait QueryParamTrait {
 	 * @return string
 	 */
 	protected function getParam($key) {
-		if (!$this->initialized) $this->init();
+		if (!$this->initialized) {
+			$this->init();
+		}
 
 		if (array_key_exists($key, $this->kvp)) {
 			return $this->kvp[$key];
@@ -112,7 +114,9 @@ trait QueryParamTrait {
 	 * @return string[]
 	 */
 	protected function getQueryParams() {
-		if (!$this->initialized) $this->init();
+		if (!$this->initialized) {
+			$this->init();
+		}
 
 		return $this->kvp;
 	}
@@ -124,7 +128,9 @@ trait QueryParamTrait {
 	 * @return array
 	 */
 	protected function getParams($num = 0) {
-		if (!$this->initialized) $this->init();
+		if (!$this->initialized) {
+			$this->init();
+		}
 
 		$params = array_values($this->queryparts);
 		for ($i = 0; $i < $num; $i++) {

--- a/lib/view/documenten/DocumentBewerkenForm.php
+++ b/lib/view/documenten/DocumentBewerkenForm.php
@@ -24,7 +24,7 @@ class DocumentBewerkenForm extends Formulier {
 		$fields[] = new RequiredTextField('naam', $document->naam, 'Documentnaam');
 		$fields['rechten'] = new RechtenField('leesrechten', $document->leesrechten, 'Leesrechten');
 		$fields['rechten']->readonly = true;
-		$fields[] = new FormDefaultKnoppen('/documenten/');
+		$fields[] = new FormDefaultKnoppen('/documenten');
 
 		$this->addFields($fields);
 	}

--- a/lib/view/documenten/DocumentToevoegenForm.php
+++ b/lib/view/documenten/DocumentToevoegenForm.php
@@ -39,7 +39,7 @@ class DocumentToevoegenForm extends Formulier {
 		$fields[] = $this->uploader = new RequiredFileField('document', 'Document', $this->model, $map);
 		$fields['rechten'] = new RechtenField('leesrechten', $this->model->leesrechten, 'Leesrechten');
 		$fields['rechten']->readonly = true;
-		$fields[] = new FormDefaultKnoppen('/documenten/');
+		$fields[] = new FormDefaultKnoppen('/documenten');
 
 		$this->addFields($fields);
 	}

--- a/lib/view/formulier/invoervelden/ZoekField.php
+++ b/lib/view/formulier/invoervelden/ZoekField.php
@@ -70,7 +70,7 @@ JS;
 			}
 
 			if (LidInstellingenModel::get('zoeken', 'documenten') === 'ja') {
-				$this->suggestions['Documenten'] = '/documenten/zoeken/?q=';
+				$this->suggestions['Documenten'] = '/documenten/zoeken?q=';
 			}
 
 			if (LidInstellingenModel::get('zoeken', 'boeken') === 'ja') {

--- a/resources/assets/js/context.ts
+++ b/resources/assets/js/context.ts
@@ -56,7 +56,7 @@ export function domUpdate(this: HTMLElement | void, htmlString: string|object) {
 		if (target.length === 1) {
 			if ($element.hasClass('remove')) {
 				target.effect('fade', {}, 400, () => {
-					$element.remove();
+					target.remove();
 				});
 			} else {
 				target.replaceWith($element.show().get()).effect('highlight');

--- a/resources/assets/js/formulier.ts
+++ b/resources/assets/js/formulier.ts
@@ -131,6 +131,16 @@ export function formSubmit(event: Event) {
 			}
 		}
 
+		if (form.hasClass('ModalForm')) {
+			done = (response: any) => {
+				if (typeof response === 'string') {
+					domUpdate(response);
+				} else {
+					modalClose();
+				}
+			};
+		}
+
 		if (form.hasClass('DataTableResponse')) {
 
 			const tableId = form.attr('data-tableid')!;

--- a/resources/views/documenten/categorie.blade.php
+++ b/resources/views/documenten/categorie.blade.php
@@ -11,13 +11,13 @@ Documenten in categorie: {{ $categorie->naam }}
 @section('content')
 	<div id="controls">
 		@can(P_DOCS_MOD)
-			<a class="btn" href="/documenten/toevoegen/?catID={{$categorie->id}}">@icon('toevoegen') Toevoegen</a>
+			<a class="btn" href="/documenten/toevoegen?catID={{$categorie->id}}">@icon('toevoegen') Toevoegen</a>
 		@endcan
 	</div>
 
 	<h1>{{$categorie->naam}}</h1>
 
-	<table id="documentencategorie" class="documenten">
+	<table id="documentencategorie" class="table table-striped">
 		<thead>
 		<tr>
 			<th>Document</th>

--- a/resources/views/documenten/documenten.blade.php
+++ b/resources/views/documenten/documenten.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 	<div id="controls">
 		@can(P_DOCS_MOD)
-			<a class="btn" href="/documenten/toevoegen">@icon('toevoegen') Toevoegen</a>
+			<a class="btn post" href="/documenten/toevoegen">@icon('toevoegen') Toevoegen</a>
 		@endcan
 	</div>
 
@@ -13,7 +13,7 @@
 
 	<h1>Documenten</h1>
 
-	<table id="documenten" class="documenten">
+	<table id="documenten" class="table table-striped">
 		<thead>
 		<tr>
 			<th>Document</th>
@@ -26,18 +26,18 @@
 
 		@forelse($categorieen as $categorie)
 			<tbody>
-			<tr>
-				<th colspan="5">
-					<a href="/documenten/categorie/{{$categorie->id}}/" title="Alle documenten in {{$categorie->naam}}">
+			<tr class="table-primary">
+				<td colspan="5">
+					<a href="/documenten/categorie/{{$categorie->id}}" title="Alle documenten in {{$categorie->naam}}">
 						{{ $categorie->naam }}
 					</a>
 					@can(P_DOCS_MOD)
-						<a class="toevoegen" href="/documenten/toevoegen/?catID={{$categorie->id}}"
+						<a class="toevoegen post float-right" href="/documenten/toevoegen?catID={{$categorie->id}}"
 							 title="Document toevoegen in categorie: {{$categorie->naam}}">
 							@icon('toevoegen')
 						</a>
 					@endcan
-				</th>
+				</td>
 			</tr>
 			@forelse($model->getRecent($categorie, 5) as $document)
 				@include('documenten.documentregel', ['document' => $document])

--- a/resources/views/documenten/documentregel.blade.php
+++ b/resources/views/documenten/documentregel.blade.php
@@ -1,4 +1,4 @@
-<tr class="document">
+<tr class="document" id="document-{{ $document->id }}">
 	<td>
 		@if($document->hasFile())
 			<a href="{{$document->getUrl()}}" target="_blank">
@@ -11,11 +11,11 @@
 		@endif
 
 		@if($document->magVerwijderen())
-			<a class="verwijderen" href="/documenten/verwijderen/{{$document->id}}" title="Document verwijderen"
+			<a class="verwijderen mr-2 post float-right" href="/documenten/verwijderen/{{$document->id}}" title="Document verwijderen"
 				 onclick="return confirm('Weet u zeker dat u dit document wilt verwijderen')">@icon('verwijderen')</a>
 		@endif
 		@if($document->magBewerken())
-			<a class="bewerken" href="/documenten/bewerken/{{$document->id}}"
+			<a class="bewerken mr-2 float-right" href="/documenten/bewerken/{{$document->id}}"
 				 title="Document bewerken">@icon('bewerken')</a>
 		@endif
 	</td>


### PR DESCRIPTION
Routes zijn gedefinieerd in `lib/config/routes.yaml` en `lib/config/routes/*.yaml`

Controllers hoeven niets te extenden. Ik heb de query param meuk uit de abstracte controller gesloopt en in een trait geplaatst.

Zolang dingen nog in `htdocs/.htaccess` staan worden ze op de 'oude' manier geroute.