### PR TITLE
Courant

### DIFF
--- a/db/migrations/20191120104601_courant_compile.php
+++ b/db/migrations/20191120104601_courant_compile.php
@@ -1,0 +1,39 @@
+<?php
+
+use CsrDelft\model\CourantBerichtModel;
+use CsrDelft\model\CourantModel;
+use CsrDelft\view\courant\CourantView;
+use Phinx\Db\Adapter\MysqlAdapter;
+use Phinx\Migration\AbstractMigration;
+
+class CourantCompile extends AbstractMigration {
+	public function up() {
+		$this->table('courant')
+			->addColumn('inhoud', 'text', ['limit' => MysqlAdapter::TEXT_MEDIUM])
+			->update();
+
+		require_once 'lib/configuratie.include.php';
+
+		$courantModel = CourantModel::instance();
+		$courantBerichtModel = CourantBerichtModel::instance();
+		$couranten = $courantModel->find();
+
+		foreach ($couranten as $courant) {
+			$view = new CourantView($courant);
+
+			$courant->inhoud = $view->getHtml(false);
+
+			$courantModel->update($courant);
+
+			$berichten = $courantBerichtModel->getBerichten($courant->id);
+
+			foreach ($berichten as $bericht) {
+				$courantBerichtModel->delete($bericht);
+			}
+		}
+	}
+
+	public function down() {
+		// sorry
+	}
+}

