### PR TITLE
Verplaats interesse formulier van voorpagina naar lid worden pagina

### DIFF
--- a/lib/controller/CmsPaginaController.php
+++ b/lib/controller/CmsPaginaController.php
@@ -52,6 +52,8 @@ class CmsPaginaController extends AbstractController {
 				$tmpl = 'index';
 			} elseif ($naam === 'vereniging') {
 				$menu = true;
+			} elseif ($pagina->naam === 'lidworden') {
+				$tmpl = 'lidworden';
 			}
 			return view('layout-extern.' . $tmpl, [
 				'titel' => $body->getTitel(),

--- a/resources/assets/sass/extern.scss
+++ b/resources/assets/sass/extern.scss
@@ -321,3 +321,30 @@ optgroup {
 	background-color: #414262;
 }
 
+/**
+Lid worden pagina content en interesse formulier css
+ */
+#lid-worden-tekst {
+	float: left;
+	width: calc(50% - 1.5em);
+	margin-right: 3em;
+}
+
+#interesse-formulier {
+	float: right;
+	width: calc(50% - 1.5em);
+	padding: 10px;
+	border-radius: 5px;
+	z-index: 4;
+}
+
+@media screen and (max-width: $scherm-middel) {
+
+	#lid-worden-tekst, #interesse-formulier {
+		float: none;
+		width: 100%;
+		margin: 0 0 2em 0;
+		padding: 0;
+	}
+
+}

--- a/resources/assets/sass/extern.scss
+++ b/resources/assets/sass/extern.scss
@@ -336,6 +336,10 @@ Lid worden pagina content en interesse formulier css
 	padding: 10px;
 	border-radius: 5px;
 	z-index: 4;
+
+	h2 {
+		margin-top: 1.5em;
+	}
 }
 
 @media screen and (max-width: $scherm-middel) {

--- a/resources/assets/sass/extern/_footer.scss
+++ b/resources/assets/sass/extern/_footer.scss
@@ -34,15 +34,6 @@
       width: 100%;
     }
 
-    form {
-      margin: 0 3em 0 0;
-      width: calc(50% - 1.5em);
-    }
-
-    .contact {
-      width: calc(50% - 1.5em);
-    }
-
     .copyright,.sponsors {
       border-top: solid 2px $geel;
       list-style: none;
@@ -100,19 +91,6 @@
       padding: 3em 3em 1em 3em;
       display: block;
       width: 100%;
-      form {
-        width: 100%;
-        margin: 0 0 4em 0;
-      }
-
-      .contact {
-        width: 100%;
-        margin: 0 0 4em 0;
-      }
-
-      .copyright,.sponsors {
-        margin: 4em 0 2em 0;
-      }
     }
   }
 }
@@ -123,16 +101,8 @@
     margin-top: -2.5em;
     padding-top: 2.5em;
     .inner {
-      padding: 2em 2em 0.1em 2em;
-    }
-
-    form {
-      margin: 0 0 3em 0;
-    }
-
-    .contact {
-      margin: 0 0 3em 0;
-    }
+			padding: 2em 2em 0.1em 2em;
+		}
   }
 
 }

--- a/resources/assets/sass/extern/_form.scss
+++ b/resources/assets/sass/extern/_form.scss
@@ -20,7 +20,7 @@
 }
 
 form {
-  margin: 0 0 0 0;
+  margin: 2.5em 0 0 0;
 
   .field, .form-control {
     margin: 0 0 2em 0;

--- a/resources/views/layout-extern/index.blade.php
+++ b/resources/views/layout-extern/index.blade.php
@@ -149,8 +149,7 @@
 		<!-- Footer -->
 		<section id="footer">
 			<div class="inner">
-				<h2 class="major">Interesseformulier</h2>
-				@include('layout-extern.form')
+				<h2 class="major">Contactgegevens</h2>
 				<ul class="contact">
 					<li class="fa-home">
 						Soci&euml;teit Confide <br/>

--- a/resources/views/layout-extern/lidworden.blade.php
+++ b/resources/views/layout-extern/lidworden.blade.php
@@ -10,7 +10,11 @@
 	@if($showmenu)
 		@include('layout-extern.menu')
 	@endif
-	@php($body->view())
-	<h2 class="major" style="margin-top:1.5em;">Interesse Formulier</h2>
-	@include('layout-extern.form')
+	<div id="lid-worden-tekst">
+		@php($body->view())
+	</div>
+	<div id="interesse-formulier">
+		<h2 class="major" style="margin-top:1.5em;">Interesse Formulier</h2>
+		@include('layout-extern.form')
+	</div>
 @endsection

--- a/resources/views/layout-extern/lidworden.blade.php
+++ b/resources/views/layout-extern/lidworden.blade.php
@@ -14,7 +14,7 @@
 		@php($body->view())
 	</div>
 	<div id="interesse-formulier">
-		<h2 class="major" style="margin-top:1.5em;">Interesse Formulier</h2>
+		<h2 class="major">Interesse Formulier</h2>
 		@include('layout-extern.form')
 	</div>
 @endsection

--- a/resources/views/layout-extern/lidworden.blade.php
+++ b/resources/views/layout-extern/lidworden.blade.php
@@ -1,0 +1,16 @@
+@extends('layout-extern.layout')
+
+@section('titel', $titel)
+
+@section('styles')
+	@stylesheet('extern.css')
+@endsection
+
+@section('content')
+	@if($showmenu)
+		@include('layout-extern.menu')
+	@endif
+	@php($body->view())
+	<h2 class="major" style="margin-top:1.5em;">Interesse Formulier</h2>
+	@include('layout-extern.form')
+@endsection


### PR DESCRIPTION
- Zet alleen het interesse formulier van de voorpagina op de 'Lid worden' pagina.
- PromoCie wil eigenlijk: "Zijbalk rechts die mee scrollt en waar het interesseformulier in staat." Nu is het interesseformulier alleen zo groot dat de scrollbare zijbalk dan 2x groter is dan überhaupt de tekst die op de "Lid worden" pagina staat en het ziet er niet uit. Ik heb dus geen scrollbare zijbalk, maar het gewoon rechts gezet.

Nu op groot scherm: (formulier rechts)
![image](https://user-images.githubusercontent.com/24373899/82145125-f2fdad80-9848-11ea-90cd-06972d1e0cfa.png)

En op klein scherm: (formulier onder de tekst)
![image](https://user-images.githubusercontent.com/24373899/82145131-f8f38e80-9848-11ea-96f9-ac695836716e.png)
