### PR TITLE
Fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,10 @@
 		"phpstan/phpstan": "*",
 		"phpunit/phpunit": "^6.5",
 		"spatie/phpunit-snapshot-assertions": "^1.4",
-		"symfony/profiler-pack": "*"
+		"symfony/profiler-pack": "*",
+		"doctrine/doctrine-fixtures-bundle": "^3.3",
+		"symfony/maker-bundle": "^1.19",
+		"fzaninotto/faker": "^1.9"
 	},
 	"scripts": {
 		"serve": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa3586772602536ce0adfdb765056e78",
+    "content-hash": "f0d416e8bf27287edf0a5ba50fb07f2c",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -3554,16 +3554,16 @@
         },
         {
             "name": "symfony/cache-contracts",
-            "version": "v2.1.2",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "87c92f62c494626598e9148208aaa6d1716b8e3c"
+                "reference": "9771a09d2e6b84ecb8c9f0a7dbc72ee92aeba009"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/87c92f62c494626598e9148208aaa6d1716b8e3c",
-                "reference": "87c92f62c494626598e9148208aaa6d1716b8e3c",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/9771a09d2e6b84ecb8c9f0a7dbc72ee92aeba009",
+                "reference": "9771a09d2e6b84ecb8c9f0a7dbc72ee92aeba009",
                 "shasum": ""
             },
             "require": {
@@ -3577,6 +3577,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -3608,7 +3612,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-07-06T13:23:11+00:00"
         },
         {
             "name": "symfony/config",
@@ -3832,16 +3836,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.1.2",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337"
+                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337",
-                "reference": "dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5e20b83385a77593259c9f8beb2c43cd03b2ac14",
+                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14",
                 "shasum": ""
             },
             "require": {
@@ -3851,6 +3855,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -3874,7 +3882,7 @@
             ],
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
-            "time": "2020-05-27T08:34:37+00:00"
+            "time": "2020-06-06T08:49:21+00:00"
         },
         {
             "name": "symfony/doctrine-bridge",
@@ -4164,16 +4172,16 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.1.2",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "405952c4e90941a17e52ef7489a2bd94870bb290"
+                "reference": "f6f613d74cfc5a623fc36294d3451eb7fa5a042b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/405952c4e90941a17e52ef7489a2bd94870bb290",
-                "reference": "405952c4e90941a17e52ef7489a2bd94870bb290",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/f6f613d74cfc5a623fc36294d3451eb7fa5a042b",
+                "reference": "f6f613d74cfc5a623fc36294d3451eb7fa5a042b",
                 "shasum": ""
             },
             "require": {
@@ -4187,6 +4195,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -4218,7 +4230,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-07-06T13:23:11+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -5920,16 +5932,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.1.2",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "66a8f0957a3ca54e4f724e49028ab19d75a8918b"
+                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/66a8f0957a3ca54e4f724e49028ab19d75a8918b",
-                "reference": "66a8f0957a3ca54e4f724e49028ab19d75a8918b",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/58c7475e5457c5492c26cc740cc0ad7464be9442",
+                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442",
                 "shasum": ""
             },
             "require": {
@@ -5943,6 +5955,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -5974,7 +5990,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-07-06T13:23:11+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -6155,16 +6171,16 @@
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v2.1.2",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "e5ca07c8f817f865f618aa072c2fe8e0e637340e"
+                "reference": "616a9773c853097607cf9dd6577d5b143ffdcd63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/e5ca07c8f817f865f618aa072c2fe8e0e637340e",
-                "reference": "e5ca07c8f817f865f618aa072c2fe8e0e637340e",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/616a9773c853097607cf9dd6577d5b143ffdcd63",
+                "reference": "616a9773c853097607cf9dd6577d5b143ffdcd63",
                 "shasum": ""
             },
             "require": {
@@ -6177,6 +6193,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -6208,7 +6228,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-07-06T13:23:11+00:00"
         },
         {
             "name": "symfony/twig-bridge",
@@ -6868,6 +6888,188 @@
     ],
     "packages-dev": [
         {
+            "name": "doctrine/data-fixtures",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/data-fixtures.git",
+                "reference": "7ebac50901eb4516816ac39100dba1759d843943"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/7ebac50901eb4516816ac39100dba1759d843943",
+                "reference": "7ebac50901eb4516816ac39100dba1759d843943",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "^2.11",
+                "doctrine/persistence": "^1.3.3",
+                "php": "^7.2 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/phpcr-odm": "<1.3.0"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^6.0",
+                "doctrine/dbal": "^2.5.4",
+                "doctrine/mongodb-odm": "^1.3.0",
+                "doctrine/orm": "^2.7.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "For using MongoDB ODM with PHP 7",
+                "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
+                "doctrine/orm": "For loading ORM fixtures",
+                "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\DataFixtures\\": "lib/Doctrine/Common/DataFixtures"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Data Fixtures for all Doctrine Object Managers",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database"
+            ],
+            "time": "2020-05-25T19:45:03+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-fixtures-bundle",
+            "version": "3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineFixturesBundle.git",
+                "reference": "39defca57ee0949e1475c46177b30b6d1b732e8f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/39defca57ee0949e1475c46177b30b6d1b732e8f",
+                "reference": "39defca57ee0949e1475c46177b30b6d1b732e8f",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/data-fixtures": "^1.3",
+                "doctrine/doctrine-bundle": "^1.11|^2.0",
+                "doctrine/orm": "^2.6.0",
+                "doctrine/persistence": "^1.3",
+                "php": "^7.1",
+                "symfony/config": "^3.4|^4.3|^5.0",
+                "symfony/console": "^3.4|^4.3|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.3|^5.0",
+                "symfony/doctrine-bridge": "^3.4|^4.1|^5.0",
+                "symfony/http-kernel": "^3.4|^4.3|^5.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpunit/phpunit": "^7.4",
+                "symfony/phpunit-bridge": "^4.1|^5.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\FixturesBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "http://www.doctrine-project.org"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DoctrineFixturesBundle",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "Fixture",
+                "persistence"
+            ],
+            "time": "2020-04-02T16:40:37+00:00"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "fc10d778e4b84d5bd315dad194661e091d307c6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/fc10d778e4b84d5bd315dad194661e091d307c6f",
+                "reference": "fc10d778e4b84d5bd315dad194661e091d307c6f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7",
+                "squizlabs/php_codesniffer": "^2.9.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2019-12-12T13:22:17+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.10.1",
             "source": {
@@ -6914,6 +7116,58 @@
                 "object graph"
             ],
             "time": "2020-06-29T13:22:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "c346bbfafe2ff60680258b631afb730d186ed864"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c346bbfafe2ff60680258b631afb730d186ed864",