--- a/lib/model/entity/courant/Courant.php
+++ b/lib/model/entity/courant/Courant.php
@@ -12,6 +12,7 @@ class Courant extends PersistentEntity {
 	public $id;
 	public $verzendMoment;
 	public $template;
+	public $inhoud;
 	public $verzender;
 
 	protected static $table_name = 'courant';
@@ -20,6 +21,7 @@ class Courant extends PersistentEntity {
 		'id' => [T::Integer, false, 'auto_increment'],
 		'verzendMoment' => [T::DateTime],
 		'template' => [T::String],
+		'inhoud' => [T::Text],
 		'verzender' => [T::UID],
 	];
 

--- a/lib/templates/courant/mail/courant_LustrumX.tpl
+++ b/lib/templates/courant/mail/courant_LustrumX.tpl
@@ -32,7 +32,7 @@ td{
     background-repeat: repeat-y;
 }
 .hoofdKolom{
-    margin: 0; 
+    margin: 0;
     padding: 23px 20px 0 0;
     vertical-align: top;
 }
@@ -73,7 +73,7 @@ div.p{
 }
 ul{
     margin: 0 0 0 10px; padding: 0 0 0 5px;
-    
+
 }
 .onderlijn{
     text-decoration: underline;
@@ -113,15 +113,15 @@ li{
 <h4><font size="-3" face="verdana">Inhoud</font></h4>
 <table class="inhoud">
 <tr>
-{foreach from=$indexCats item=categorie key=catKey}
+{foreach from=$catNames item=catName key=categorie}
     {if $categorie!='voorwoord' AND $categorie!='sponsor'}
         <td class="inhoudKolom" valign="top">
         <font face="verdana" size="-1">
-        <div class="inhoudKop"><b>{$catNames[$catKey]}</b></div>
+        <div class="inhoudKop"><b>{$catName}</b></div>
         <ul>
         {foreach from=$courant->getBerichten() item=bericht}
-            {if $bericht.categorie==$categorie}
-                <li><a href="#{$bericht.ID}" style="text-decoration: none;">{$bericht.titel|bbcode:"mail"}</a></li>
+            {if $bericht->categorie==$categorie}
+                <li><a href="#{$bericht->id}" style="text-decoration: none;">{$bericht->titel|bbcode:"mail"}</a></li>
             {/if}
         {/foreach}
         </ul>
@@ -133,8 +133,8 @@ li{
 </table>
 <font face="verdana" size="-1">
 {foreach from=$courant->getBerichten() item=bericht}
-    <h4><a name="{$bericht.ID}"></a>{$bericht.titel|bbcode:"mail"}</h4>
-    <div class="p">{$bericht.bericht|bbcode:"mail"}</div>
+    <h4><a name="{$bericht->id}"></a>{$bericht->titel|bbcode:"mail"}</h4>
+    <div class="p">{$bericht->bericht|bbcode:"mail"}</div>
 {/foreach}
 </font>
 </td>

--- a/lib/templates/courant/mail/courant_delphiadaily2011.tpl
+++ b/lib/templates/courant/mail/courant_delphiadaily2011.tpl
@@ -24,7 +24,7 @@ td{
 	font-face: "Adobe Garamond Pro", "Garamond", "Times", serif;
 }
 .hoofdKolom{
-	margin: 10px; 
+	margin: 10px;
 	padding: 23px 20px 0 0;
 	vertical-align: top;
 }
@@ -40,7 +40,7 @@ p{
 	color: #151515;
 	margin: 0 0 0 0;
 	padding: 10px 5px 5px 10px;
-	font-size: 16px; 
+	font-size: 16px;
 	font-face: "Adobe Garamond Pro", "Garamond", "Times", serif;
 	line-height: 1.4em;
 }
@@ -62,7 +62,7 @@ p{
 }
 ul{
 	margin: 0 0 0 10px; padding: 0 0 0 5px;
-	
+
 }
 .onderlijn{
 	text-decoration: underline;
@@ -95,15 +95,15 @@ div.citaatContainer{
 <font size="2" face="garamond"><h4>Inhoud</h4></font>
 <table class="inhoud" width="800">
 <tr>
-{foreach from=$indexCats item=categorie key=catKey}
+{foreach from=$catNames item=catName key=categorie}
 	{if $categorie!='voorwoord' AND $categorie!='sponsor'}
 		<td class="inhoudKolom" valign="top">
 		<font face="garamond" size="2">
-		<div class="inhoudKop"><b>{$catNames[$catKey]}</b></div>
+		<div class="inhoudKop"><b>{$catName}</b></div>
 		<ul>
 		{foreach from=$courant->getBerichten() item=bericht}
-			{if $bericht.categorie==$categorie}
-				<li><a href="#{$bericht.ID}" style="text-decoration: none;">{$bericht.titel|bbcode:"mail"}</a></li>
+			{if $bericht->categorie==$categorie}
+				<li><a href="#{$bericht->id}" style="text-decoration: none;">{$bericht->titel|bbcode:"mail"}</a></li>
 			{/if}
 		{/foreach}
 		</ul>
@@ -113,10 +113,10 @@ div.citaatContainer{
 {/foreach}
 </tr>
 </table>
-<font face="garamond" size="2">	
+<font face="garamond" size="2">
 {foreach from=$courant->getBerichten() item=bericht}
-	<h4><a name="{$bericht.ID}"></a>{$bericht.titel|bbcode:"mail"}</h4>
-	<p>{$bericht.bericht|bbcode:"mail"}</p>
+	<h4><a name="{$bericht->id}"></a>{$bericht->titel|bbcode:"mail"}</h4>
+	<p>{$bericht->bericht|bbcode:"mail"}</p>
 {/foreach}
 </font>
 </td>

--- a/lib/templates/courant/mail/courant_draadloos2009.tpl
+++ b/lib/templates/courant/mail/courant_draadloos2009.tpl
@@ -24,7 +24,7 @@ td{
 	font-size: 11px; font-face: verdana, arial, sans-serif;
 }
 .hoofdKolom{
-	margin: 10px; 
+	margin: 10px;
 	padding: 23px 20px 0 0;
 	vertical-align: top;
 }
@@ -63,7 +63,7 @@ p{
 }
 ul{
 	margin: 0 0 0 10px; padding: 0 0 0 5px;
-	
+
 }
 .onderlijn{
 	text-decoration: underline;
@@ -85,15 +85,15 @@ li{
 <font size="-1" face="verdana"><h4>Inhoud</h4></font>
 <table class="inhoud">
 <tr>
-{foreach from=$indexCats item=categorie key=catKey}
+{foreach from=$catNames item=catName key=categorie}
 	{if $categorie!='voorwoord' AND $categorie!='sponsor'}
 		<td class="inhoudKolom" valign="top">
 		<font face="verdana" size="-1">
-		<div class="inhoudKop"><b>{$catNames[$catKey]}</b></div>
+		<div class="inhoudKop"><b>{$catName}</b></div>
 		<ul>
 		{foreach from=$courant->getBerichten() item=bericht}
-			{if $bericht.categorie==$categorie}
-				<li><a href="#{$bericht.ID}" style="text-decoration: none;">{$bericht.titel|bbcode:"mail"}</a></li>
+			{if $bericht->categorie==$categorie}
+				<li><a href="#{$bericht->id}" style="text-decoration: none;">{$bericht->titel|bbcode:"mail"}</a></li>
 			{/if}
 		{/foreach}
 		</ul>
@@ -103,10 +103,10 @@ li{
 {/foreach}
 </tr>
 </table>
-<font face="verdana" size="-1">	
+<font face="verdana" size="-1">
 {foreach from=$courant->getBerichten() item=bericht}
-	<h4><a name="{$bericht.ID}"></a>{$bericht.titel|bbcode:"mail"}</h4>
-	<p>{$bericht.bericht|bbcode:"mail"}</p>
+	<h4><a name="{$bericht->id}"></a>{$bericht->titel|bbcode:"mail"}</h4>
+	<p>{$bericht->bericht|bbcode:"mail"}</p>
 {/foreach}
 </font>
 </td>

--- a/lib/templates/courant/mail/courant_triomphedor2011.tpl
+++ b/lib/templates/courant/mail/courant_triomphedor2011.tpl
@@ -24,7 +24,7 @@ td{
 	font-size: 11px; font-face: verdana, arial, sans-serif;
 }
 .hoofdKolom{
-	margin: 10px; 
+	margin: 10px;
 	padding: 23px 20px 0 0;
 	vertical-align: top;
 }
@@ -63,7 +63,7 @@ p{
 }
 ul{
 	margin: 0 0 0 10px; padding: 0 0 0 5px;
-	
+
 }
 .onderlijn{
 	text-decoration: underline;
@@ -85,15 +85,15 @@ li{
 <font size="-1" face="verdana"><h4>Inhoud</h4></font>
 <table class="inhoud">
 <tr>
-{foreach from=$indexCats item=categorie key=catKey}
+{foreach from=$catNames item=catName key=categorie}
 	{if $categorie!='voorwoord' AND $categorie!='sponsor'}
 		<td class="inhoudKolom" valign="top">
 		<font face="verdana" size="-1">
-		<div class="inhoudKop"><b>{$catNames[$catKey]}</b></div>
+		<div class="inhoudKop"><b>{$catName}</b></div>
 		<ul>
 		{foreach from=$courant->getBerichten() item=bericht}
-			{if $bericht.categorie==$categorie}
-				<li><a href="#{$bericht.ID}" style="text-decoration: none;">{$bericht.titel|bbcode:"mail"}</a></li>
+			{if $bericht->categorie==$categorie}
+				<li><a href="#{$bericht->id}" style="text-decoration: none;">{$bericht->titel|bbcode:"mail"}</a></li>
 			{/if}
 		{/foreach}
 		</ul>
@@ -103,10 +103,10 @@ li{
 {/foreach}
 </tr>
 </table>
-<font face="verdana" size="-1">	
+<font face="verdana" size="-1">
 {foreach from=$courant->getBerichten() item=bericht}
-	<h4><a name="{$bericht.ID}"></a>{$bericht.titel|bbcode:"mail"}</h4>
-	<p>{$bericht.bericht|bbcode:"mail"}</p>
+	<h4><a name="{$bericht->id}"></a>{$bericht->titel|bbcode:"mail"}</h4>
+	<p>{$bericht->bericht|bbcode:"mail"}</p>
 {/foreach}
 </font>
 </td>

--- a/lib/templates/courant/mail/csrmail_owee.tpl
+++ b/lib/templates/courant/mail/csrmail_owee.tpl
@@ -29,7 +29,7 @@ td{
 	background-repeat: repeat-y;
 }
 .hoofdKolom{
-	margin: 0; 
+	margin: 0;
 	padding: 23px 20px 0 0;
 	vertical-align: top;
 }
@@ -69,7 +69,7 @@ p{
 }
 ul{
 	margin: 0 0 0 10px; padding: 0 0 0 5px;
-	
+
 }
 .onderlijn{
 	text-decoration: underline;
@@ -78,7 +78,7 @@ li{
 	margin: 0 0 0 00px;
 	color: #000;
 	font-size: 11px;
-} 
+}
 a{
 	color: black;
 }
@@ -89,7 +89,7 @@ a{
 <table>
 <tr>
 <td class="Zijbalk" valign="top">
-<img src="/plaetjes/csrmail/logo_owee2007.jpg" width="150" 
+<img src="/plaetjes/csrmail/logo_owee2007.jpg" width="150"
 height="187" alt="OWee-courant" />
 </td>
 <td class="hoofdKolom">
@@ -115,9 +115,9 @@ height="187" alt="OWee-courant" />
 </tr>
 </table>
 <font face="verdana" size="-1">
-	{foreach from=$courant.getBerichten() item=bericht}
-		<h4><a name={$bericht.ID}</a>{$bericht.titel|bbcode:"mail"}</h4>
-		<p>{$bericht.bericht|bbcode:"mail"}</p>
+	{foreach from=$courant->getBerichten() item=bericht}
+		<h4><a name={$bericht->id}</a>{$bericht->titel|bbcode:"mail"}</h4>
+		<p>{$bericht->bericht|bbcode:"mail"}</p>
 	{/foreach}
 </font>
 </td>


### PR DESCRIPTION
Stapje voor de nieuwe courant en het omschrijven van de courant naar Blade. Met deze manier wordt de courant gecompileerd bij het verzenden en wordt de html die verzonden wordt over de mail in de database gezet. Zo kun je in het archief terugkijken naar een oude courant op de manier dat deze courant ooit bedoeld was. Dit haalt de zorg weg van het onderhoud aan couranttemplates die alleen geupdate moeten worden omdat het archief ze nodig heeft.

Deze pr laat de repo in een suboptimale staat achter, maar dat is nu nodig om de migratie te kunnen runnen.