### PR TITLE
Verwijder csrdelft/orm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
 	],
 	"require": {
 		"csrdelft/bb": "1.1.9",
-		"csrdelft/orm": "^1.9",
 		"easyrdf/easyrdf": "^0.9.1",
 		"eftec/bladeone": "3.21",
 		"ext-PDO": "*",
@@ -49,7 +48,8 @@
 		"symfony/serializer-pack": "^1.0",
 		"symfony/cache": "^5.0",
 		"beberlei/doctrineextensions": "^1.2",
-		"symfony/var-dumper": "^5.0"
+		"symfony/var-dumper": "^5.0",
+		"zumba/json-serializer": "^2.2"
     },
 	"config": {
 		"platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4aad40434af1c9d21a105c93c2f831a5",
+    "content-hash": "9a0f3633ddb0275f0127ff6f5047e8d4",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -436,66 +436,6 @@
             "description": "C.S.R. BB Parser",
             "homepage": "https://csrdelft.github.io/bb",
             "time": "2020-05-21T08:17:18+00:00"
-        },
-        {
-            "name": "csrdelft/orm",
-            "version": "v1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/csrdelft/orm.git",
-                "reference": "ec8b8d161aad28faddc359268d27d2264d33a2a4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/csrdelft/orm/zipball/ec8b8d161aad28faddc359268d27d2264d33a2a4",
-                "reference": "ec8b8d161aad28faddc359268d27d2264d33a2a4",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "ext-pdo": "*",
-                "php": ">=7.0.27",
-                "psr/container": "^1.0",
-                "zumba/json-serializer": "^2.2"
-            },
-            "require-dev": {
-                "phpunit/dbunit": "^4.0",
-                "phpunit/php-code-coverage": "^6.0",
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "CsrDelft\\Orm\\": "src"
-                },
-                "files": [
-                    "src/common.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PubCie der C.S.R. Delft",
-                    "email": "pubcie@csrdelft.nl",
-                    "homepage": "https://csrdelft.nl"
-                },
-                {
-                    "name": "Paul Brussee",
-                    "homepage": "https://github.com/brussee",
-                    "role": "Creator"
-                },
-                {
-                    "name": "Gerben Oolbekkink",
-                    "email": "g.j.w.oolbekkink@gmail.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "The creatively named object-relational mapping library for csrdelft.nl",
-            "homepage": "https://csrdelft.github.io/orm",
-            "time": "2020-03-05T16:18:53+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/lib/common/Doctrine/Type/SafeJsonType.php
+++ b/lib/common/Doctrine/Type/SafeJsonType.php
@@ -4,7 +4,7 @@
 namespace CsrDelft\common\Doctrine\Type;
 
 
-use CsrDelft\Orm\JsonSerializer\SafeJsonSerializer;
+use CsrDelft\common\Doctrine\Type\Serializer\SafeJsonSerializer;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 

--- a/lib/common/Doctrine/Type/Serializer/SafeJsonSerializer.php
+++ b/lib/common/Doctrine/Type/Serializer/SafeJsonSerializer.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace CsrDelft\common\Doctrine\Type\Serializer;
+
+use ReflectionClass;
+use Zumba\JsonSerializer\JsonSerializer;
+
+/**
+ * JsonSerializer that only allows serializing and deserializing of classes that are explicitly allowed.
+ * @author Sander
+ * @since 13-07-2018
+ */
+class SafeJsonSerializer extends JsonSerializer {
+
+	/**
+	 * Array of allowed classes
+	 * @var string[]
+	 */
+	protected $allowedClasses;
+
+	/**
+	 * SafeJsonSerializer constructor.
+	 * @param string[] $allowedClasses The classnames of classes that this serializer is allowed to (de)serialize. Passing null will allow all classes.
+	 * @param array $customObjectSerializerMap
+	 */
+	public function __construct(array $allowedClasses = null, array $customObjectSerializerMap = array()) {
+		parent::__construct(null, $customObjectSerializerMap);
+		$this->allowedClasses = (array)$allowedClasses;
+	}
+
+	/**
+	 * @param object $value
+	 * @return array
+	 * @throws \ReflectionException
+	 */
+	protected function serializeObject($value) {
+		$ref = new ReflectionClass($value);
+		$className = $ref->getName();
+		if ($this->classAllowed($className)) {
+			return parent::serializeObject($value);
+		} else {
+			throw new SafeJsonSerializerException("Serializing of $className is not allowed by this SafeJsonSerializer");
+		}
+	}
+
+	protected function unserializeObject($value) {
+		$className = $value[static::CLASS_IDENTIFIER_KEY];
+		if ($this->classAllowed($className)) {
+			return parent::unserializeObject($value);
+		} else {
+			throw new SafeJsonSerializerException("Deserializing of $className is not allowed by this SafeJsonSerializer");
+		}
+	}
+
+	/**
+	 * Whether this classname is allowed to be (un)serialized.
+	 * @param $className
+	 */
+	protected function classAllowed($className) {
+		return $this->allowedClasses === null || in_array($className, $this->allowedClasses);
+	}
+
+}

--- a/lib/common/Doctrine/Type/Serializer/SafeJsonSerializerException.php
+++ b/lib/common/Doctrine/Type/Serializer/SafeJsonSerializerException.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace CsrDelft\common\Doctrine\Type\Serializer;
+
+
+use Zumba\JsonSerializer\Exception\JsonSerializerException;
+
+class SafeJsonSerializerException extends JsonSerializerException {
+
+	/**
+	 * SafeJsonSerializerException constructor.
+	 * @param string $string
+	 */
+	public function __construct($string) {
+		parent::__construct($string);
+	}
+}

--- a/lib/configuratie.include.php
+++ b/lib/configuratie.include.php
@@ -14,10 +14,6 @@
 use CsrDelft\common\ContainerFacade;
 use CsrDelft\common\ShutdownHandler;
 use CsrDelft\Kernel;
-use CsrDelft\Orm\DependencyManager;
-use CsrDelft\Orm\Persistence\Database;
-use CsrDelft\Orm\Persistence\DatabaseAdmin;
-use CsrDelft\Orm\Persistence\OrmMemcache;
 use CsrDelft\repository\LogRepository;
 use CsrDelft\repository\security\AccountRepository;
 use CsrDelft\service\security\LoginService;
@@ -97,12 +93,6 @@ $container = $kernel->getContainer();
 // Gebruik de PDO connectie van doctrine
 $pdo = $container->get('doctrine.dbal.default_connection')->getWrappedConnection();
 
-// Set csrdelft/orm parts of the container
-$container->set(OrmMemcache::class, new OrmMemcache(env('CACHE_HOST'), (int)env('CACHE_PORT')));
-$container->set(Database::class, new Database($pdo));
-$container->set(DatabaseAdmin::class, new DatabaseAdmin($pdo));
-
-DependencyManager::setContainer($container);
 ContainerFacade::init($container);
 
 // ---

--- a/lib/configuratie.include.php
+++ b/lib/configuratie.include.php
@@ -90,9 +90,6 @@ $kernel = new Kernel($_SERVER['APP_ENV'], (bool)$_SERVER['APP_DEBUG']);
 $kernel->boot();
 $container = $kernel->getContainer();
 
-// Gebruik de PDO connectie van doctrine
-$pdo = $container->get('doctrine.dbal.default_connection')->getWrappedConnection();
-
 ContainerFacade::init($container);
 
 // ---

--- a/symfony.lock
+++ b/symfony.lock
@@ -26,9 +26,6 @@
     "csrdelft/bb": {
         "version": "v1.1.3"
     },
-    "csrdelft/orm": {
-        "version": "v1.8.6"
-    },
     "doctrine/annotations": {
         "version": "1.0",
         "recipe": {


### PR DESCRIPTION
Na jaren trouwe dienst is het moment gekomen om vaarwel te zeggen
tegen deze code. Alles is omgeschreven naar Doctrine wat de
mogelijkheid geeft om nog makkelijker uit te breiden.

Het proces van alles in een standaard structuur gieten en database
toegang standaardiseren is nu zo goed als klaar. Een proces wat nu al
meer dan zes jaar aan de gang is.