### PR TITLE
Disallow onnodige crawlers

### DIFF
--- a/htdocs/robots.txt
+++ b/htdocs/robots.txt
@@ -2,6 +2,15 @@
 # Niet-relevante pagina's uitsluiten van indexering
 # mailto:pubcie@csrdelft.nl
 
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: magpie-crawler
+Disallow: /
+
 User-agent: *
 Disallow: /tools/
 Disallow: /forum/posten/


### PR DESCRIPTION
Zijn allemaal business intelligence bots, die ons niet echt wat kunnen
schelen. Ze zijn wel lekker hard aan het spammen met z'n allen.

Misschien ook nog fixen dat een redirect naar login een `403` pagina is, ik heb nu het idee dat bij een aantal crawlers de `/?redirect=...` in het register staat.