### PR TITLE
Verwijder huizenmarkt advertentie

### DIFF
--- a/resources/views/layout-extern/index.blade.php
+++ b/resources/views/layout-extern/index.blade.php
@@ -178,11 +178,6 @@
 							</a>
 						</li>
 						<li>
-							<a href="https://www.huizenmarkt.nl/">
-								<img src='https://csrdelft.nl/plaetjes/banners/logo-huizenmarkt.png' alt='Huurwoningen'>
-							</a>
-						</li>
-						<li>
 							<a href="http://mechdes.nl/">
 								<img src='https://csrdelft.nl/plaetjes/banners/mechdes.gif' alt='Mechdes advertentie'>
 							</a>


### PR DESCRIPTION
Huizenmarkt advertentie moest weg van de AqCie

- Advertentie link verwijderd uit `resources/views/layout-extern/index.blade.php`
- Advertentie afbeelding verwijderd van de server