### PR TITLE
Trek dependency injection verder door

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		"jacwright/restserver": "dev-master",
 		"globalcitizen/php-iban": "^2.6",
 		"robmorgan/phinx": "^0.11.1",
-		"csrdelft/orm": "1.8.4",
+		"csrdelft/orm": "1.8.5",
 		"csrdelft/bb": "1.1.6",
 		"maknz/slack": "^1.7",
 		"jakeasmith/http_build_url": "^1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3581c24f8b25e2bcc6110af0d066ece4",
+    "content-hash": "9af9d878c369be5706af45e08d4a0aaf",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -385,16 +385,16 @@
         },
         {
             "name": "csrdelft/orm",
-            "version": "v1.8.4",
+            "version": "v1.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/csrdelft/orm.git",
-                "reference": "4dc8b408dfb411323ff92dfdc82ebaf48a822b36"
+                "reference": "8a28b99112584f206bce909a95c4461b7c8337d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/csrdelft/orm/zipball/4dc8b408dfb411323ff92dfdc82ebaf48a822b36",
-                "reference": "4dc8b408dfb411323ff92dfdc82ebaf48a822b36",
+                "url": "https://api.github.com/repos/csrdelft/orm/zipball/8a28b99112584f206bce909a95c4461b7c8337d2",
+                "reference": "8a28b99112584f206bce909a95c4461b7c8337d2",
                 "shasum": ""
             },
             "require": {
@@ -429,18 +429,18 @@
                 },
                 {
                     "name": "Paul Brussee",
-                    "role": "Creator",
-                    "homepage": "https://github.com/brussee"
+                    "homepage": "https://github.com/brussee",
+                    "role": "Creator"
                 },
                 {
                     "name": "Gerben Oolbekkink",
-                    "role": "Developer",
-                    "email": "g.j.w.oolbekkink@gmail.com"
+                    "email": "g.j.w.oolbekkink@gmail.com",
+                    "role": "Developer"
                 }
             ],
             "description": "The creatively named object-relational mapping library for csrdelft.nl",
             "homepage": "https://csrdelft.github.io/orm",
-            "time": "2019-08-18T13:57:48+00:00"
+            "time": "2019-11-30T12:09:57+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -3618,16 +3618,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.4.8",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "f5bfc79c1f5bed6b2bb4ca9e49a736c2abc03e8f"
+                "reference": "97d4d94bff1b6bd9e9c5750ddbe248185ecb588b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/f5bfc79c1f5bed6b2bb4ca9e49a736c2abc03e8f",
-                "reference": "f5bfc79c1f5bed6b2bb4ca9e49a736c2abc03e8f",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/97d4d94bff1b6bd9e9c5750ddbe248185ecb588b",
+                "reference": "97d4d94bff1b6bd9e9c5750ddbe248185ecb588b",
                 "shasum": ""
             },
             "require": {
@@ -3643,7 +3643,7 @@
             "type": "composer-plugin",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 },
                 "class": "Symfony\\Flex\\Flex"
             },
@@ -3663,7 +3663,7 @@
                 }
             ],
             "description": "Composer plugin for Symfony",
-            "time": "2019-11-14T09:25:51+00:00"
+            "time": "2019-11-30T11:43:11+00:00"
         },
         {
             "name": "symfony/framework-bundle",
@@ -3954,16 +3954,16 @@
         },
         {
             "name": "symfony/polyfill-apcu",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-apcu.git",
-                "reference": "71ce80635d5dcd67772b4dda00b86068595f64d5"
+                "reference": "a8e961c841b9ec52927a87914f8820a1ad8f8116"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/71ce80635d5dcd67772b4dda00b86068595f64d5",
-                "reference": "71ce80635d5dcd67772b4dda00b86068595f64d5",
+                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/a8e961c841b9ec52927a87914f8820a1ad8f8116",
+                "reference": "a8e961c841b9ec52927a87914f8820a1ad8f8116",
                 "shasum": ""
             },
             "require": {
@@ -3972,7 +3972,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -4006,20 +4006,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
                 "shasum": ""
             },
             "require": {
@@ -4031,7 +4031,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -4064,20 +4064,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
-                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7b4aab9743c30be783b73de055d24a39cf4b954f",
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f",
                 "shasum": ""
             },
             "require": {
@@ -4089,7 +4089,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -4123,20 +4123,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T14:18:11+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "0e3b212e96a51338639d8ce175c046d7729c3403"
+                "reference": "53dd1cdf3cb986893ccf2b96665b25b3abb384f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/0e3b212e96a51338639d8ce175c046d7729c3403",
-                "reference": "0e3b212e96a51338639d8ce175c046d7729c3403",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/53dd1cdf3cb986893ccf2b96665b25b3abb384f4",
+                "reference": "53dd1cdf3cb986893ccf2b96665b25b3abb384f4",
                 "shasum": ""
             },
             "require": {
@@ -4146,7 +4146,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -4179,20 +4179,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "54b4c428a0054e254223797d2713c31e08610831"
+                "reference": "af23c7bb26a73b850840823662dda371484926c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/54b4c428a0054e254223797d2713c31e08610831",
-                "reference": "54b4c428a0054e254223797d2713c31e08610831",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/af23c7bb26a73b850840823662dda371484926c4",
+                "reference": "af23c7bb26a73b850840823662dda371484926c4",
                 "shasum": ""
             },
             "require": {
@@ -4202,7 +4202,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -4238,20 +4238,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-util",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "4317de1386717b4c22caed7725350a8887ab205c"
+                "reference": "964a67f293b66b95883a5ed918a65354fcd2258f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/4317de1386717b4c22caed7725350a8887ab205c",
-                "reference": "4317de1386717b4c22caed7725350a8887ab205c",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/964a67f293b66b95883a5ed918a65354fcd2258f",
+                "reference": "964a67f293b66b95883a5ed918a65354fcd2258f",
                 "shasum": ""
             },
             "require": {
@@ -4260,7 +4260,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -4290,7 +4290,7 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/routing",
@@ -7309,31 +7309,29 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -7355,7 +7353,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-08-24T08:43:50+00:00"
+            "time": "2019-11-24T13:36:37+00:00"
         }
     ],
     "aliases": [],

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,7 +16,7 @@ services:
 
   CsrDelft\:
     resource: '../lib'
-    exclude: '../lib/{view,config,model,common,Kernel.php}'
+    exclude: '../lib/{view,config,common,Kernel.php}'
 
   # controllers are imported separately to make sure services can be injected
   # as action arguments even if you don't extend any base controller class

