### PR TITLE
iCal-activiteiten als bezet

### DIFF
--- a/lib/config/instellingen/lid_instelling.yaml
+++ b/lib/config/instellingen/lid_instelling.yaml
@@ -19,6 +19,12 @@ instellingen:
       opties: ['ja', 'nee']
       default: 'ja'
       beschrijving: 'Geef verjaardagen weer in de ge&iuml;mporteerde agenda (iCal) in je eigen systeem.'
+    transparantICal:
+      titel: 'iCal tonen als vrij'
+      type: Enumeration
+      opties: ['ja', 'nee']
+      default: 'nee'
+      beschrijving: 'Toon alle agenda-items als vrij.'
     toonMaaltijden:
       titel: 'Maaltijden weergeven'
       type: Enumeration

--- a/lib/model/entity/agenda/AgendaItem.php
+++ b/lib/model/entity/agenda/AgendaItem.php
@@ -131,4 +131,9 @@ class AgendaItem extends PersistentEntity implements Agendeerbaar {
 		}
 		return false;
 	}
+
+	public function isTransparant() {
+		// Toon als transparant (vrij) als lid dat wil of activiteit hele dag(en) duurt
+		return lid_instelling('agenda', 'transparantICal') === 'ja' || $this->isHeledag();
+	}
 }

--- a/lib/model/entity/agenda/Agendeerbaar.php
+++ b/lib/model/entity/agenda/Agendeerbaar.php
@@ -33,4 +33,6 @@ interface Agendeerbaar {
 	public function getUrl();
 
 	public function isHeledag();
+
+	public function isTransparant();
 }

--- a/lib/model/entity/groepen/Activiteit.php
+++ b/lib/model/entity/groepen/Activiteit.php
@@ -142,4 +142,10 @@ class Activiteit extends Ketzer implements Agendeerbaar {
 		return $begin == '00:00' AND ($eind == '23:59' OR $eind == '00:00');
 	}
 
+	public function isTransparant() {
+		// Toon als transparant (vrij) als lid dat wil, activiteit hele dag(en) duurt of lid niet ingeketzt is
+		return lid_instelling('agenda', 'transparantICal') === 'ja' ||
+			$this->isHeledag() ||
+			$this->getLid(LoginModel::getUid()) === false;
+	}
 }

--- a/lib/model/entity/maalcie/ArchiefMaaltijd.php
+++ b/lib/model/entity/maalcie/ArchiefMaaltijd.php
@@ -83,6 +83,10 @@ class ArchiefMaaltijd extends PersistentEntity implements Agendeerbaar {
 		return false;
 	}
 
+	public function isTransparant() {
+		return true;
+	}
+
 	protected static $table_name = 'mlt_archief';
 	protected static $persistent_attributes = array(
 		'maaltijd_id' => array(T::Integer, false, 'auto_increment'),
@@ -100,5 +104,4 @@ class ArchiefMaaltijd extends PersistentEntity implements Agendeerbaar {
 		$json['aanmeldingen'] = count($this->getAanmeldingenArray());
 		return $json;
 	}
-
 }

--- a/lib/model/entity/maalcie/CorveeTaak.php
+++ b/lib/model/entity/maalcie/CorveeTaak.php
@@ -191,6 +191,10 @@ class CorveeTaak extends PersistentEntity implements Agendeerbaar {
 		return true;
 	}
 
+	public function isTransparant() {
+		return true;
+	}
+
 	protected static $table_name = 'crv_taken';
 	protected static $persistent_attributes = array(
 		'taak_id' => array(T::Integer, false, 'auto_increment'),

--- a/lib/model/entity/maalcie/Maaltijd.php
+++ b/lib/model/entity/maalcie/Maaltijd.php
@@ -11,6 +11,7 @@ use CsrDelft\model\maalcie\CorveeTakenModel;
 use CsrDelft\model\maalcie\FunctiesModel;
 use CsrDelft\model\maalcie\MaaltijdAanmeldingenModel;
 use CsrDelft\model\maalcie\MaaltijdRepetitiesModel;
+use CsrDelft\model\security\LoginModel;
 use CsrDelft\Orm\Entity\PersistentEntity;
 use CsrDelft\Orm\Entity\T;
 
@@ -156,6 +157,12 @@ class Maaltijd extends PersistentEntity implements Agendeerbaar, HeeftAanmeldLim
 
 	public function isHeledag() {
 		return false;
+	}
+
+	public function isTransparant() {
+		// Toon als transparant (vrij) als lid dat wil of lid niet ingeketzt is
+		$aangemeld = MaaltijdAanmeldingenModel::instance()->getIsAangemeld($this->maaltijd_id, LoginModel::getUid());
+		return lid_instelling('agenda', 'transparantICal') === 'ja' || !$aangemeld;
 	}
 
 	// Controller ############################################################

--- a/lib/model/entity/profiel/Profiel.php
+++ b/lib/model/entity/profiel/Profiel.php
@@ -468,6 +468,10 @@ class Profiel extends PersistentEntity implements Agendeerbaar {
 		return $l . $naam . '</a>';
 	}
 
+	public function isTransparant() {
+		return true;
+	}
+
 	//einde implements Agendeerbaar
 
 	/**

--- a/resources/views/agenda/icalendar.blade.php
+++ b/resources/views/agenda/icalendar.blade.php
@@ -47,7 +47,11 @@ LOCATION:{!!escape_ical($item->getLocatie(), 9)!!}
 SEQUENCE:0
 STATUS:CONFIRMED
 SUMMARY:{!!escape_ical($item->getTitel(), 8)!!}
-TRANSP:TRANSPARENT
+@if($item->isTransparant())
+	TRANSP:TRANSPARENT
+@else
+	TRANS:OPAQUE
+@endif
 END:VEVENT
 @endforeach
 END:VCALENDAR

--- a/resources/views/agenda/icalendar.blade.php
+++ b/resources/views/agenda/icalendar.blade.php
@@ -48,9 +48,9 @@ SEQUENCE:0
 STATUS:CONFIRMED
 SUMMARY:{!!escape_ical($item->getTitel(), 8)!!}
 @if($item->isTransparant())
-	TRANSP:TRANSPARENT
+TRANSP:TRANSPARENT
 @else
-	TRANS:OPAQUE
+TRANS:OPAQUE
 @endif
 END:VEVENT
 @endforeach


### PR DESCRIPTION
Maak mogelijk om iCal-activiteiten als bezet (opaque) te tonen.
Standaard aan voor agenda-afspraken en ingeketzte activiteiten & maaltijden m.u.v. activiteiten die hele dag(en) duren.