+                "reference": "c346bbfafe2ff60680258b631afb730d186ed864",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "0.0.5",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2020-07-02T17:12:47+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -8121,6 +8375,74 @@
                 "testing"
             ],
             "time": "2019-05-13T06:15:55+00:00"
+        },
+        {
+            "name": "symfony/maker-bundle",
+            "version": "v1.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/maker-bundle.git",
+                "reference": "bea8c3c959e48a2c952cc7c4f4f32964be8b8874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/maker-bundle/zipball/bea8c3c959e48a2c952cc7c4f4f32964be8b8874",
+                "reference": "bea8c3c959e48a2c952cc7c4f4f32964be8b8874",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^1.2",
+                "nikic/php-parser": "^4.0",
+                "php": "^7.1.3",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/filesystem": "^3.4|^4.0|^5.0",
+                "symfony/finder": "^3.4|^4.0|^5.0",
+                "symfony/framework-bundle": "^3.4|^4.0|^5.0",
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
+            },
+            "require-dev": {
+                "doctrine/doctrine-bundle": "^1.8|^2.0",
+                "doctrine/orm": "^2.3",
+                "friendsofphp/php-cs-fixer": "^2.8",
+                "friendsoftwig/twigcs": "^3.1.2",
+                "symfony/http-client": "^4.3|^5.0",
+                "symfony/phpunit-bridge": "^4.3|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/security-core": "^3.4|^4.0|^5.0",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\MakerBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Maker helps you create empty commands, controllers, form classes, tests and more so you can forget about writing boilerplate code.",
+            "homepage": "https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html",
+            "keywords": [
+                "code generator",
+                "generator",
+                "scaffold",
+                "scaffolding"
+            ],
+            "time": "2020-05-29T14:47:30+00:00"
         },
         {
             "name": "symfony/profiler-pack",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -8,4 +8,6 @@ return [
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
+    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
+    Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
 ];

--- a/config/packages/dev/maker.yaml
+++ b/config/packages/dev/maker.yaml
@@ -1,0 +1,2 @@
+maker:
+  root_namespace: 'CsrDelft'

--- a/docs/fixtures.md
+++ b/docs/fixtures.md
@@ -1,0 +1,26 @@
+# Fixtures
+
+Er zijn fixtures om data in de database te laden zonder dat je een productiedatabase nodig hebt. Dit kan handing zijn voor het maken van tests.
+
+De fixture generators gaan altijd uit van een verse database waar alle migraties op uitgevoerd zijn.
+
+## Fixtures laden
+
+Voordat je fixtures gaat laden is het belangrijk om te controleren of je huidige database weggegooid mag worden
+
+Run `php bin/console doctirne:database:drop` om te checken welke database je nu in gebruik hebt en verander deze in `.env.local` als het niet klopt. Het is aanbevolen om een losse database te hebben waar de fixtures in geladen zijn.
+
+1. Zet de database url naar een nieuwe database in .env.local
+1. Run `php bin/console doctrine:database:drop --force` om de huidige database te droppen (hoeft niet de eerste keer).
+1. Run `php bin/console doctrine:database:create` om de database aan te maken.
+1. Run `php bin/console doctrine:migrations:migrate -n` om alle migraties uit te voeren.
+1. Run `php bin/console doctrine:fixtures:load --no-interaction` om alle fixtures te laden.
+
+De fixtures bevatten ook het account `x101` met wachtwoord `stek open u voor mij!`, dit account heeft PubCie rechten.
+
+## Fixtures maken
+
+Met de maker bundle kun je makkelijk nieuwe fixtures genereren. Run `php bin/console make:fixtures` om nieuwe fixtures te maken. In de map `lib/DataFixtures` staan alle fixtures. Je kan hier afkijken hoe het gedaan wordt.
+
+Voor fixtures kun je ook `fzaninotto/faker` gebruiken om fake data te genereren.
+

--- a/lib/DataFixtures/AccountFixtures.php
+++ b/lib/DataFixtures/AccountFixtures.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace CsrDelft\DataFixtures;
+
+use CsrDelft\entity\Geslacht;
+use CsrDelft\entity\OntvangtContactueel;
+use CsrDelft\entity\profiel\Profiel;
+use CsrDelft\entity\security\Account;
+use CsrDelft\entity\security\enum\AccessRole;
+use CsrDelft\model\entity\LidStatus;
+use CsrDelft\repository\security\AccountRepository;
+use CsrDelft\service\security\LoginService;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class AccountFixtures extends Fixture {
+	/**
+	 * @var AccountRepository
+	 */
+	private $accountRepository;
+
+	public function __construct(AccountRepository $accountRepository) {
+		$this->accountRepository = $accountRepository;
+	}
+
+	public function load(ObjectManager $manager) {
+		$externProfiel = new Profiel();
+		$externProfiel->uid = LoginService::UID_EXTERN;
+		$externProfiel->nickname = 'nobody';
+		$externProfiel->voornaam = 'Niet';
+		$externProfiel->achternaam = 'ingelogd';
+		$externProfiel->voorletters = 'Niet';
+		$externProfiel->land = 'Nederland';
+		$externProfiel->geslacht = Geslacht::Man();
+		$externProfiel->status = LidStatus::Nobody;
+		$externProfiel->ontvangtcontactueel = OntvangtContactueel::Nee();
+		$externProfiel->gebdatum = date_create_immutable('1960-01-01');
+		$externProfiel->lengte = 0;
+		$externProfiel->adres = '';
+		$externProfiel->postcode = '';
+		$externProfiel->woonplaats = '';
+		$externProfiel->email = '';
+		$externProfiel->lidjaar = 0;
+
+		$manager->persist($externProfiel);
+
+		$externAccount = new Account();
+		$externAccount->username = '';
+		$externAccount->email = '';
+		$externAccount->pass_hash = '';
+		$externAccount->failed_login_attempts = 0;
+		$externAccount->pass_since = date_create_immutable();
+		$externAccount->uid = $externProfiel->uid;
+		$externAccount->profiel = $externProfiel;
+		$externAccount->perm_role = AccessRole::Nobody;
+
+		$manager->persist($externAccount);
+
+		$pubcieProfiel = new Profiel();
+		$pubcieProfiel->uid = 'x101';
+		$pubcieProfiel->nickname = 'pubcie';
+		$pubcieProfiel->voornaam = 'Pub';
+		$pubcieProfiel->achternaam = 'Cie';
+		$pubcieProfiel->voorletters = 'P.';
+		$pubcieProfiel->land = 'Nederland';
+		$pubcieProfiel->geslacht = Geslacht::Man();
+		$pubcieProfiel->status = LidStatus::Lid;
+		$pubcieProfiel->ontvangtcontactueel = OntvangtContactueel::Nee();
+		$pubcieProfiel->gebdatum = date_create_immutable('1960-01-01');
+		$pubcieProfiel->lengte = 0;
+		$pubcieProfiel->adres = '';
+		$pubcieProfiel->postcode = '';
+		$pubcieProfiel->woonplaats = '';
+		$pubcieProfiel->email = '';
+		$pubcieProfiel->lidjaar = 0;
+
+		$manager->persist($pubcieProfiel);
+
+		$account = $this->accountRepository->maakAccount('x101');
+
+		$this->accountRepository->wijzigWachtwoord($account, 'stek open u voor mij!');
+
+		$account->perm_role = AccessRole::PubCie;
+
+		$manager->flush();
+	}
+}

--- a/lib/DataFixtures/CmsPaginaFixtures.php
+++ b/lib/DataFixtures/CmsPaginaFixtures.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace CsrDelft\DataFixtures;
+
+use CsrDelft\entity\CmsPagina;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class CmsPaginaFixtures extends Fixture {
+	public function load(ObjectManager $manager) {
+		$legePagina = new CmsPagina();
+
+		$legePagina->inhoud = '';
+		$legePagina->laatst_gewijzigd = date_create_immutable();
+		$legePagina->titel = '';
+		$legePagina->naam = '';
+		$legePagina->inline_html = false;
+		$legePagina->rechten_bekijken = P_PUBLIC;
+		$legePagina->rechten_bewerken = '';
+
+		$manager->persist($legePagina);
+
+		$geenToegangPagina = new CmsPagina();
+
+		$geenToegangPagina->naam = '403';
+		$geenToegangPagina->titel = 'Geen toegang';
+		$geenToegangPagina->inhoud = <<<BB
+[h=1]Geen toegang[/h]
+U heeft helaas niet genoeg rechten om deze pagina te bekijken, of er is een fout opgetreden die bij legaal gebruik van de website niet voor zou moeten kunnen komen.
+
+Log in als gebruiker van de website met behulp van het inlogvakje rechtsboven op de pagina. Neem voor meer informatie contact op met de [email=pubcie@csrdelft.nl spamsafe=true]PubCie[/email].
+BB;
+		$geenToegangPagina->laatst_gewijzigd = date_create_immutable();
+		$geenToegangPagina->rechten_bekijken = P_PUBLIC;
+		$geenToegangPagina->rechten_bewerken = P_ADMIN;
+		$geenToegangPagina->inline_html = false;
+
+		$manager->persist($geenToegangPagina);
+
+		$nietGevondenPagina = new CmsPagina();
+
+		$nietGevondenPagina->naam = '404';
+		$nietGevondenPagina->titel = 'Niet gevonden';
+		$nietGevondenPagina->inhoud = <<<BB
+[h=1]Pagina niet gevonden[/h]
+
+De pagina die u zoekt kan helaas niet worden gevonden.
+BB;
+		$nietGevondenPagina->laatst_gewijzigd = date_create_immutable();
+		$nietGevondenPagina->rechten_bekijken = P_PUBLIC;
+		$nietGevondenPagina->rechten_bewerken = P_ADMIN;
+		$nietGevondenPagina->inline_html = false;
+
+		$manager->persist($nietGevondenPagina);
+
+		$thuisPagina = new CmsPagina();
+		$thuisPagina->naam = 'thuis';
+		$thuisPagina->titel = 'Vereniging van Christenstudenten';
+		$thuisPagina->inhoud = <<<BB
+[h=1]Civitas Studiosorum Reformatorum Delft[/h]
+
+Dit is de voorpagina.
+BB;
+		$thuisPagina->laatst_gewijzigd = date_create_immutable();
+		$thuisPagina->rechten_bekijken = P_PUBLIC;
+		$thuisPagina->rechten_bewerken = 'P_ADMIN,Bestuur';
+		$thuisPagina->inline_html = true;
+
+		$manager->persist($thuisPagina);
+
+		$manager->flush();
+	}
+}

--- a/lib/DataFixtures/ExternMenuFixtures.php
+++ b/lib/DataFixtures/ExternMenuFixtures.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace CsrDelft\DataFixtures;
+
+use CsrDelft\entity\MenuItem;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class ExternMenuFixtures extends Fixture {
+	public function load(ObjectManager $manager) {
+		$externMenuItem = $this->nieuwMenuItem(null, 0, 'extern', '/', true, P_PUBLIC);
+		$manager->persist($externMenuItem);
+
+		$verenigingMenuItem = $this->nieuwMenuItem($externMenuItem, 10, 'Vereniging', '/vereniging', true, P_PUBLIC);
+
+		$manager->persist($verenigingMenuItem);
+
+		$manager->flush();
+	}
+
+	private function nieuwMenuItem($parent, $volgorde, $tekst, $link, $zichtbaar, $rechten_bekijken) {
+		$menuItem = new MenuItem();
+		$menuItem->parent = $parent;
+		$menuItem->volgorde = $volgorde;
+		$menuItem->tekst = $tekst;
+		$menuItem->link = $link;
+		$menuItem->zichtbaar = $zichtbaar;
+		$menuItem->rechten_bekijken = $rechten_bekijken;
+
+		return $menuItem;
+	}
+}

--- a/lib/DataFixtures/MenuFixtures.php
+++ b/lib/DataFixtures/MenuFixtures.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CsrDelft\DataFixtures;
+
+use CsrDelft\entity\MenuItem;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class MenuFixtures extends Fixture {
+	public function load(ObjectManager $manager) {
+		$mainMenuItem = $this->nieuwMenuItem(null, 0, 'main', '/', true, P_PUBLIC);
+		$manager->persist($mainMenuItem);
+
+		$personalMenuItem = $this->nieuwMenuItem(null, 5, 'Personal', '/profiel', true, P_LOGGED_IN);
+		$manager->persist($personalMenuItem);
+
+		$remoteForaMenuItem = $this->nieuwMenuItem(null, 0, 'remotefora', '/', true, P_PUBLIC);
+		$manager->persist($remoteForaMenuItem);
+
+		$manager->flush();
+	}
+
+	private function nieuwMenuItem($parent, $volgorde, $tekst, $link, $zichtbaar, $rechten_bekijken) {
+		$menuItem = new MenuItem();
+		$menuItem->parent = $parent;
+		$menuItem->volgorde = $volgorde;
+		$menuItem->tekst = $tekst;
+		$menuItem->link = $link;
+		$menuItem->zichtbaar = $zichtbaar;
+		$menuItem->rechten_bekijken = $rechten_bekijken;
+
+		return $menuItem;
+	}
+}

--- a/lib/DataFixtures/ProfielFixture.php
+++ b/lib/DataFixtures/ProfielFixture.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace CsrDelft\DataFixtures;
+
+use CsrDelft\entity\Geslacht;
+use CsrDelft\entity\OntvangtContactueel;
+use CsrDelft\entity\profiel\Profiel;
+use CsrDelft\model\entity\LidStatus;
+use CsrDelft\model\entity\profiel\ProfielLogTextEntry;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Faker\Factory as Faker;
+
+class ProfielFixture extends Fixture {
+	public function load(ObjectManager $manager) {
+		$lichtingen = range(20, 29);
+		$lichtingsGrootte = 50;
+		$faker = Faker::create('nl_NL');
+
+		foreach ($lichtingen as $lichting) {
+			foreach (range(1, $lichtingsGrootte) as $index) {
+				$lidNummer = sprintf("%02d%02d", $lichting, $index);
+				$geslacht = $faker->randomElement(['male', 'female']);
+
+				$profiel = new Profiel();
+				$profiel->uid = $lidNummer;
+				$profiel->lidjaar = 2000 + $lichting;
+				$profiel->geslacht = ['male' => Geslacht::Man(), 'female' => Geslacht::Vrouw()][$geslacht];
+				// TODO $profiel->changelog;
+				$profiel->changelog = [
+					new ProfielLogTextEntry('Aangemaakt door fixtures'),
+				];
+				$profiel->voornaam = $faker->firstName($geslacht);
+				$profiel->voornamen = $profiel->voornaam . " " . $faker->firstName($geslacht);
+				$profiel->voorletters = implode("", array_map(function ($el) {
+					return substr($el, 0, 1) . ".";
+				}, explode(" ", $profiel->voornamen)));
+				$profiel->tussenvoegsel = '';
+				$profiel->achternaam = $faker->lastName;
+				$profiel->postfix = '';
+				$profiel->nickname = '';
+				$profiel->duckname = '';
+				$profiel->gebdatum = $faker->dateTimeBetween('-25 years', '-18 years');
+				$profiel->sterfdatum = null;
+				$profiel->lengte = $faker->numberBetween(160, 210);
+				// getrouwd
+				$profiel->echtgenoot = null;
+				$profiel->adresseringechtpaar = null;
+				$profiel->ontvangtcontactueel = OntvangtContactueel::Nee();
+				// adres
+				$profiel->adres = $faker->streetAddress;
+				$profiel->postcode = $faker->postcode;
+				$profiel->woonplaats = $faker->city;
+				$profiel->land = $faker->country;
+				$profiel->telefoon = $faker->phoneNumber;
+				$profiel->o_adres = $faker->streetAddress;
+				$profiel->o_postcode = $faker->postcode;
+				$profiel->o_woonplaats = $faker->city;
+				$profiel->o_land = $faker->country;
+				$profiel->o_telefoon = $faker->phoneNumber;
+				// contact
+				$profiel->email = $faker->email;
+				$profiel->sec_email = $faker->email;
+				$profiel->mobiel = $faker->phoneNumber;
+				$profiel->linkedin = null;
+				$profiel->website = null;
+				// studie
+				$profiel->studie = null;
+				$profiel->studiejaar = 2000 + $lichting;
+				$profiel->beroep = null;
+				// lidmaatschap
+				$profiel->lidafdatum = null;
+				$profiel->status = LidStatus::Lid;
+				// geld
+				$profiel->bankrekening = $faker->iban('NL');
+				$profiel->machtiging = true;
+				// verticale
+				$profiel->moot = null;
+				$profiel->verticale = $faker->randomElement(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']);
+				$profiel->verticaleleider = false;
+				$profiel->kringcoach = false;
+				// civi-gegevens
+				$profiel->patroon = null;
+				$profiel->eetwens = null;
+				$profiel->corvee_punten = 0;
+				$profiel->corvee_punten_bonus = 0;
+				// novitiaat
+				$profiel->novitiaat = null;
+				$profiel->novitiaatBijz = null;
+				$profiel->medisch = null;
+				$profiel->startkamp = null;
+				$profiel->matrixPlek = null;
+				$profiel->novietSoort = null;
+				$profiel->kgb = null;
+				$profiel->vrienden = null;
+				$profiel->middelbareSchool = null;
+				$profiel->profielOpties = null;
+				// overig
+				$profiel->kerk = null;
+				$profiel->muziek = null;
+				$profiel->zingen = null;
+
+				$manager->persist($profiel);
+			}
+		}
+
+		$manager->flush();
+	}
+}

--- a/lib/DataFixtures/VerticalenFixtures.php
+++ b/lib/DataFixtures/VerticalenFixtures.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace CsrDelft\DataFixtures;
+
+use CsrDelft\entity\groepen\enum\GroepStatus;
+use CsrDelft\entity\groepen\Verticale;
+use CsrDelft\entity\profiel\Profiel;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Faker\Factory as Faker;
+
+class VerticalenFixtures extends Fixture {
+	public function load(ObjectManager $manager) {
+		$faker = Faker::create('nl_NL');
+
+		$verticaleLetters = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'];
+		$verticaleNamen = $faker->words(count($verticaleLetters));
+
+		foreach ($verticaleLetters as $i => $letter) {
+			$verticale = new Verticale();
+
+			$verticale->letter = $letter;
+			$verticale->naam = ucfirst($verticaleNamen[$i]);
+			$verticale->familie = 'Verticale';
+			$verticale->begin_moment = date_create_immutable();
+			$verticale->eind_moment = null;
+			$verticale->status = GroepStatus::HT();
+			$verticale->samenvatting = '';
+			$verticale->maker = $manager->find(Profiel::class, '2020');
+
+			$manager->persist($verticale);
+		}
+
+		$manager->flush();
+	}
+}

--- a/lib/repository/security/AccountRepository.php
+++ b/lib/repository/security/AccountRepository.php
@@ -8,6 +8,7 @@ use CsrDelft\entity\security\Account;
 use CsrDelft\entity\security\enum\AccessRole;
 use CsrDelft\repository\AbstractRepository;
 use CsrDelft\repository\fiscaat\CiviSaldoRepository;
+use CsrDelft\repository\MenuItemRepository;
 use CsrDelft\repository\ProfielRepository;
 use CsrDelft\service\AccessService;
 use Doctrine\Persistence\ManagerRegistry;
@@ -33,11 +34,16 @@ class AccountRepository extends AbstractRepository {
 	 * @var CiviSaldoRepository
 	 */
 	private $civiSaldoRepository;
+	/**
+	 * @var MenuItemRepository
+	 */
+	private $menuItemRepository;
 
-	public function __construct(ManagerRegistry $registry, AccessService $accessService, CiviSaldoRepository $civiSaldoRepository) {
+	public function __construct(ManagerRegistry $registry, AccessService $accessService, CiviSaldoRepository $civiSaldoRepository, MenuItemRepository $menuItemRepository) {
 		parent::__construct($registry, Account::class);
 		$this->accessService = $accessService;
 		$this->civiSaldoRepository = $civiSaldoRepository;
+		$this->menuItemRepository = $menuItemRepository;
 	}
 
 	const PASSWORD_HASH_ALGORITHM = PASSWORD_DEFAULT;
@@ -116,6 +122,15 @@ class AccountRepository extends AbstractRepository {
 		if (!$this->civiSaldoRepository->getSaldo($uid)) {
 			// Maak een CiviSaldo voor dit account
 			$this->civiSaldoRepository->maakSaldo($uid);
+		}
+
+		if (!$this->menuItemRepository->getMenuRoot($uid)) {
+			$menuItem = $this->menuItemRepository->nieuw(null);
+			$menuItem->rechten_bekijken = $uid;
+			$menuItem->tekst = $uid;
+			$menuItem->link = '';
+
+			$this->_em->persist($menuItem);
 		}
 
 		$account = new Account();

--- a/symfony.lock
+++ b/symfony.lock
@@ -47,6 +47,9 @@
     "doctrine/common": {
         "version": "v2.7.3"
     },
+    "doctrine/data-fixtures": {
+        "version": "1.4.3"
+    },
     "doctrine/dbal": {
         "version": "v2.5.13"
     },
@@ -63,6 +66,18 @@
             "./config/packages/prod/doctrine.yaml",
             "./src/Entity/.gitignore",
             "./src/Repository/.gitignore"
+        ]
+    },
+    "doctrine/doctrine-fixtures-bundle": {
+        "version": "3.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "3.0",
+            "ref": "fc52d86631a6dfd9fdf3381d0b7e3df2069e51b3"
+        },
+        "files": [
+            "./src/DataFixtures/AppFixtures.php"
         ]
     },
     "doctrine/doctrine-migrations-bundle": {
@@ -117,6 +132,9 @@
     "firebase/php-jwt": {
         "version": "v5.0.0"
     },
+    "fzaninotto/faker": {
+        "version": "v1.9.1"
+    },
     "globalcitizen/php-iban": {
         "version": "v2.7.2"
     },
@@ -167,6 +185,9 @@
     },
     "myclabs/deep-copy": {
         "version": "1.7.0"
+    },
+    "nikic/php-parser": {
+        "version": "v4.6.0"
     },
     "ocramius/proxy-manager": {
         "version": "2.0.4"
@@ -397,6 +418,15 @@
     },
     "symfony/inflector": {
         "version": "v5.0.4"
+    },
+    "symfony/maker-bundle": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
+        }
     },
     "symfony/mime": {
         "version": "v5.1.2"


### PR DESCRIPTION
Maakt het mogelijk om een stek te draaien zonder productiedata.

Het `doctrine:fixtures:load` command kan helaas niet alle tabellen legen (tabellen met een self-reference kunnen niet geleegd worden), dus daarom moet de db eerst gedropt worden als je m weer wil vullen.

## Stappen om dit te testen.
1. Zet de database url naar een nieuwe database in `.env.local`
1. Run `php bin/console doctrine:database:drop --force`
1. Run `php bin/console doctrine:database:create`
1. Run `php bin/console doctrine:migrations:migrate -n`
1. Run `php bin/console doctrine:fixtures:load --no-interaction`

Je hebt nu een verse db, er zijn alleen geen accounts. Run hier voor `php bin/console stek:account:nieuw` (fixtures maken nu profielen aan voor lichtingen tussen 2020 en 2029, dus daartussen kunnen accounts aangemaakt worden)