--- a/lib/controller/AgendaController.php
+++ b/lib/controller/AgendaController.php
@@ -40,10 +40,37 @@ class AgendaController {
 	 * @var AgendaVerbergenRepository
 	 */
 	private $agendaVerbergenRepository;
+	/**
+	 * @var ActiviteitenModel
+	 */
+	private $activiteitenModel;
+	/**
+	 * @var CorveeTakenModel
+	 */
+	private $corveeTakenModel;
+	/**
+	 * @var MaaltijdenModel
+	 */
+	private $maaltijdenModel;
+	/**
+	 * @var ProfielModel
+	 */
+	private $profielModel;
 
-	public function __construct(AgendaRepository $agendaRepository, AgendaVerbergenRepository $agendaVerbergenRepository) {
+	public function __construct(
+		AgendaRepository $agendaRepository,
+		AgendaVerbergenRepository $agendaVerbergenRepository,
+		ActiviteitenModel $activiteitenModel,
+		CorveeTakenModel $corveeTakenModel,
+		MaaltijdenModel $maaltijdenModel,
+		ProfielModel $profielModel
+	) {
 		$this->agendaRepository = $agendaRepository;
 		$this->agendaVerbergenRepository = $agendaVerbergenRepository;
+		$this->activiteitenModel = $activiteitenModel;
+		$this->corveeTakenModel = $corveeTakenModel;
+		$this->maaltijdenModel = $maaltijdenModel;
+		$this->profielModel = $profielModel;
 	}
 
 	/**
@@ -146,7 +173,7 @@ class AgendaController {
 			$item->item_id = (int)$this->agendaRepository->create($item);
 			if ($datum === 'doorgaan') {
 				$_POST = []; // clear post values of previous input
-				setMelding('Toegevoegd: ' . $item->titel . ' (' . $item->begin_moment . ')', 1);
+				setMelding('Toegevoegd: ' . $item->titel . ' (' . $item->begin_moment->format(DATETIME_FORMAT) . ')', 1);
 				$item->item_id = null;
 				return new AgendaItemForm($item, 'toevoegen'); // fetches POST values itself
 			} else {
@@ -214,19 +241,19 @@ class AgendaController {
 		switch ($module[0]) {
 
 			case 'csrdelft':
-				$item = ProfielModel::instance()->retrieveByUUID($refuuid);
+				$item = $this->profielModel->retrieveByUUID($refuuid);
 				break;
 
 			case 'maaltijd':
-				$item = MaaltijdenModel::instance()->retrieveByUUID($refuuid);
+				$item = $this->maaltijdenModel->retrieveByUUID($refuuid);
 				break;
 
 			case 'corveetaak':
-				$item = CorveeTakenModel::instance()->retrieveByUUID($refuuid);
+				$item = $this->corveeTakenModel->retrieveByUUID($refuuid);
 				break;
 
 			case 'activiteit':
-				$item = ActiviteitenModel::instance()->retrieveByUUID($refuuid);
+				$item = $this->activiteitenModel->retrieveByUUID($refuuid);
 				break;
 
 			case 'agendaitem':

--- a/lib/controller/ForumController.php
+++ b/lib/controller/ForumController.php
@@ -38,38 +38,69 @@ use Symfony\Component\HttpFoundation\Request;
  * Controller van het forum.
  */
 class ForumController extends AbstractController {
-	/** @var DebugLogModel */
+	/**
+	 * @var DebugLogModel
+	 */
 	private $debugLogModel;
-	/** @var ForumDelenMeldingModel */
+	/**
+	 * @var ForumDelenMeldingModel
+	 */
 	private $forumDelenMeldingModel;
-	/** @var ForumDelenModel */
+	/**
+	 * @var ForumDelenModel
+	 */
 	private $forumDelenModel;
-	/** @var ForumDradenGelezenModel */
+	/**
+	 * @var ForumDradenGelezenModel
+	 */
 	private $forumDradenGelezenModel;
-	/** @var ForumDradenMeldingModel */
+	/**
+	 * @var ForumDradenMeldingModel
+	 */
 	private $forumDradenMeldingModel;
-	/** @var ForumDradenModel */
+	/**
+	 * @var ForumDradenModel
+	 */
 	private $forumDradenModel;
-	/** @var ForumDradenReagerenModel */
+	/**
+	 * @var ForumDradenReagerenModel
+	 */
 	private $forumDradenReagerenModel;
-	/** @var ForumDradenVerbergenModel */
+	/**
+	 * @var ForumDradenVerbergenModel
+	 */
 	private $forumDradenVerbergenModel;
-	/** @var ForumModel */
+	/**
+	 * @var ForumModel
+	 */
 	private $forumModel;
-	/** @var ForumPostsModel */
+	/**
+	 * @var ForumPostsModel
+	 */
 	private $forumPostsModel;
 
-	public function __construct() {
-		$this->debugLogModel = DebugLogModel::instance();
-		$this->forumDelenMeldingModel = ForumDelenMeldingModel::instance();
-		$this->forumDelenModel = ForumDelenModel::instance();
-		$this->forumDradenGelezenModel = ForumDradenGelezenModel::instance();
-		$this->forumDradenMeldingModel = ForumDradenMeldingModel::instance();
-		$this->forumDradenModel = ForumDradenModel::instance();
-		$this->forumDradenReagerenModel = ForumDradenReagerenModel::instance();
-		$this->forumDradenVerbergenModel = ForumDradenVerbergenModel::instance();
-		$this->forumModel = ForumModel::instance();
-		$this->forumPostsModel = ForumPostsModel::instance();
+	public function __construct(
+		DebugLogModel $debugLogModel,
+		ForumDelenMeldingModel $forumDelenMeldingModel,
+		ForumDelenModel $forumDelenModel,
+		ForumDradenGelezenModel $forumDradenGelezenModel,
+		ForumDradenMeldingModel $forumDradenMeldingModel,
+		ForumDradenModel $forumDradenModel,
+		ForumDradenReagerenModel $forumDradenReagerenModel,
+		ForumDradenVerbergenModel $forumDradenVerbergenModel,
+		ForumModel $forumModel,
+		ForumPostsModel $forumPostsModel
+	) {
+		$this->debugLogModel = $debugLogModel;
+		$this->forumDelenMeldingModel = $forumDelenMeldingModel;
+		$this->forumDelenModel = $forumDelenModel;
+		$this->forumDradenGelezenModel = $forumDradenGelezenModel;
+		$this->forumDradenMeldingModel = $forumDradenMeldingModel;
+		$this->forumDradenModel = $forumDradenModel;
+		$this->forumDradenReagerenModel = $forumDradenReagerenModel;
+		$this->forumDradenVerbergenModel = $forumDradenVerbergenModel;
+		$this->forumModel = $forumModel;
+		$this->forumPostsModel = $forumPostsModel;
 	}
 
 	/**

--- a/lib/controller/PeilingOptiesController.php
+++ b/lib/controller/PeilingOptiesController.php
@@ -24,9 +24,9 @@ class PeilingOptiesController extends AbstractController {
 	/** @var PeilingOptiesModel */
 	private $peilingOptiesModel;
 
-	public function __construct() {
-		$this->peilingOptiesModel = PeilingOptiesModel::instance();
-		$this->peilingenLogic = PeilingenLogic::instance();
+	public function __construct(PeilingOptiesModel $peilingOptiesModel, PeilingenLogic $peilingenLogic) {
+		$this->peilingOptiesModel = $peilingOptiesModel;
+		$this->peilingenLogic = $peilingenLogic;
 	}
 
 	public function table($id) {

--- a/lib/controller/PeilingenController.php
+++ b/lib/controller/PeilingenController.php
@@ -24,9 +24,9 @@ class PeilingenController extends AbstractController {
 	/** @var PeilingenLogic */
 	private $peilingenLogic;
 
-	public function __construct() {
-		$this->peilingenModel = PeilingenModel::instance();
-		$this->peilingenLogic = PeilingenLogic::instance();
+	public function __construct(PeilingenModel $peilingenModel, PeilingenLogic $peilingenLogic) {
+		$this->peilingenModel = $peilingenModel;
+		$this->peilingenLogic = $peilingenLogic;
 	}
 
 	/**

--- a/lib/controller/ProfielController.php
+++ b/lib/controller/ProfielController.php
@@ -47,14 +47,145 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 class ProfielController extends AbstractController {
-	private $model;
+	/**
+	 * @var ProfielModel
+	 */
+	private $profielModel;
+	/**
+	 * @var VoorkeurOpmerkingModel
+	 */
+	private $voorkeurOpmerkingModel;
+	/**
+	 * @var CommissieVoorkeurModel
+	 */
+	private $commissieVoorkeurModel;
+	/**
+	 * @var FotoTagsModel
+	 */
+	private $fotoTagsModel;
+	/**
+	 * @var FotoModel
+	 */
+	private $fotoModel;
+	/**
+	 * @var BesturenModel
+	 */
+	private $besturenModel;
+	/**
+	 * @var CommissiesModel
+	 */
+	private $commissiesModel;
+	/**
+	 * @var BoekRecensieModel
+	 */
+	private $boekRecensieModel;
+	/**
+	 * @var MaaltijdAbonnementenModel
+	 */
+	private $maaltijdAbonnementenModel;
+	/**
+	 * @var MaaltijdAanmeldingenModel
+	 */
+	private $maaltijdAanmeldingenModel;
+	/**
+	 * @var BoekExemplaarModel
+	 */
+	private $boekExemplaarModel;
+	/**
+	 * @var ForumPostsModel
+	 */
+	private $forumPostsModel;
+	/**
+	 * @var KwalificatiesModel
+	 */
+	private $kwalificatiesModel;
+	/**
+	 * @var CorveeVrijstellingenModel
+	 */
+	private $corveeVrijstellingenModel;
+	/**
+	 * @var CommissieVoorkeurModel
+	 */
+	private $corveeVoorkeurenModel;
+	/**
+	 * @var CorveeTakenModel
+	 */
+	private $corveeTakenModel;
+	/**
+	 * @var CiviBestellingModel
+	 */
+	private $civiBestellingModel;
+	/**
+	 * @var ActiviteitenModel
+	 */
+	private $activiteitenModel;
+	/**
+	 * @var KetzersModel
+	 */
+	private $ketzersModel;
+	/**
+	 * @var RechtenGroepenModel
+	 */
+	private $rechtenGroepenModel;
+	/**
+	 * @var OnderverenigingenModel
+	 */
+	private $onderverenigingenModel;
+	/**
+	 * @var WerkgroepenModel
+	 */
+	private $werkgroepenModel;
 
-	public function __construct() {
-		$this->model = ProfielModel::instance();
+	public function __construct(
+		ProfielModel $profielModel,
+		VoorkeurOpmerkingModel $voorkeurOpmerkingModel,
+		CommissieVoorkeurModel $commissieVoorkeurModel,
+		FotoTagsModel $fotoTagsModel,
+		FotoModel $fotoModel,
+		BesturenModel $besturenModel,
+		CommissiesModel $commissiesModel,
+		BoekRecensieModel $boekRecensieModel,
+		MaaltijdAbonnementenModel $maaltijdAbonnementenModel,
+		MaaltijdAanmeldingenModel $maaltijdAanmeldingenModel,
+		BoekExemplaarModel $boekExemplaarModel,
+		ForumPostsModel $forumPostsModel,
+		KwalificatiesModel $kwalificatiesModel,
+		CorveeVrijstellingenModel $corveeVrijstellingenModel,
+		CommissieVoorkeurModel $corveeVoorkeurenModel,
+		CorveeTakenModel $corveeTakenModel,
+		CiviBestellingModel $civiBestellingModel,
+		ActiviteitenModel $activiteitenModel,
+		KetzersModel $ketzersModel,
+		RechtenGroepenModel $rechtenGroepenModel,
+		OnderverenigingenModel $onderverenigingenModel,
+		WerkgroepenModel $werkgroepenModel
+	) {
+		$this->profielModel = $profielModel;
+		$this->voorkeurOpmerkingModel = $voorkeurOpmerkingModel;
+		$this->commissieVoorkeurModel = $commissieVoorkeurModel;
+		$this->fotoTagsModel = $fotoTagsModel;
+		$this->fotoModel = $fotoModel;
+		$this->besturenModel = $besturenModel;
+		$this->commissiesModel = $commissiesModel;
+		$this->boekRecensieModel = $boekRecensieModel;
+		$this->maaltijdAbonnementenModel = $maaltijdAbonnementenModel;
+		$this->maaltijdAanmeldingenModel = $maaltijdAanmeldingenModel;
+		$this->boekExemplaarModel = $boekExemplaarModel;
+		$this->forumPostsModel = $forumPostsModel;
+		$this->kwalificatiesModel = $kwalificatiesModel;
+		$this->corveeVrijstellingenModel = $corveeVrijstellingenModel;
+		$this->corveeVoorkeurenModel = $corveeVoorkeurenModel;
+		$this->corveeTakenModel = $corveeTakenModel;
+		$this->civiBestellingModel = $civiBestellingModel;
+		$this->activiteitenModel = $activiteitenModel;
+		$this->ketzersModel = $ketzersModel;
+		$this->rechtenGroepenModel = $rechtenGroepenModel;
+		$this->onderverenigingenModel = $onderverenigingenModel;
+		$this->werkgroepenModel = $werkgroepenModel;
 	}
 
 	public function resetPrivateToken($uid) {
-		$profiel = ProfielModel::instance()->get($uid);
+		$profiel = $this->profielModel->get($uid);
 
 		if ($profiel === false) {
 			throw new ResourceNotFoundException();
@@ -68,16 +199,16 @@ class ProfielController extends AbstractController {
 			$uid = LoginModel::getUid();
 		}
 
-		$profiel = ProfielModel::instance()->get($uid);
+		$profiel = $this->profielModel->get($uid);
 
 		if ($profiel === false) {
 			throw new ResourceNotFoundException();
 		}
 
 		$fotos = [];
-		foreach (FotoTagsModel::instance()->find('keyword = ?', [$uid], null, null, 3) as $tag) {
+		foreach ($this->fotoTagsModel->find('keyword = ?', [$uid], null, null, 3) as $tag) {
 			/** @var Foto $foto */
-			$foto = FotoModel::instance()->retrieveByUUID($tag->refuuid);
+			$foto = $this->fotoModel->retrieveByUUID($tag->refuuid);
 			if ($foto) {
 				$fotos[] = new FotoBBView($foto);
 			}
@@ -85,25 +216,25 @@ class ProfielController extends AbstractController {
 
 		return view('profiel.profiel', [
 			'profiel' => $profiel,
-			'besturen' => BesturenModel::instance()->getGroepenVoorLid($uid),
-			'commissies' => CommissiesModel::instance()->getGroepenVoorLid($uid),
-			'werkgroepen' => WerkgroepenModel::instance()->getGroepenVoorLid($uid),
-			'onderverenigingen' => OnderverenigingenModel::instance()->getGroepenVoorLid($uid),
-			'groepen' => RechtenGroepenModel::instance()->getGroepenVoorLid($uid),
-			'ketzers' => KetzersModel::instance()->getGroepenVoorLid($uid),
-			'activiteiten' => ActiviteitenModel::instance()->getGroepenVoorLid($uid),
-			'bestellinglog' => CiviBestellingModel::instance()->getBeschrijving(CiviBestellingModel::instance()->getBestellingenVoorLid($uid, 10)->fetchAll()),
+			'besturen' => $this->besturenModel->getGroepenVoorLid($uid),
+			'commissies' => $this->commissiesModel->getGroepenVoorLid($uid),
+			'werkgroepen' => $this->werkgroepenModel->getGroepenVoorLid($uid),
+			'onderverenigingen' => $this->onderverenigingenModel->getGroepenVoorLid($uid),
+			'groepen' => $this->rechtenGroepenModel->getGroepenVoorLid($uid),
+			'ketzers' => $this->ketzersModel->getGroepenVoorLid($uid),
+			'activiteiten' => $this->activiteitenModel->getGroepenVoorLid($uid),
+			'bestellinglog' => $this->civiBestellingModel->getBeschrijving($this->civiBestellingModel->getBestellingenVoorLid($uid, 10)->fetchAll()),
 			'bestellingenlink' => '/fiscaat/bestellingen' . (LoginModel::getUid() === $uid ? '' : '/' . $uid),
-			'corveetaken' => CorveeTakenModel::instance()->getTakenVoorLid($uid),
-			'corveevoorkeuren' => CorveeVoorkeurenModel::instance()->getVoorkeurenVoorLid($uid),
-			'corveevrijstelling' => CorveeVrijstellingenModel::instance()->getVrijstelling($uid),
-			'corveekwalificaties' => KwalificatiesModel::instance()->getKwalificatiesVanLid($uid),
-			'forumpostcount' => ForumPostsModel::instance()->getAantalForumPostsVoorLid($uid),
-			'forumrecent' => ForumPostsModel::instance()->getRecenteForumPostsVanLid($uid, (int)lid_instelling('forum', 'draden_per_pagina')),
-			'boeken' => BoekExemplaarModel::instance()->getEigendom($uid),
-			'recenteAanmeldingen' => MaaltijdAanmeldingenModel::instance()->getRecenteAanmeldingenVoorLid($uid, strtotime(instelling('maaltijden', 'recent_lidprofiel'))),
-			'abos' => MaaltijdAbonnementenModel::instance()->getAbonnementenVoorLid($uid),
-			'gerecenseerdeboeken' => BoekRecensieModel::instance()->getVoorLid($uid),
+			'corveetaken' => $this->corveeTakenModel->getTakenVoorLid($uid),
+			'corveevoorkeuren' => $this->corveeVoorkeurenModel->getVoorkeurenVoorLid($uid),
+			'corveevrijstelling' => $this->corveeVrijstellingenModel->getVrijstelling($uid),
+			'corveekwalificaties' => $this->kwalificatiesModel->getKwalificatiesVanLid($uid),
+			'forumpostcount' => $this->forumPostsModel->getAantalForumPostsVoorLid($uid),
+			'forumrecent' => $this->forumPostsModel->getRecenteForumPostsVanLid($uid, (int)lid_instelling('forum', 'draden_per_pagina')),
+			'boeken' => $this->boekExemplaarModel->getEigendom($uid),
+			'recenteAanmeldingen' => $this->maaltijdAanmeldingenModel->getRecenteAanmeldingenVoorLid($uid, strtotime(instelling('maaltijden', 'recent_lidprofiel'))),
+			'abos' => $this->maaltijdAbonnementenModel->getAbonnementenVoorLid($uid),
+			'gerecenseerdeboeken' => $this->boekRecensieModel->getVoorLid($uid),
 			'fotos' => $fotos
 		]);
 	}
@@ -119,7 +250,7 @@ class ProfielController extends AbstractController {
 			throw new CsrToegangException();
 		}
 		// Maak nieuw profiel zonder op te slaan
-		$profiel = ProfielModel::instance()->nieuw((int)$lidjaar, $lidstatus);
+		$profiel = $this->profielModel->nieuw((int)$lidjaar, $lidstatus);
 
 		return $this->profielBewerken($profiel, true);
 	}
@@ -135,18 +266,18 @@ class ProfielController extends AbstractController {
 			if (empty($diff)) {
 				setMelding('Geen wijzigingen', 0);
 			} else {
-				$nieuw = !$this->model->exists($profiel);
+				$nieuw = !$this->profielModel->exists($profiel);
 				$changeEntry = ProfielModel::changelog($diff, LoginModel::getUid());
 				foreach ($diff as $change) {
 					if ($change->property === 'status') {
-						array_push($changeEntry->entries, ...$this->model->wijzig_lidstatus($profiel, $change->old_value));
+						array_push($changeEntry->entries, ...$this->profielModel->wijzig_lidstatus($profiel, $change->old_value));
 					}
 				}
 				$profiel->changelog[] = $changeEntry;
 				if ($nieuw) {
 					try {
 						Database::transaction(function () use ($profiel) {
-							$this->model->create($profiel);
+							$this->profielModel->create($profiel);
 
 							if (filter_input(INPUT_POST, 'toestemming_geven') === 'true') {
 								// Sla toesteming op.
@@ -163,7 +294,7 @@ class ProfielController extends AbstractController {
 					}
 
 					setMelding('Profiel succesvol opgeslagen met lidnummer: ' . $profiel->uid, 1);
-				} elseif (1 === $this->model->update($profiel)) {
+				} elseif (1 === $this->profielModel->update($profiel)) {
 					setMelding(count($diff) . ' wijziging(en) succesvol opgeslagen', 1);
 				} else {
 					setMelding('Opslaan van ' . count($diff) . ' wijziging(en) mislukt', -1);
@@ -178,7 +309,7 @@ class ProfielController extends AbstractController {
 	}
 
 	public function bewerken($uid) {
-		$profiel = ProfielModel::instance()->get($uid);
+		$profiel = $this->profielModel->get($uid);
 
 		if ($profiel === false) {
 			throw new ResourceNotFoundException();
@@ -188,7 +319,7 @@ class ProfielController extends AbstractController {
 	}
 
 	public function voorkeuren($uid) {
-		$profiel = ProfielModel::instance()->get($uid);
+		$profiel = $this->profielModel->get($uid);
 
 		if ($profiel === false) {
 			throw new ResourceNotFoundException();
@@ -201,9 +332,9 @@ class ProfielController extends AbstractController {
 			$voorkeuren = $form->getVoorkeuren();
 			$opmerking = $form->getOpmerking();
 			foreach ($voorkeuren as $voorkeur) {
-				CommissieVoorkeurModel::instance()->updateOrCreate($voorkeur);
+				$this->commissieVoorkeurModel->updateOrCreate($voorkeur);
 			}
-			VoorkeurOpmerkingModel::instance()->updateOrCreate($opmerking);
+			$this->voorkeurOpmerkingModel->updateOrCreate($opmerking);
 			setMelding('Voorkeuren opgeslagen', 1);
 			$this->redirectToRoute('profiel-voorkeuren');
 
@@ -212,7 +343,7 @@ class ProfielController extends AbstractController {
 	}
 
 	public function addToGoogleContacts($uid) {
-		$profiel = ProfielModel::instance()->get($uid);
+		$profiel = $this->profielModel->get($uid);
 
 		if ($profiel === false) {
 			throw new ResourceNotFoundException();

--- a/lib/controller/fiscaat/FiscaatController.php
+++ b/lib/controller/fiscaat/FiscaatController.php
@@ -11,8 +11,8 @@ class FiscaatController {
 	/** @var CiviSaldoModel */
 	private $civiSaldoModel;
 
-	public function __construct() {
-		$this->civiSaldoModel = CiviSaldoModel::instance();
+	public function __construct(CiviSaldoModel $civiSaldoModel) {
+		$this->civiSaldoModel = $civiSaldoModel;
 	}
 
 	public function overzicht() {

--- a/lib/controller/fiscaat/PinTransactieController.php
+++ b/lib/controller/fiscaat/PinTransactieController.php
@@ -40,12 +40,18 @@ class PinTransactieController {
 	/** @var PinTransactieModel */
 	private $pinTransactieModel;
 
-	public function __construct() {
-		$this->civiBestellingInhoudModel = CiviBestellingInhoudModel::instance();
-		$this->civiBestellingModel = CiviBestellingModel::instance();
-		$this->civiSaldoModel = CiviSaldoModel::instance();
-		$this->pinTransactieMatchModel = PinTransactieMatchModel::instance();
-		$this->pinTransactieModel = PinTransactieModel::instance();
+	public function __construct(
+		CiviBestellingInhoudModel $civiBestellingInhoudModel,
+		CiviBestellingModel $civiBestellingModel,
+		CiviSaldoModel $civiSaldoModel,
+		PinTransactieMatchModel $pinTransactieMatchModel,
+		PinTransactieModel $pinTransactieModel
+	) {
+		$this->civiBestellingInhoudModel = $civiBestellingInhoudModel;
+		$this->civiBestellingModel = $civiBestellingModel;
+		$this->civiSaldoModel = $civiSaldoModel;
+		$this->pinTransactieMatchModel = $pinTransactieMatchModel;
+		$this->pinTransactieModel = $pinTransactieModel;
 	}
 
 	public function overzicht() {

--- a/lib/controller/groepen/AbstractGroepenController.php
+++ b/lib/controller/groepen/AbstractGroepenController.php
@@ -56,9 +56,14 @@ abstract class AbstractGroepenController {
 	protected $table;
 	/** @var AbstractGroepenModel */
 	protected $model;
+	/**
+	 * @var ChangeLogModel
+	 */
+	private $changeLogModel;
 
 	public function __construct($model = null) {
 		$this->model = $model;
+		$this->changeLogModel = ChangeLogModel::instance();
 	}
 
 	/**
@@ -283,7 +288,7 @@ abstract class AbstractGroepenController {
 			$form->setDataTableId($this->table->getDataTableId());
 			return view('default', ['content' => $this->table, 'modal' => $form]);
 		} elseif ($form->validate()) {
-			ChangeLogModel::instance()->log($groep, 'create', null, print_r($groep, true));
+			$this->changeLogModel->log($groep, 'create', null, print_r($groep, true));
 			$this->model->create($groep);
 			$response[] = $groep;
 			if ($old) {
@@ -329,7 +334,7 @@ abstract class AbstractGroepenController {
 				$form->setDataTableId($this->table->getDataTableId());
 				return view('default', ['content' => $this->table, 'modal' => $form]);
 			} elseif ($form->validate()) {
-				ChangeLogModel::instance()->logChanges($form->diff());
+				$this->changeLogModel->logChanges($form->diff());
 				$this->model->update($groep);
 				return new GroepenBeheerData([$groep]);
 			} else {
@@ -348,7 +353,7 @@ abstract class AbstractGroepenController {
 			}
 			$form = new GroepForm($groep, $groep->getUrl() . '/wijzigen', AccessAction::Wijzigen); // checks rechten wijzigen
 			if ($form->validate()) {
-				ChangeLogModel::instance()->logChanges($form->diff());
+				$this->changeLogModel->logChanges($form->diff());
 				$this->model->update($groep);
 				return new GroepenBeheerData([$groep]);
 			} else {
@@ -362,7 +367,7 @@ abstract class AbstractGroepenController {
 		/** @var AbstractGroep $groep */
 		$groep = $this->model->retrieveByUUID($id);
 		if ($groep && $groep->mag(AccessAction::Verwijderen) && count($groep->getLeden()) === 0) {
-			ChangeLogModel::instance()->log($groep, 'delete', print_r($groep, true), null);
+			$this->changeLogModel->log($groep, 'delete', print_r($groep, true), null);
 			$this->model->delete($groep);
 			$response[] = $groep;
 		}
@@ -379,8 +384,8 @@ abstract class AbstractGroepenController {
 			/** @var AbstractGroep $groep */
 			$groep = $this->model->retrieveByUUID($id);
 			if ($groep and $groep->mag(AccessAction::Opvolging)) {
-				ChangeLogModel::instance()->log($groep, 'familie', $groep->familie, $values['familie']);
-				ChangeLogModel::instance()->log($groep, 'status', $groep->status, $values['status']);
+				$this->changeLogModel->log($groep, 'familie', $groep->familie, $values['familie']);
+				$this->changeLogModel->log($groep, 'status', $groep->status, $values['status']);
 				$groep->familie = $values['familie'];
 				$groep->status = $values['status'];
 				$this->model->update($groep);
@@ -406,13 +411,13 @@ abstract class AbstractGroepenController {
 			$groep = $this->model->retrieveByUUID($id);
 			if ($groep and $groep->mag(AccessAction::Wijzigen)) {
 				if ($converteer) {
-					ChangeLogModel::instance()->log($groep, 'class', get_class($groep), $model::ORM);
+					$this->changeLogModel->log($groep, 'class', get_class($groep), $model::ORM);
 					$nieuw = $model->converteer($groep, $this->model, $values['soort']);
 					if ($nieuw) {
 						$response[] = $groep;
 					}
 				} elseif (property_exists($groep, 'soort')) {
-					ChangeLogModel::instance()->log($groep, 'soort', $groep->soort, $values['soort']);
+					$this->changeLogModel->log($groep, 'soort', $groep->soort, $values['soort']);
 					$groep->soort = $values['soort'];
 					$rowCount = $this->model->update($groep);
 					if ($rowCount > 0) {
@@ -435,7 +440,7 @@ abstract class AbstractGroepenController {
 		/** @var AbstractGroep $groep */
 		$groep = $this->model->retrieveByUUID($id);
 		if ($groep and property_exists($groep, 'aanmelden_tot') and time() <= strtotime($groep->aanmelden_tot) and $groep->mag(AccessAction::Wijzigen)) {
-			ChangeLogModel::instance()->log($groep, 'aanmelden_tot', $groep->aanmelden_tot, getDateTime());
+			$this->changeLogModel->log($groep, 'aanmelden_tot', $groep->aanmelden_tot, getDateTime());
 			$groep->aanmelden_tot = getDateTime();
 			$this->model->update($groep);
 			$response[] = $groep;
@@ -464,7 +469,7 @@ abstract class AbstractGroepenController {
 			if (!$groep->mag(AccessAction::Bekijken)) {
 				throw new CsrToegangException();
 			}
-			$data = ChangeLogModel::instance()->find('subject = ?', [$groep->getUUID()]);
+			$data = $this->changeLogModel->find('subject = ?', [$groep->getUUID()]);
 			return new GroepLogboekData($data);
 		} // popup request
 		else {
@@ -514,7 +519,7 @@ abstract class AbstractGroepenController {
 
 		$lid->opmerking2 = $keuzes;
 
-		ChangeLogModel::instance()->log($groep, 'aanmelden', null, $lid->uid);
+		$this->changeLogModel->log($groep, 'aanmelden', null, $lid->uid);
 		$model->create($lid);
 
 		return new JsonResponse(['success' => true]);
@@ -533,7 +538,7 @@ abstract class AbstractGroepenController {
 		$form = new GroepAanmeldenForm($lid, $groep);
 
 		if ($form->validate()) {
-			ChangeLogModel::instance()->log($groep, 'aanmelden', null, $lid->uid);
+			$this->changeLogModel->log($groep, 'aanmelden', null, $lid->uid);
 			$model->create($lid);
 			return new GroepPasfotosView($groep);
 		} else {
@@ -554,7 +559,7 @@ abstract class AbstractGroepenController {
 		$form = new GroepLidBeheerForm($lid, $groep->getUrl() . '/aanmelden', array_keys($leden));
 
 		if ($form->validate()) {
-			ChangeLogModel::instance()->log($groep, 'aanmelden', null, $lid->uid);
+			$this->changeLogModel->log($groep, 'aanmelden', null, $lid->uid);
 			$model->create($lid);
 			return new GroepLedenData([$lid]);
 		} else {
@@ -574,7 +579,7 @@ abstract class AbstractGroepenController {
 		$form = new GroepBewerkenForm($lid, $groep);
 
 		if ($form->validate()) {
-			ChangeLogModel::instance()->logChanges($form->diff());
+			$this->changeLogModel->logChanges($form->diff());
 			$model->update($lid);
 		}
 
@@ -603,7 +608,7 @@ abstract class AbstractGroepenController {
 		$form = new GroepLidBeheerForm($lid, $groep->getUrl() . '/bewerken');
 
 		if ($form->validate()) {
-			ChangeLogModel::instance()->logChanges($form->diff());
+			$this->changeLogModel->logChanges($form->diff());
 			$model->update($lid);
 			return new GroepLedenData([$lid]);
 		} else {
@@ -626,7 +631,7 @@ abstract class AbstractGroepenController {
 			throw new CsrToegangException('Niet aangemeld');
 		}
 
-		ChangeLogModel::instance()->log($groep, 'afmelden', $lid->uid, null);
+		$this->changeLogModel->log($groep, 'afmelden', $lid->uid, null);
 		$model->delete($lid);
 
 		return new GroepView($groep);
@@ -641,7 +646,7 @@ abstract class AbstractGroepenController {
 		}
 
 		$lid = $model->get($groep, $uid);
-		ChangeLogModel::instance()->log($groep, 'afmelden', $lid->uid, null);
+		$this->changeLogModel->log($groep, 'afmelden', $lid->uid, null);
 		$model->delete($lid);
 		return new RemoveRowsResponse([$lid]);
 	}
@@ -669,8 +674,8 @@ abstract class AbstractGroepenController {
 			}
 			Database::transaction(function () use ($groep, $ot_groep, $uid, $model) {
 				$lid = $model->get($groep, $uid);
-				ChangeLogModel::instance()->log($groep, 'afmelden', $lid->uid, null);
-				ChangeLogModel::instance()->log($ot_groep, 'aanmelden', $lid->uid, null);
+				$this->changeLogModel->log($groep, 'afmelden', $lid->uid, null);
+				$this->changeLogModel->log($ot_groep, 'aanmelden', $lid->uid, null);
 				$model->delete($lid);
 				$lid->groep_id = $ot_groep->id;
 				$model->create($lid);
@@ -694,8 +699,8 @@ abstract class AbstractGroepenController {
 					if ($ot_groep->getLid($lid->uid)) {
 						throw new CsrGebruikerException('Lid al onderdeel van o.t. groep');
 					}
-					ChangeLogModel::instance()->log($groep, 'afmelden', $lid->uid, null);
-					ChangeLogModel::instance()->log($ot_groep, 'aanmelden', $lid->uid, null);
+					$this->changeLogModel->log($groep, 'afmelden', $lid->uid, null);
+					$this->changeLogModel->log($ot_groep, 'aanmelden', $lid->uid, null);
 					$model->delete($lid);
 					$lid->groep_id = $ot_groep->id;
 					$lid->lid_sinds = getDateTime();

--- a/lib/controller/groepen/ActiviteitenController.php
+++ b/lib/controller/groepen/ActiviteitenController.php
@@ -13,8 +13,7 @@ use CsrDelft\model\groepen\ActiviteitenModel;
  * Controller voor activiteiten.
  */
 class ActiviteitenController extends KetzersController {
-	public function __construct() {
-		parent::__construct();
-		$this->model = ActiviteitenModel::instance();
+	public function __construct(ActiviteitenModel $activiteitenModel) {
+		parent::__construct($activiteitenModel);
 	}
 }

--- a/lib/controller/groepen/BesturenController.php
+++ b/lib/controller/groepen/BesturenController.php
@@ -12,7 +12,7 @@ use CsrDelft\model\groepen\BesturenModel;
  * Controller voor besturen.
  */
 class BesturenController extends AbstractGroepenController {
-	public function __construct() {
-		parent::__construct(BesturenModel::instance());
+	public function __construct(BesturenModel $besturenModel) {
+		parent::__construct($besturenModel);
 	}
 }

--- a/lib/controller/groepen/CommissiesController.php
+++ b/lib/controller/groepen/CommissiesController.php
@@ -12,7 +12,7 @@ use CsrDelft\model\groepen\CommissiesModel;
  * Controller voor commissies.
  */
 class CommissiesController extends AbstractGroepenController {
-	public function __construct() {
-		parent::__construct(CommissiesModel::instance());
+	public function __construct(CommissiesModel $commissiesModel) {
+		parent::__construct($commissiesModel);
 	}
 }

--- a/lib/controller/groepen/KetzersController.php
+++ b/lib/controller/groepen/KetzersController.php
@@ -17,8 +17,8 @@ use Symfony\Component\HttpFoundation\Request;
  * @property KetzersModel $model
  */
 class KetzersController extends AbstractGroepenController {
-	public function __construct() {
-		parent::__construct(KetzersModel::instance());
+	public function __construct(KetzersModel $ketzersModel) {
+		parent::__construct($ketzersModel);
 	}
 
 	public function nieuw(Request $request, $id = null, $soort = null) {

--- a/lib/controller/groepen/KringenController.php
+++ b/lib/controller/groepen/KringenController.php
@@ -19,8 +19,8 @@ use Symfony\Component\HttpFoundation\Request;
  * @property KringenModel $model
  */
 class KringenController extends AbstractGroepenController {
-	public function __construct() {
-		parent::__construct(KringenModel::instance());
+	public function __construct(KringenModel $kringenModel) {
+		parent::__construct($kringenModel);
 	}
 
 	public function zoeken(Request $request, $zoekterm = null) {

--- a/lib/controller/groepen/LichtingenController.php
+++ b/lib/controller/groepen/LichtingenController.php
@@ -17,8 +17,8 @@ use Symfony\Component\HttpFoundation\Request;
  * @property LichtingenModel $model
  */
 class LichtingenController extends AbstractGroepenController {
-	public function __construct() {
-		parent::__construct(LichtingenModel::instance());
+	public function __construct(LichtingenModel $lichtingenModel) {
+		parent::__construct($lichtingenModel);
 	}
 
 	public function zoeken(Request $request, $zoekterm = null) {

--- a/lib/controller/groepen/OnderverenigingenController.php
+++ b/lib/controller/groepen/OnderverenigingenController.php
@@ -12,7 +12,7 @@ use CsrDelft\model\groepen\OnderverenigingenModel;
  * Controller voor onderverenigingen.
  */
 class OnderverenigingenController extends AbstractGroepenController {
-	public function __construct() {
-		parent::__construct(OnderverenigingenModel::instance());
+	public function __construct(OnderverenigingenModel $onderverenigingenModel) {
+		parent::__construct($onderverenigingenModel);
 	}
 }

--- a/lib/controller/groepen/RechtengroepenController.php
+++ b/lib/controller/groepen/RechtengroepenController.php
@@ -12,7 +12,7 @@ use CsrDelft\model\groepen\RechtenGroepenModel;
  * Controller voor rechten-groepen. Kleine letter g vanwege groepen-router.
  */
 class RechtengroepenController extends AbstractGroepenController {
-	public function __construct() {
-		parent::__construct(RechtenGroepenModel::instance());
+	public function __construct(RechtenGroepenModel $rechtenGroepenModel) {
+		parent::__construct($rechtenGroepenModel);
 	}
 }

--- a/lib/controller/groepen/VerticalenController.php
+++ b/lib/controller/groepen/VerticalenController.php
@@ -16,8 +16,8 @@ use Symfony\Component\HttpFoundation\Request;
  * Controller voor verticalen.
  */
 class VerticalenController extends AbstractGroepenController {
-	public function __construct() {
-		parent::__construct(VerticalenModel::instance());
+	public function __construct(VerticalenModel $verticalenModel) {
+		parent::__construct($verticalenModel);
 	}
 
 	public function zoeken(Request $request, $zoekterm = null) {

--- a/lib/controller/groepen/WerkgroepenController.php
+++ b/lib/controller/groepen/WerkgroepenController.php
@@ -15,7 +15,7 @@ use CsrDelft\model\groepen\WerkgroepenModel;
  * N.B. Een Werkgroep extends Ketzer, maar de controller niet om de "nieuwe ketzer"-wizard te vermijden.
  */
 class WerkgroepenController extends AbstractGroepenController {
-	public function __construct() {
-		parent::__construct(WerkgroepenModel::instance());
+	public function __construct(WerkgroepenModel $werkgroepenModel) {
+		parent::__construct($werkgroepenModel);
 	}
 }

--- a/lib/controller/groepen/WoonoordenController.php
+++ b/lib/controller/groepen/WoonoordenController.php
@@ -12,7 +12,7 @@ use CsrDelft\model\groepen\WoonoordenModel;
  * Controller voor woonoorden en huizen.
  */
 class WoonoordenController extends AbstractGroepenController {
-	public function __construct() {
-		parent::__construct(WoonoordenModel::instance());
+	public function __construct(WoonoordenModel $woonoordenModel) {
+		parent::__construct($woonoordenModel);
 	}
 }

--- a/lib/controller/maalcie/BeheerAbonnementenController.php
+++ b/lib/controller/maalcie/BeheerAbonnementenController.php
@@ -14,40 +14,48 @@ use CsrDelft\model\ProfielModel;
  * @author P.W.G. Brussee <brussee@live.nl>
  */
 class BeheerAbonnementenController {
-	private $model;
+	/**
+	 * @var MaaltijdAbonnementenModel
+	 */
+	private $maaltijdAbonnementenModel;
+	/**
+	 * @var MaaltijdRepetitiesModel
+	 */
+	private $maaltijdRepetitiesModel;
 
-	public function __construct() {
-		$this->model = MaaltijdAbonnementenModel::instance();
+	public function __construct(MaaltijdAbonnementenModel $maaltijdAbonnementenModel, MaaltijdRepetitiesModel $maaltijdRepetitiesModel) {
+		$this->maaltijdAbonnementenModel = $maaltijdAbonnementenModel;
+		$this->maaltijdRepetitiesModel = $maaltijdRepetitiesModel;
 	}
 
 	public function waarschuwingen() {
-		$matrix_repetities = MaaltijdAbonnementenModel::instance()->getAbonnementenWaarschuwingenMatrix();
+		$matrix_repetities = $this->maaltijdAbonnementenModel->getAbonnementenWaarschuwingenMatrix();
 
 		return view('maaltijden.abonnement.beheer_abonnementen', [
 			'toon' => 'waarschuwing',
-			'aborepetities' => MaaltijdRepetitiesModel::instance()->find('abonneerbaar = true'),
+			'aborepetities' => $this->maaltijdRepetitiesModel->find('abonneerbaar = true'),
 			'repetities' => $matrix_repetities[1],
 			'matrix' => $matrix_repetities[0],
 		]);
 	}
 
 	public function ingeschakeld() {
-		$matrix_repetities = MaaltijdAbonnementenModel::instance()->getAbonnementenMatrix();
+		$matrix_repetities = $this->maaltijdAbonnementenModel->getAbonnementenMatrix();
 
 		return view('maaltijden.abonnement.beheer_abonnementen', [
 			'toon' => 'in',
-			'aborepetities' => MaaltijdRepetitiesModel::instance()->find('abonneerbaar = true'),
+			'aborepetities' => $this->maaltijdRepetitiesModel->find('abonneerbaar = true'),
 			'repetities' => $matrix_repetities[1],
 			'matrix' => $matrix_repetities[0],
 		]);
 	}
 
 	public function abonneerbaar() {
-		$matrix_repetities = MaaltijdAbonnementenModel::instance()->getAbonnementenAbonneerbaarMatrix();
+		$matrix_repetities = $this->maaltijdAbonnementenModel->getAbonnementenAbonneerbaarMatrix();
 
 		return view('maaltijden.abonnement.beheer_abonnementen', [
 			'toon' => 'waarschuwing',
-			'aborepetities' => MaaltijdRepetitiesModel::instance()->find('abonneerbaar = true'),
+			'aborepetities' => $this->maaltijdRepetitiesModel->find('abonneerbaar = true'),
 			'repetities' => $matrix_repetities[1],
 			'matrix' => $matrix_repetities[0],
 		]);
@@ -55,8 +63,8 @@ class BeheerAbonnementenController {
 
 	public function novieten() {
 		$mrid = filter_input(INPUT_POST, 'mrid', FILTER_SANITIZE_NUMBER_INT);
-		$aantal = $this->model->inschakelenAbonnementVoorNovieten((int)$mrid);
-		$matrix = $this->model->getAbonnementenVanNovieten();
+		$aantal = $this->maaltijdAbonnementenModel->inschakelenAbonnementVoorNovieten((int)$mrid);
+		$matrix = $this->maaltijdAbonnementenModel->getAbonnementenVanNovieten();
 		$novieten = sizeof($matrix);
 		setMelding(
 			$aantal . ' abonnement' . ($aantal !== 1 ? 'en' : '') . ' aangemaakt voor ' .
@@ -71,7 +79,7 @@ class BeheerAbonnementenController {
 		$abo = new MaaltijdAbonnement();
 		$abo->mlt_repetitie_id = $mrid;
 		$abo->uid = $uid;
-		$aantal = $this->model->inschakelenAbonnement($abo);
+		$aantal = $this->maaltijdAbonnementenModel->inschakelenAbonnement($abo);
 		if ($aantal > 0) {
 			$melding = 'Automatisch aangemeld voor ' . $aantal . ' maaltijd' . ($aantal === 1 ? '' : 'en');
 			setMelding($melding, 2);
@@ -83,7 +91,7 @@ class BeheerAbonnementenController {
 		if (!ProfielModel::existsUid($uid)) {
 			throw new CsrGebruikerException(sprintf('Lid met uid "%s" bestaat niet.', $uid));
 		}
-		$abo_aantal = $this->model->uitschakelenAbonnement((int)$mrid, $uid);
+		$abo_aantal = $this->maaltijdAbonnementenModel->uitschakelenAbonnement((int)$mrid, $uid);
 		if ($abo_aantal[1] > 0) {
 			$melding = 'Automatisch afgemeld voor ' . $abo_aantal[1] . ' maaltijd' . ($abo_aantal[1] === 1 ? '' : 'en');
 			setMelding($melding, 2);

--- a/lib/controller/maalcie/BeheerFunctiesController.php
+++ b/lib/controller/maalcie/BeheerFunctiesController.php
@@ -12,10 +12,18 @@ use CsrDelft\view\maalcie\corvee\functies\KwalificatieForm;
  * @author P.W.G. Brussee <brussee@live.nl>
  */
 class BeheerFunctiesController {
-	private $model;
+	/**
+	 * @var FunctiesModel
+	 */
+	private $functiesModel;
+	/**
+	 * @var KwalificatiesModel
+	 */
+	private $kwalificatiesModel;
 
-	public function __construct() {
-		$this->model = FunctiesModel::instance();
+	public function __construct(FunctiesModel $functiesModel, KwalificatiesModel $kwalificatiesModel) {
+		$this->functiesModel = $functiesModel;
+		$this->kwalificatiesModel = $kwalificatiesModel;
 	}
 
 	public function beheer($fid = null) {
@@ -24,15 +32,15 @@ class BeheerFunctiesController {
 		if ($fid > 0) {
 			$modal = $this->bewerken($fid);
 		}
-		$functies = $this->model->getAlleFuncties(); // grouped by functie_id
+		$functies = $this->functiesModel->getAlleFuncties(); // grouped by functie_id
 		return view('maaltijden.functie.beheer_functies', ['functies' => $functies, 'modal' => $modal]);
 	}
 
 	public function toevoegen() {
-		$functie = $this->model->nieuw();
+		$functie = $this->functiesModel->nieuw();
 		$form = new FunctieForm($functie, 'toevoegen'); // fetches POST values itself
 		if ($form->validate()) {
-			$id = $this->model->create($functie);
+			$id = $this->functiesModel->create($functie);
 			$functie->functie_id = (int)$id;
 			setMelding('Toegevoegd', 1);
 			return view('maaltijden.functie.beheer_functie', ['functie' => $functie]);
@@ -42,10 +50,10 @@ class BeheerFunctiesController {
 	}
 
 	public function bewerken($fid) {
-		$functie = $this->model->get((int)$fid);
+		$functie = $this->functiesModel->get((int)$fid);
 		$form = new FunctieForm($functie, 'bewerken'); // fetches POST values itself
 		if ($form->validate()) {
-			$rowCount = $this->model->update($functie);
+			$rowCount = $this->functiesModel->update($functie);
 			if ($rowCount > 0) {
 				setMelding('Bijgewerkt', 1);
 			} else {
@@ -58,18 +66,18 @@ class BeheerFunctiesController {
 	}
 
 	public function verwijderen($fid) {
-		$functie = $this->model->get((int)$fid);
-		$this->model->removeFunctie($functie);
+		$functie = $this->functiesModel->get((int)$fid);
+		$this->functiesModel->removeFunctie($functie);
 		setMelding('Verwijderd', 1);
 		return new FunctieDeleteView($fid);
 	}
 
 	public function kwalificeer($fid) {
-		$functie = $this->model->get((int)$fid);
-		$kwalificatie = KwalificatiesModel::instance()->nieuw($functie);
+		$functie = $this->functiesModel->get((int)$fid);
+		$kwalificatie = $this->kwalificatiesModel->nieuw($functie);
 		$form = new KwalificatieForm($kwalificatie); // fetches POST values itself
 		if ($form->validate()) {
-			KwalificatiesModel::instance()->kwalificatieToewijzen($kwalificatie);
+			$this->kwalificatiesModel->kwalificatieToewijzen($kwalificatie);
 			return view('maaltijden.functie.beheer_functie', ['functie' => $functie]);
 		} else {
 			return $form;
@@ -77,8 +85,8 @@ class BeheerFunctiesController {
 	}
 
 	public function dekwalificeer($fid, $uid) {
-		$functie = $this->model->get((int)$fid);
-		KwalificatiesModel::instance()->kwalificatieIntrekken($uid, $functie->functie_id);
+		$functie = $this->functiesModel->get((int)$fid);
+		$this->kwalificatiesModel->kwalificatieIntrekken($uid, $functie->functie_id);
 		return view('maaltijden.functie.beheer_functie', ['functie' => $functie]);
 	}
 

--- a/lib/controller/maalcie/MijnVoorkeurenController.php
+++ b/lib/controller/maalcie/MijnVoorkeurenController.php
@@ -11,14 +11,17 @@ use CsrDelft\view\maalcie\forms\EetwensForm;
  * @author P.W.G. Brussee <brussee@live.nl>
  */
 class MijnVoorkeurenController {
-	private $model;
+	/**
+	 * @var CorveeVoorkeurenModel
+	 */
+	private $corveeVoorkeurenModel;
 
-	public function __construct() {
-		$this->model = CorveeVoorkeurenModel::instance();
+	public function __construct(CorveeVoorkeurenModel $corveeVoorkeurenModel) {
+		$this->corveeVoorkeurenModel = $corveeVoorkeurenModel;
 	}
 
 	public function mijn() {
-		$voorkeuren = $this->model->getVoorkeurenVoorLid(LoginModel::getUid(), true);
+		$voorkeuren = $this->corveeVoorkeurenModel->getVoorkeurenVoorLid(LoginModel::getUid(), true);
 		return view('maaltijden.voorkeuren.mijn_voorkeuren', [
 			'voorkeuren' => $voorkeuren,
 			'eetwens' => new EetwensForm(),
@@ -29,7 +32,7 @@ class MijnVoorkeurenController {
 		$voorkeur = new CorveeVoorkeur();
 		$voorkeur->crv_repetitie_id = $crid;
 		$voorkeur->uid = LoginModel::getUid();
-		$voorkeur = $this->model->inschakelenVoorkeur($voorkeur);
+		$voorkeur = $this->corveeVoorkeurenModel->inschakelenVoorkeur($voorkeur);
 		return view('maaltijden.voorkeuren.mijn_voorkeur_veld', [
 			'uid' => $voorkeur->uid,
 			'crid' => $voorkeur->crv_repetitie_id,
@@ -40,7 +43,7 @@ class MijnVoorkeurenController {
 		$voorkeur = new CorveeVoorkeur();
 		$voorkeur->crv_repetitie_id = $crid;
 		$voorkeur->uid = LoginModel::getUid();
-		$voorkeur = $this->model->uitschakelenVoorkeur($voorkeur);
+		$voorkeur = $this->corveeVoorkeurenModel->uitschakelenVoorkeur($voorkeur);
 		return view('maaltijden.voorkeuren.mijn_voorkeur_veld', [
 			'uid' => $voorkeur->uid,
 			'crid' => $voorkeur->crv_repetitie_id,
@@ -50,7 +53,7 @@ class MijnVoorkeurenController {
 	public function eetwens() {
 		$form = new EetwensForm();
 		if ($form->validate()) {
-			$this->model->setEetwens(LoginModel::getProfiel(), $form->getField()->getValue());
+			$this->corveeVoorkeurenModel->setEetwens(LoginModel::getProfiel(), $form->getField()->getValue());
 		}
 		return $form;
 	}

--- a/lib/model/ProfielModel.php
+++ b/lib/model/ProfielModel.php
@@ -37,6 +37,29 @@ use CsrDelft\Orm\Persistence\Database;
 class ProfielModel extends CachedPersistenceModel {
 
 	const ORM = Profiel::class;
+	/**
+	 * @var MaaltijdAbonnementenModel
+	 */
+	private $maaltijdAbonnementenModel;
+	/**
+	 * @var CorveeTakenModel
+	 */
+	private $corveeTakenModel;
+	/**
+	 * @var BoekExemplaarModel
+	 */
+	private $boekExemplaarModel;
+
+	public function __construct(
+		MaaltijdAbonnementenModel $maaltijdAbonnementenModel,
+		CorveeTakenModel $corveeTakenModel,
+		BoekExemplaarModel $boekExemplaarModel
+	) {
+		parent::__construct();
+		$this->maaltijdAbonnementenModel = $maaltijdAbonnementenModel;
+		$this->corveeTakenModel = $corveeTakenModel;
+		$this->boekExemplaarModel = $boekExemplaarModel;
+	}
 
 	public static function changelog(array $diff, $uid) {
 		if (empty($diff)) {
@@ -244,7 +267,7 @@ class ProfielModel extends CachedPersistenceModel {
 	 * @return AbstractProfielLogEntry[] wijzigingen
 	 */
 	private function disableMaaltijdabos(Profiel $profiel, $oudestatus) {
-		$aantal = MaaltijdAbonnementenModel::instance()->verwijderAbonnementenVoorLid($profiel->uid);
+		$aantal = $this->maaltijdAbonnementenModel->verwijderAbonnementenVoorLid($profiel->uid);
 		if ($aantal > 0) {
 			return [new ProfielLogTextEntry('Afmelden abo\'s: ' . $aantal . ' uitgezet.')];
 		}
@@ -259,8 +282,8 @@ class ProfielModel extends CachedPersistenceModel {
 	 * @return AbstractProfielLogEntry[] wijzigingen
 	 */
 	private function removeToekomstigeCorvee(Profiel $profiel, $oudestatus) {
-		$taken = CorveeTakenModel::instance()->getKomendeTakenVoorLid($profiel->uid);
-		$aantal = CorveeTakenModel::instance()->verwijderTakenVoorLid($profiel->uid);
+		$taken = $this->corveeTakenModel->getKomendeTakenVoorLid($profiel->uid);
+		$aantal = $this->corveeTakenModel->verwijderTakenVoorLid($profiel->uid);
 		if (sizeof($taken) !== $aantal) {
 			setMelding('Niet alle toekomstige corveetaken zijn verwijderd!', -1);
 		}
@@ -332,7 +355,7 @@ class ProfielModel extends CachedPersistenceModel {
 	 * @return bool mailen is wel/niet verzonden
 	 */
 	private function notifyBibliothecaris(Profiel $profiel, $oudestatus) {
-		$geleend = BoekExemplaarModel::instance()->getGeleend($profiel);
+		$geleend = $this->boekExemplaarModel->getGeleend($profiel);
 		if (!is_array($geleend)) {
 			$geleend = array();
 		}

--- a/lib/model/fiscaat/CiviBestellingInhoudModel.php
+++ b/lib/model/fiscaat/CiviBestellingInhoudModel.php
@@ -19,7 +19,7 @@ class CiviBestellingInhoudModel extends PersistenceModel {
 	 */
 	private $civiProductModel;
 
-	protected function __construct(CiviProductModel $civiProductModel) {
+	public function __construct(CiviProductModel $civiProductModel) {
 		parent::__construct();
 
 		$this->civiProductModel = $civiProductModel;

--- a/lib/model/forum/ForumDelenModel.php
+++ b/lib/model/forum/ForumDelenModel.php
@@ -30,7 +30,7 @@ class ForumDelenModel extends CachedPersistenceModel {
 	 */
 	private $forumPostsModel;
 
-	protected function __construct(ForumDradenModel $forumDradenModel, ForumPostsModel $forumPostsModel) {
+	public function __construct(ForumDradenModel $forumDradenModel, ForumPostsModel $forumPostsModel) {
 		parent::__construct();
 
 		$this->forumDradenModel = $forumDradenModel;

--- a/lib/model/forum/ForumDradenModel.php
+++ b/lib/model/forum/ForumDradenModel.php
@@ -108,7 +108,7 @@ class ForumDradenModel extends CachedPersistenceModel implements Paging {
 		return $draad;
 	}
 
-	protected function __construct(
+	public function __construct(
 		ForumDradenGelezenModel $forumDradenGelezenModel,
 		ForumDradenReagerenModel $forumDradenReagerenModel,
 		ForumDradenVerbergenModel $forumDradenVerbergenModel,

--- a/lib/model/forum/ForumModel.php
+++ b/lib/model/forum/ForumModel.php
@@ -68,7 +68,7 @@ class ForumModel extends CachedPersistenceModel {
 	 */
 	private $forumPostsModel;
 
-	protected function __construct(
+	public function __construct(
 		ForumDelenModel $forumDelenModel,
 		ForumDradenModel $forumDradenModel,
 		ForumDradenGelezenModel $forumDradenGelezenModel,

--- a/lib/model/forum/ForumPostsModel.php
+++ b/lib/model/forum/ForumPostsModel.php
@@ -75,7 +75,7 @@ class ForumPostsModel extends CachedPersistenceModel implements Paging {
 		return $post;
 	}
 
-	protected function __construct(
+	public function __construct(
 		ForumDradenGelezenModel $forumDradenGelezenModel
 	) {
 		parent::__construct();

--- a/lib/model/fotoalbum/FotoTagsModel.php
+++ b/lib/model/fotoalbum/FotoTagsModel.php
@@ -12,6 +12,10 @@ use CsrDelft\Orm\PersistenceModel;
 class FotoTagsModel extends PersistenceModel {
 
 	const ORM = FotoTag::class;
+	public function __construct() {
+		parent::__static();
+		parent::__construct();
+	}
 
 	/**
 	 * Default ORDER BY

--- a/lib/model/groepen/BesturenModel.php
+++ b/lib/model/groepen/BesturenModel.php
@@ -6,6 +6,10 @@ use CsrDelft\model\AbstractGroepenModel;
 use CsrDelft\model\entity\groepen\Bestuur;
 
 class BesturenModel extends AbstractGroepenModel {
+	public function __construct() {
+		parent::__static();
+		parent::__construct();
+	}
 
 	const ORM = Bestuur::class;
 

--- a/lib/model/groepen/CommissiesModel.php
+++ b/lib/model/groepen/CommissiesModel.php
@@ -7,6 +7,10 @@ use CsrDelft\model\entity\groepen\Commissie;
 use CsrDelft\model\entity\groepen\CommissieSoort;
 
 class CommissiesModel extends AbstractGroepenModel {
+	public function __construct() {
+		parent::__static();
+		parent::__construct();
+	}
 
 	const ORM = Commissie::class;
 

--- a/lib/model/groepen/KetzersModel.php
+++ b/lib/model/groepen/KetzersModel.php
@@ -6,6 +6,10 @@ use CsrDelft\model\AbstractGroepenModel;
 use CsrDelft\model\entity\groepen\Ketzer;
 
 class KetzersModel extends AbstractGroepenModel {
+	public function __construct() {
+		parent::__static();
+		parent::__construct();
+	}
 
 	const ORM = Ketzer::class;
 

--- a/lib/model/groepen/KringenModel.php
+++ b/lib/model/groepen/KringenModel.php
@@ -7,6 +7,10 @@ use CsrDelft\model\entity\groepen\Kring;
 use CsrDelft\model\entity\groepen\Verticale;
 
 class KringenModel extends AbstractGroepenModel {
+	public function __construct() {
+		parent::__static();
+		parent::__construct();
+	}
 
 	const ORM = Kring::class;
 

--- a/lib/model/groepen/LichtingenModel.php
+++ b/lib/model/groepen/LichtingenModel.php
@@ -8,6 +8,10 @@ use CsrDelft\model\ProfielModel;
 use CsrDelft\Orm\Persistence\Database;
 
 class LichtingenModel extends AbstractGroepenModel {
+	public function __construct() {
+		parent::__static();
+		parent::__construct();
+	}
 
 	const ORM = Lichting::class;
 

--- a/lib/model/groepen/OnderverenigingenModel.php
+++ b/lib/model/groepen/OnderverenigingenModel.php
@@ -8,6 +8,10 @@ use CsrDelft\model\entity\groepen\OnderverenigingStatus;
 use CsrDelft\model\security\LoginModel;
 
 class OnderverenigingenModel extends AbstractGroepenModel {
+	public function __construct() {
+		parent::__static();
+		parent::__construct();
+	}
 
 	const ORM = Ondervereniging::class;
 

--- a/lib/model/groepen/RechtenGroepenModel.php
+++ b/lib/model/groepen/RechtenGroepenModel.php
@@ -6,6 +6,10 @@ use CsrDelft\model\AbstractGroepenModel;
 use CsrDelft\model\entity\groepen\RechtenGroep;
 
 class RechtenGroepenModel extends AbstractGroepenModel {
+	public function __construct() {
+		parent::__static();
+		parent::__construct();
+	}
 
 	const ORM = RechtenGroep::class;
 

--- a/lib/model/groepen/VerticalenModel.php
+++ b/lib/model/groepen/VerticalenModel.php
@@ -6,6 +6,10 @@ use CsrDelft\model\AbstractGroepenModel;
 use CsrDelft\model\entity\groepen\Verticale;
 
 class VerticalenModel extends AbstractGroepenModel {
+	public function __construct() {
+		parent::__static();
+		parent::__construct();
+	}
 
 	const ORM = Verticale::class;
 

--- a/lib/model/groepen/WerkgroepenModel.php
+++ b/lib/model/groepen/WerkgroepenModel.php
@@ -6,5 +6,9 @@ use CsrDelft\model\entity\groepen\Werkgroep;
 
 
 class WerkgroepenModel extends KetzersModel {
+	public function __construct() {
+		parent::__static();
+		parent::__construct();
+	}
 	const ORM = Werkgroep::class;
 }

--- a/lib/model/groepen/WoonoordenModel.php
+++ b/lib/model/groepen/WoonoordenModel.php
@@ -8,6 +8,10 @@ use CsrDelft\model\entity\groepen\Woonoord;
 use CsrDelft\model\security\LoginModel;
 
 class WoonoordenModel extends AbstractGroepenModel {
+	public function __construct() {
+		parent::__static();
+		parent::__construct();
+	}
 
 	const ORM = Woonoord::class;
 

--- a/lib/model/instellingen/InstellingenModel.php
+++ b/lib/model/instellingen/InstellingenModel.php
@@ -32,7 +32,7 @@ class InstellingenModel extends CachedPersistenceModel {
 	 * @throws FileLoaderImportCircularReferenceException
 	 * @throws FileLoaderLoadException
 	 */
-	protected function __construct() {
+	public function __construct() {
 		parent::__construct();
 
 		$this->load('instellingen/stek_instelling.yaml', new InstellingConfiguration());

--- a/lib/model/instellingen/LidInstellingenModel.php
+++ b/lib/model/instellingen/LidInstellingenModel.php
@@ -33,7 +33,7 @@ class LidInstellingenModel extends CachedPersistenceModel {
 	 * @throws FileLoaderImportCircularReferenceException
 	 * @throws FileLoaderLoadException
 	 */
-	protected function __construct() {
+	public function __construct() {
 		parent::__construct();
 
 		$this->load('instellingen/lid_instelling.yaml', new InstellingConfiguration());

--- a/lib/model/instellingen/LidToestemmingModel.php
+++ b/lib/model/instellingen/LidToestemmingModel.php
@@ -30,7 +30,7 @@ class LidToestemmingModel extends CachedPersistenceModel {
 	 * @throws FileLoaderImportCircularReferenceException
 	 * @throws FileLoaderLoadException
 	 */
-	protected function __construct() {
+	public function __construct() {
 		parent::__construct();
 
 		$this->load('instellingen/toestemming.yaml', new InstellingConfiguration());

--- a/lib/model/maalcie/MaaltijdenModel.php
+++ b/lib/model/maalcie/MaaltijdenModel.php
@@ -53,7 +53,7 @@ class MaaltijdenModel extends PersistenceModel {
 	 * @param CorveeTakenModel $corveeTakenModel
 	 * @param CorveeRepetitiesModel $corveeRepetitiesModel
 	 */
-	protected function __construct(
+	public function __construct(
 		MaaltijdAanmeldingenModel $maaltijdAanmeldingenModel,
 		MaaltijdAbonnementenModel $maaltijdAbonnementenModel,
 		ArchiefMaaltijdModel $archiefMaaltijdModel,

--- a/lib/model/security/AccessModel.php
+++ b/lib/model/security/AccessModel.php
@@ -152,7 +152,7 @@ class AccessModel extends CachedPersistenceModel {
 	/**
 	 * AccessModel constructor.
 	 */
-	protected function __construct() {
+	public function __construct() {
 		parent::__construct();
 		$this->loadPermissions();
 	}

--- a/lib/model/security/CliLoginModel.php
+++ b/lib/model/security/CliLoginModel.php
@@ -40,7 +40,7 @@ class CliLoginModel extends LoginModel {
 	/**
 	 * CliLoginModel constructor.
 	 */
-	protected function __construct() {
+	public function __construct() {
 		parent::__static();
 		parent::__construct();
 		if (!$this->validate()) {

--- a/lib/model/security/LoginModel.php
+++ b/lib/model/security/LoginModel.php
@@ -93,7 +93,7 @@ class LoginModel extends PersistenceModel implements Validator {
 	/**
 	 * LoginModel constructor.
 	 */
-	protected function __construct() {
+	public function __construct() {
 		parent::__construct();
 		/**
 		 * CliLoginModel doet zijn eigen ding.


### PR DESCRIPTION
Zorg ervoor dat standaard PersistenceModel modellen ook via de symfony DI geladen kunnen worden.

Grootste veranderingen hierdoor zijn:
- Alle modellen hebben nu een public constructor
- De `__static` method werkt niet meer helemaal naar behoren, deze moet als deze gebruikt wordt vóór `parent::__construct` aangeroepen worden. Er moet misschien nog iets komen om te voorkomen dat de initializatiecode meerdere keren wordt uitgevoerd.