### PR TITLE
Voeg de mogelijkheid voor vertalingen toe

### DIFF
--- a/assets/scss/extern/_header.scss
+++ b/assets/scss/extern/_header.scss
@@ -114,6 +114,27 @@
 				padding: .6em 1.15em;
 			}
 		}
+
+		.locale-switch {
+			.nav-link {
+				background: $button-bg;
+				padding: 0.8em;
+				width: auto;
+			}
+
+			img {
+				vertical-align: middle;
+			}
+
+			.dropdown {
+				width: auto;
+				padding: 1em 0 0;
+				margin-top: -1em;
+				.dropdown-item {
+					padding: 0.8em;
+				}
+			}
+		}
 	}
 
 	&.alt {

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,9 @@
 		"symfony/yaml": "^5.0",
 		"sentry/sentry-symfony": "^3.5",
 		"symfony/form": "^5.0",
-		"symfony/translation": "^5.0"
+		"symfony/translation": "^5.0",
+		"twig/intl-extra": "^3.2",
+		"twig/extra-bundle": "^3.2"
 	},
 	"config": {
 		"platform": {

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
 		"symfony/security-bundle": "^5.0",
 		"symfony/yaml": "^5.0",
 		"sentry/sentry-symfony": "^3.5",
-		"symfony/form": "^5.0"
+		"symfony/form": "^5.0",
+		"symfony/translation": "^5.0"
 	},
 	"config": {
 		"platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6da10a40c952861ac46ec4279c74303a",
+    "content-hash": "59f6ad4be393065c200ff93a0eff96c9",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -8359,17 +8359,158 @@
             "time": "2020-12-08T17:02:38+00:00"
         },
         {
-            "name": "twig/twig",
-            "version": "v3.1.1",
+            "name": "twig/extra-bundle",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/twigphp/Twig.git",
-                "reference": "b02fa41f3783a2616eccef7b92fbc2343ffed737"
+                "url": "https://github.com/twigphp/twig-extra-bundle.git",
+                "reference": "07c94c7dcfe7e49abd45d4083ca5544a34969714"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/b02fa41f3783a2616eccef7b92fbc2343ffed737",
-                "reference": "b02fa41f3783a2616eccef7b92fbc2343ffed737",
+                "url": "https://api.github.com/repos/twigphp/twig-extra-bundle/zipball/07c94c7dcfe7e49abd45d4083ca5544a34969714",
+                "reference": "07c94c7dcfe7e49abd45d4083ca5544a34969714",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3|^8.0",
+                "symfony/framework-bundle": "^4.3|^5.0",
+                "symfony/twig-bundle": "^4.3|^5.0",
+                "twig/twig": "^3.2"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9",
+                "twig/cache-extra": "^3.0",
+                "twig/cssinliner-extra": "^2.12|^3.0",
+                "twig/html-extra": "^2.12|^3.0",
+                "twig/inky-extra": "^2.12|^3.0",
+                "twig/intl-extra": "^2.12|^3.0",
+                "twig/markdown-extra": "^2.12|^3.0",
+                "twig/string-extra": "^2.12|^3.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Twig\\Extra\\TwigExtraBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "A Symfony bundle for extra Twig extensions",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "bundle",
+                "extra",
+                "twig"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-05T15:24:51+00:00"
+        },
+        {
+            "name": "twig/intl-extra",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/intl-extra.git",
+                "reference": "919e8f945c30bd3efeb6a4d79722cda538116658"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/intl-extra/zipball/919e8f945c30bd3efeb6a4d79722cda538116658",
+                "reference": "919e8f945c30bd3efeb6a4d79722cda538116658",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/intl": "^4.3|^5.0",
+                "twig/twig": "^2.4|^3.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Twig\\Extra\\Intl\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "A Twig extension for Intl",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "intl",
+                "twig"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-01T14:58:18+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "f795ca686d38530045859b0350b5352f7d63447d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/f795ca686d38530045859b0350b5352f7d63447d",
+                "reference": "f795ca686d38530045859b0350b5352f7d63447d",
                 "shasum": ""
             },
             "require": {
@@ -8384,7 +8525,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -8428,7 +8569,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-27T19:28:23+00:00"
+            "time": "2021-01-05T15:40:36+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06c7e4d41365ce986907ae76fb368f69",
+    "content-hash": "6da10a40c952861ac46ec4279c74303a",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -7767,6 +7767,96 @@
                 }
             ],
             "time": "2020-10-24T12:01:57+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v5.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "a04209ba0d1391c828e5b2373181dac63c52ee70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/a04209ba0d1391c828e5b2373181dac63c52ee70",
+                "reference": "a04209ba0d1391c828e5b2373181dac63c52ee70",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/translation-contracts": "^2.3"
+            },
+            "conflict": {
+                "symfony/config": "<4.4",
+                "symfony/dependency-injection": "<5.0",
+                "symfony/http-kernel": "<5.0",
+                "symfony/twig-bundle": "<5.0",
+                "symfony/yaml": "<4.4"
+            },
+            "provide": {
+                "symfony/translation-implementation": "2.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/console": "^4.4|^5.0",
+                "symfony/dependency-injection": "^5.0",
+                "symfony/finder": "^4.4|^5.0",
+                "symfony/http-kernel": "^5.0",
+                "symfony/intl": "^4.4|^5.0",
+                "symfony/service-contracts": "^1.1.2|^2",
+                "symfony/yaml": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log-implementation": "To use logging capability in translator",
+                "symfony/config": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Translation Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-12-08T17:03:37+00:00"
         },
         {
             "name": "symfony/translation-contracts",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -12,4 +12,5 @@ return [
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
     Sentry\SentryBundle\SentryBundle::class => ['all' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
+    Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
 ];

--- a/config/packages/translation.yaml
+++ b/config/packages/translation.yaml
@@ -1,0 +1,6 @@
+framework:
+    default_locale: nl
+    translator:
+        default_path: '%kernel.project_dir%/translations'
+        fallbacks:
+            - nl

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -10,6 +10,11 @@ app-controller-sub:
 
 # Deze route is een catch-all als allerlaatste
 default:
-  path: /{naam}/{subnaam}
+  path: /{_locale<%app.supported_locales%>}/{naam}/{subnaam}
   controller: CsrDelft\controller\CmsPaginaController::bekijken
   defaults: { naam: thuis, subnaam: "", _mag: P_PUBLIC }
+
+defaultNoLocale:
+  path: /{naam}/{subnaam}
+  controller: CsrDelft\controller\CmsPaginaController::bekijken
+  defaults: { naam: thuis, subnaam: "", _mag: P_PUBLIC, _locale: nl}

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,6 +5,7 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
   container.dumper.inline_class_loader: true
+  app.supported_locales: 'nl|en'
 
 services:
   # default configuration for services in *this* file

--- a/db/doctrine_migrations/Version20210118122709.php
+++ b/db/doctrine_migrations/Version20210118122709.php
@@ -66,6 +66,8 @@ SQL
 
 	public function down(Schema $schema): void
 	{
+		$this->addSql('SET FOREIGN_KEY_CHECKS = 0;');
 		$this->addSql('DELETE FROM menus WHERE link LIKE \'/en/%\' AND rechten_bekijken = \'P_PUBLIC\'');
+		$this->addSql('SET FOREIGN_KEY_CHECKS = 1;');
 	}
 }

--- a/db/doctrine_migrations/Version20210118122709.php
+++ b/db/doctrine_migrations/Version20210118122709.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20210118122709 extends AbstractMigration
+{
+	public function getDescription(): string
+	{
+		return 'Engels extern menu';
+	}
+
+	public function up(Schema $schema): void
+	{
+		$this->addSql(<<<SQL
+-- Selecteer maximale item id uit db
+SELECT MAX(item_id) + 1 INTO @max_menu_id FROM menus;
+-- Selecteer de item id van het externe menu (noot, er zijn meerdere menus met tekst = 'extern')
+SELECT item_id INTO @extern_menu_id FROM menus WHERE tekst = 'extern' AND parent_id IS null LIMIT 1;
+
+INSERT INTO menus
+-- Lees het externe menu met een Recursive Common Table Expression
+WITH RECURSIVE menus_cte
+AS (
+	SELECT *
+	FROM menus
+	WHERE parent_id IS NULL AND tekst = 'extern'
+	UNION ALL
+	SELECT m.* FROM menus AS m, menus_cte AS c
+	WHERE m.parent_id = c.item_id
+)
+SELECT
+  -- Zet item id relatief aan einde van bestaande menu items, bewaar offset
+	@max_menu_id + item_id - @extern_menu_id AS item_id,
+	@max_menu_id + parent_id - @extern_menu_id AS parent_id,
+	volgorde,
+	CASE
+	  -- Vertaal menu item waardes
+		WHEN tekst = 'extern' THEN 'extern_en'
+		WHEN tekst = 'Vereniging' THEN 'Association'
+		WHEN tekst = 'Foto\'s' THEN 'Photos'
+		WHEN tekst = 'Forum' THEN 'Forum'
+		WHEN tekst = 'Lid worden?' THEN 'Want to join?'
+		WHEN tekst = 'Contact' THEN 'Contact'
+		WHEN tekst = 'Geloof' THEN 'Faith'
+		WHEN tekst = 'Vorming' THEN 'Education'
+		WHEN tekst = 'Gezelligheid' THEN 'Social'
+		WHEN tekst = 'Onder verenigingen' THEN 'Sub-associations'
+		WHEN tekst = 'Ontspanning' THEN 'Leisure'
+		WHEN tekst = 'Kamers Zoeken en Aanbieden' THEN 'Room search and offer'
+		WHEN tekst = 'Bedrijven' THEN 'Business'
+		ELSE ''
+	END AS tekst,
+  -- Voeg /en toe aan het begin van de link om locale en te forceren.
+	CONCAT('/en', link) AS link,
+	rechten_bekijken,
+	zichtbaar
+FROM menus_cte
+SQL
+		);
+	}
+
+	public function down(Schema $schema): void
+	{
+		$this->addSql('DELETE FROM menus WHERE link LIKE \'/en/%\' AND rechten_bekijken = \'P_PUBLIC\'');
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Lees hier meer over specifieke onderdelen van de stek, kijk hier als je denkt ie
 - [Composer](composer.md)
 - [Security](security.md)
 - [Tests](test.md)
+- [Vertalingen](translations.md)
 
 ## Overig
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,57 @@
+# Vertalingen
+
+De externe stek is ook beschikbaar in het Engels. Op de meeste plekken wordt de locale automatisch gebruikt. Het is ook mogelijk om de huidige locale op te halen. In controller functies kan dit door `Symfony\Component\HttpFoundation\Request` als argument te vragen en hier `getLocale` op aan te roepen. In overige services kun je `Symfony\Component\HttpFoundation\RequestStack` als argument vragen en hier `->getCurrentRequest()->getLocale()` op aanroepen.
+
+Zie ook de documentatie van [`symfony/translation`](https://symfony.com/doc/current/translation.html) voor meer informatie.
+
+## Vertalignen gebruiken
+### Vertalingen in templates
+
+In templates kunnen stukken tekst op twee verschillende manieren vertaald worden. Met `{% trans %}` blokken en met de `trans` filter.
+
+```html
+<p>{% trans %}Deze tekst wordt vertaald{% endtrans %}</p>
+
+<p>{{ 'Deze tekst wordt vertaald'|trans }}</p>
+```
+
+### Vertalingen in code
+
+Gebruik voor vertalingen in code de functie `trans` van `Symfony\Contracts\Translation\TranslatorInterface`.
+
+```php
+function __construct(\Symfony\Contracts\Translation\TranslatorInterface $translator) {
+	$bericht = $translator->trans('Deze tekst wordt vertaald');
+}
+```
+
+### Vertalingen in CMS paginas en menus
+
+CMS paginas en menus worden op basis van de huidige locale geladen. De standaard locale is `nl`, voor deze locale wordt de pagina of het menu met de gevraagde naam geladen. Voor alle andere locales wordt gezocht of de pagina of het menu met de naam gevolgd door `_<locale>` bestaat, als dit het geval is wordt deze geladen.
+
+Bijvoorbeeld voor de pagina `vereniging`. Voor locale `nl` wordt `vereniging` geladen. Voor locale `en` wordt `vereniging_en` geladen, als deze niet bestaat wordt `vereniging` geladen.
+
+## Vertalingen bewerken
+
+Gebruik het volgende commando om alle vertalingen die in de broncode gebruikt worden in het centrale vertalingen bestand te zetten:
+
+```shell
+symfony console translation:update en --force --domain=messages
+```
+
+Dit zorgt ervoor dat het bestand `translations/messages+intl-icu.en.xlf` wordt geupdate. Zorg er in dit bestand voor dat alle `<target>` tags gevuld zijn met de vertaalde teksten. (Als alles vertaald is kun je geen `__` meer vinden in het bestand.)
+
+## Variabelen in vertalingen
+
+Het is ook mogelijk om variabelen te gebruiken in vertalingen, bijvoorbeeld als er een woord is dat op basis van een variabele gezet wordt. Op deze manier heb je geen twee losse vertaling strings nodig
+
+```html
+<p>{% trans with {'naam': get_naam()} %}Hallo, {naam}{% endtrans %}</p>
+<p>{{ 'Hallo, {naam}'|trans({'naam': get_naam()}) }}</p>
+```
+
+```php
+$vertaling = $translator->trans('Hallo, {naam}', ['naam' => get_naam()]);
+```
+
+Kijk ook in de documentatie van de [ICU messageformat](https://symfony.com/doc/current/translation/message_format.html).

--- a/htdocs/images/locale_en.svg
+++ b/htdocs/images/locale_en.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="10 5 40 20" width="900" height="600">
+<clipPath id="s">
+<!--	<path d="M0,0 v30 h60 v-30 z"/>-->
+		<circle cx="30" cy="15" r="20" />
+</clipPath>
+<clipPath id="t">
+	<path d="M30,15 h30 v15 z v15 h-30 z h-30 v-15 z v-15 h30 z"/>
+<!--	<circle cx="600" cy="300" r="300" />-->
+</clipPath>
+<g clip-path="url(#s)">
+	<path d="M0,0 v30 h60 v-30 z" fill="#012169"/>
+	<path d="M0,0 L60,30 M60,0 L0,30" stroke="#fff" stroke-width="6"/>
+	<path d="M0,0 L60,30 M60,0 L0,30" clip-path="url(#t)" stroke="#C8102E" stroke-width="4"/>
+	<path d="M30,0 v30 M0,15 h60" stroke="#fff" stroke-width="10"/>
+	<path d="M30,0 v30 M0,15 h60" stroke="#C8102E" stroke-width="6"/>
+</g>
+</svg>

--- a/htdocs/images/locale_nl.svg
+++ b/htdocs/images/locale_nl.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="10 5 40 20" width="900" height="600">
+	<clipPath id="s">
+		<circle cx="30" cy="15" r="20" />
+	</clipPath>
+	<g clip-path="url(#s)">
+		<rect fill="#21468B" width="60" height="300"/>
+		<rect fill="#FFF" width="60" height="20"/>
+		<rect fill="#AE1C28" width="60" height="10"/>
+	</g>
+</svg>

--- a/lib/Component/Formulier/FormulierBuilder.php
+++ b/lib/Component/Formulier/FormulierBuilder.php
@@ -49,6 +49,14 @@ class FormulierBuilder {
 		$this->requestStack = $requestStack;
 	}
 
+	public function setShowMelding($showMelding) {
+		$this->showMelding = $showMelding;
+	}
+
+	public function setFormId($formId) {
+		$this->formId = $formId;
+	}
+
 	public function getFormId() {
 		return $this->formId;
 	}

--- a/lib/Twig/Extension/LayoutTwigExtension.php
+++ b/lib/Twig/Extension/LayoutTwigExtension.php
@@ -34,8 +34,12 @@ class LayoutTwigExtension extends AbstractExtension
 	 */
 	private $formulierFactory;
 
-	public function __construct(RequestStack $requestStack, Zijbalk $zijbalk, MenuItemRepository $menuItemRepository, FormulierFactory $formulierFactory)
-	{
+	public function __construct(
+		RequestStack $requestStack,
+		Zijbalk $zijbalk,
+		MenuItemRepository $menuItemRepository,
+		FormulierFactory $formulierFactory
+	) {
 		$this->zijbalk = $zijbalk;
 		$this->menuItemRepository = $menuItemRepository;
 		$this->requestStack = $requestStack;

--- a/lib/Twig/Extension/LayoutTwigExtension.php
+++ b/lib/Twig/Extension/LayoutTwigExtension.php
@@ -10,6 +10,7 @@ use CsrDelft\view\formulier\InstantSearchForm;
 use CsrDelft\view\Icon;
 use CsrDelft\view\login\LoginForm;
 use CsrDelft\view\Zijbalk;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -23,11 +24,16 @@ class LayoutTwigExtension extends AbstractExtension
 	 * @var MenuItemRepository
 	 */
 	private $menuItemRepository;
+	/**
+	 * @var RequestStack
+	 */
+	private $requestStack;
 
-	public function __construct(Zijbalk $zijbalk, MenuItemRepository $menuItemRepository)
+	public function __construct(RequestStack $requestStack, Zijbalk $zijbalk, MenuItemRepository $menuItemRepository)
 	{
 		$this->zijbalk = $zijbalk;
 		$this->menuItemRepository = $menuItemRepository;
+		$this->requestStack = $requestStack;
 	}
 
 	public function getFunctions()
@@ -61,11 +67,16 @@ class LayoutTwigExtension extends AbstractExtension
 	 */
 	public function get_menu($name, $root = false)
 	{
+		$defaultName = $name;
+		$locale = $this->requestStack->getCurrentRequest()->getLocale();
+		if ($locale != $this->requestStack->getCurrentRequest()->getDefaultLocale()) {
+			$name = $name . '_' . $locale;
+		}
 		if ($root) {
-			return $this->menuItemRepository->getMenuRoot($name);
+			return $this->menuItemRepository->getMenuRoot($name) ?? $this->menuItemRepository->getMenuRoot($defaultName);
 		}
 
-		return $this->menuItemRepository->getMenu($name);
+		return $this->menuItemRepository->getMenu($name) ?? $this->menuItemRepository->getMenu($defaultName);
 	}
 
 	public function instant_search_form()

--- a/lib/Twig/Extension/LayoutTwigExtension.php
+++ b/lib/Twig/Extension/LayoutTwigExtension.php
@@ -4,6 +4,7 @@
 namespace CsrDelft\Twig\Extension;
 
 
+use CsrDelft\Component\Formulier\FormulierFactory;
 use CsrDelft\entity\MenuItem;
 use CsrDelft\repository\MenuItemRepository;
 use CsrDelft\view\formulier\InstantSearchForm;
@@ -28,12 +29,17 @@ class LayoutTwigExtension extends AbstractExtension
 	 * @var RequestStack
 	 */
 	private $requestStack;
+	/**
+	 * @var FormulierFactory
+	 */
+	private $formulierFactory;
 
-	public function __construct(RequestStack $requestStack, Zijbalk $zijbalk, MenuItemRepository $menuItemRepository)
+	public function __construct(RequestStack $requestStack, Zijbalk $zijbalk, MenuItemRepository $menuItemRepository, FormulierFactory $formulierFactory)
 	{
 		$this->zijbalk = $zijbalk;
 		$this->menuItemRepository = $menuItemRepository;
 		$this->requestStack = $requestStack;
+		$this->formulierFactory = $formulierFactory;
 	}
 
 	public function getFunctions()
@@ -91,7 +97,7 @@ class LayoutTwigExtension extends AbstractExtension
 
 	public function login_form()
 	{
-		return (new LoginForm())->toString();
+		return $this->formulierFactory->create(LoginForm::class, null, [])->createView()->toString();
 	}
 
 	public function icon($key, $hover = null, $title = null, $class = null, $content = null)

--- a/lib/controller/CmsPaginaController.php
+++ b/lib/controller/CmsPaginaController.php
@@ -75,11 +75,10 @@ class CmsPaginaController extends AbstractController {
 			throw $this->createAccessDeniedException();
 		}
 		$body = new CmsPaginaView($pagina);
-		if (!LoginService::mag(P_LOGGED_IN)) { // nieuwe layout altijd voor uitgelogde bezoekers
+		// nieuwe layout altijd voor uitgelogde bezoekers
+		if (!LoginService::mag(P_LOGGED_IN)) {
 			if ($pagina->naam === 'thuis') {
 				return $this->render('extern/index.html.twig', ['titel' => $body->getTitel()]);
-			} elseif ($naam === 'vereniging') {
-				return $this->render('extern/content.html.twig', ['titel' => $body->getTitel(), 'body' => $body]);
 			} elseif ($naam === 'lidworden') {
 				return $this->render('extern/owee.html.twig');
 			}

--- a/lib/controller/LoginController.php
+++ b/lib/controller/LoginController.php
@@ -62,7 +62,9 @@ class LoginController extends AbstractController {
 		$error = $authenticationUtils->getLastAuthenticationError();
 		$userName = $authenticationUtils->getLastUsername();
 
-		$response = $this->render('extern/login.html.twig', ['loginForm' => new LoginForm($userName, $error)]);
+		$loginForm = $this->createFormulier(LoginForm::class, null, ['lastUserName' => $userName, 'lastError' => $error]);
+
+		$response = $this->render('extern/login.html.twig', ['loginForm' => $loginForm->createView()]);
 
 		// Als er geredirect wordt, stuur dan een forbidden status
 		if ($targetPath) {

--- a/lib/controller/LoginController.php
+++ b/lib/controller/LoginController.php
@@ -47,6 +47,7 @@ class LoginController extends AbstractController {
 	 * @param AuthenticationUtils $authenticationUtils
 	 * @return Response
 	 * @Route("/login", methods={"GET"})
+	 * @Route("/{_locale<%app.supported_locales%>}/login", methods={"GET"})
 	 * @Auth(P_PUBLIC)
 	 */
 	public function loginForm(Request $request, AuthenticationUtils $authenticationUtils) {
@@ -76,6 +77,7 @@ class LoginController extends AbstractController {
 
 	/**
 	 * @Route("/login_check", name="app_login_check", methods={"POST"})
+	 * @Route("/{_locale<%app.supported_locales%>}/login_check", name="app_login_check", methods={"POST"})
 	 * @Auth(P_PUBLIC)
 	 */
 	public function login_check() {

--- a/lib/view/bbcode/CsrBB.php
+++ b/lib/view/bbcode/CsrBB.php
@@ -51,6 +51,7 @@ use CsrDelft\view\bbcode\tag\BbPeiling;
 use CsrDelft\view\bbcode\tag\BbPrive;
 use CsrDelft\view\bbcode\tag\BbQuery;
 use CsrDelft\view\bbcode\tag\BbReldate;
+use CsrDelft\view\bbcode\tag\BbTaal;
 use CsrDelft\view\bbcode\tag\BbUbboff;
 use CsrDelft\view\bbcode\tag\BbUrl;
 use CsrDelft\view\bbcode\tag\BbVerklapper;
@@ -134,6 +135,7 @@ class CsrBB extends Parser {
 		BbQuery::class,
 		BbReldate::class,
 		BbSpotify::class,
+		BbTaal::class,
 		BbTwitter::class,
 		BbUbboff::class,
 		BbUrl::class,

--- a/lib/view/bbcode/tag/BbTaal.php
+++ b/lib/view/bbcode/tag/BbTaal.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace CsrDelft\view\bbcode\tag;
+
+use CsrDelft\bb\BbTag;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Geef tekst weer gebasseerd op de huidige locale.
+ *
+ * @package CsrDelft\view\bbcode\tag
+ */
+class BbTaal extends BbTag
+{
+	/**
+	 * @var RequestStack
+	 */
+	private $requestStack;
+	/**
+	 * @var string
+	 */
+	private $taal;
+
+	public function __construct(RequestStack $requestStack)
+	{
+		$this->requestStack = $requestStack;
+	}
+
+	public static function getTagName()
+	{
+		return ['taal'];
+	}
+
+	public function parse($arguments = [])
+	{
+		$this->taal = $arguments['taal'];
+		$this->readContent();
+	}
+
+	public function render()
+	{
+		if ($this->requestStack->getCurrentRequest()->getLocale() == $this->taal) {
+			return $this->content;
+		} else {
+			return '';
+		}
+	}
+}

--- a/lib/view/formulier/knoppen/TemplateFormKnoppen.php
+++ b/lib/view/formulier/knoppen/TemplateFormKnoppen.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace CsrDelft\view\formulier\knoppen;
+
+
+use Twig\Environment;
+
+class TemplateFormKnoppen extends FormKnoppen
+{
+
+	/**
+	 * @var Environment
+	 */
+	private $twig;
+	/**
+	 * @var string
+	 */
+	private $template;
+	/**
+	 * @var array
+	 */
+	private $options;
+
+	public function __construct(Environment $twig, $template, $options = []) {
+		parent::__construct();
+		$this->twig = $twig;
+		$this->template = $template;
+		$this->options = $options;
+	}
+
+	public function getHtml()
+	{
+		return $this->twig->render($this->template, $this->options);
+	}
+
+}

--- a/lib/view/login/LoginForm.php
+++ b/lib/view/login/LoginForm.php
@@ -2,23 +2,18 @@
 
 namespace CsrDelft\view\login;
 
-use CsrDelft\common\ContainerFacade;
 use CsrDelft\Component\Formulier\FormulierBuilder;
 use CsrDelft\Component\Formulier\FormulierTypeInterface;
 use CsrDelft\view\formulier\CsrfField;
 use CsrDelft\view\formulier\elementen\HtmlComment;
-use CsrDelft\view\formulier\Formulier;
-use CsrDelft\view\formulier\invoervelden\HiddenField;
 use CsrDelft\view\formulier\invoervelden\TextField;
 use CsrDelft\view\formulier\invoervelden\WachtwoordField;
 use CsrDelft\view\formulier\keuzevelden\CheckboxField;
 use CsrDelft\view\formulier\knoppen\TemplateFormKnoppen;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use CsrDelft\view\formulier\knoppen\LoginFormKnoppen;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authenticator\FormLoginAuthenticator;
-use Symfony\Component\Translation\Translator;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
@@ -103,7 +98,8 @@ class LoginForm implements FormulierTypeInterface {
 		$fields['pass']->placeholder = $this->translator->trans('Wachtwoord');
 
 		if (isset($options['lastError'])) {
-			$fields[] = new HtmlComment('<p class="error">' . $this->formatError($options['lastError'], $options['lastUserName'] ?? "") . '</p>');
+			$fields[] = new HtmlComment(
+				sprintf("<p class=\"error\">%s</p>", $this->formatError($options['lastError'], $options['lastUserName'] ?? "")));
 		} else {
 			$fields[] = new HtmlComment('<div class="float-left">');
 			$fields[] = new HtmlComment('</div>');

--- a/lib/view/login/LoginForm.php
+++ b/lib/view/login/LoginForm.php
@@ -3,6 +3,8 @@
 namespace CsrDelft\view\login;
 
 use CsrDelft\common\ContainerFacade;
+use CsrDelft\Component\Formulier\FormulierBuilder;
+use CsrDelft\Component\Formulier\FormulierTypeInterface;
 use CsrDelft\view\formulier\CsrfField;
 use CsrDelft\view\formulier\elementen\HtmlComment;
 use CsrDelft\view\formulier\Formulier;
@@ -10,44 +12,50 @@ use CsrDelft\view\formulier\invoervelden\HiddenField;
 use CsrDelft\view\formulier\invoervelden\TextField;
 use CsrDelft\view\formulier\invoervelden\WachtwoordField;
 use CsrDelft\view\formulier\keuzevelden\CheckboxField;
+use CsrDelft\view\formulier\knoppen\TemplateFormKnoppen;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use CsrDelft\view\formulier\knoppen\LoginFormKnoppen;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authenticator\FormLoginAuthenticator;
+use Symfony\Component\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
 
 /**
  * Class LoginForm
  * @package CsrDelft\view\login
  * @see FormLoginAuthenticator Voor de afhandeling van dit formulier
  */
-class LoginForm extends Formulier {
+class LoginForm implements FormulierTypeInterface {
+	/**
+	 * @var UrlGeneratorInterface
+	 */
+	private $urlGenerator;
+	/**
+	 * @var CsrfTokenManagerInterface
+	 */
+	private $csrfTokenManager;
+	/**
+	 * @var Environment
+	 */
+	private $twig;
+	/**
+	 * @var TranslatorInterface
+	 */
+	private $translator;
 
-	public function __construct($lastUserName = null, AuthenticationException $lastError = null) {
-		parent::__construct(null, '/login_check');
-		$this->formId = 'loginform';
-		$this->showMelding = false;
+	public function __construct(
+		TranslatorInterface $translator,
+		UrlGeneratorInterface $urlGenerator,
+		CsrfTokenManagerInterface $csrfTokenManager,
+		Environment $twig
+	) {
 
-		$fields = [];
-
-		$fields[] = new CsrfField(ContainerFacade::getContainer()->get('security.csrf.token_manager')->getToken('authenticate'), '_csrf_token');
-
-		$fields['user'] = new TextField('_username', $lastUserName, null);
-		$fields['user']->placeholder = 'Lidnummer of emailadres';
-
-		$fields['pass'] = new WachtwoordField('_password', null, null);
-		$fields['pass']->placeholder = 'Wachtwoord';
-
-		if ($lastError) {
-			$fields[] = new HtmlComment('<p class="error">' . $this->formatError($lastError) . '</p>');
-		} else {
-			$fields[] = new HtmlComment('<div class="float-left">');
-			$fields[] = new HtmlComment('</div>');
-
-			$fields['remember'] = new CheckboxField('_remember_me', false, null, 'Blijf ingelogd');
-		}
-
-		$this->addFields($fields);
-
-		$this->formKnoppen = new LoginFormKnoppen();
+		$this->urlGenerator = $urlGenerator;
+		$this->csrfTokenManager = $csrfTokenManager;
+		$this->twig = $twig;
+		$this->translator = $translator;
 	}
 
 	/**
@@ -56,16 +64,16 @@ class LoginForm extends Formulier {
 	 * @param AuthenticationException $exception
 	 * @return string
 	 */
-	private function formatError(AuthenticationException $exception) {
+	private function formatError(AuthenticationException $exception, $lastUsername) {
 		switch ($exception->getMessageKey()) {
 			case "Username could not be found.":
-				$errorString = "Gebruiker {{ username }} niet gevonden.";
+				$errorString = $this->translator->trans("Gebruiker '%username%' niet gevonden.", ['%username%' => $lastUsername]);
 				break;
 			case "Invalid credentials.":
-				$errorString = "Onjuist wachtwoord.";
+				$errorString = $this->translator->trans("Onjuist wachtwoord.");
 				break;
 			default:
-				$errorString = "Er was een fout.";
+				$errorString = $this->translator->trans("Er was een fout.");
 				break;
 		}
 
@@ -75,5 +83,36 @@ class LoginForm extends Formulier {
 	protected function getScriptTag() {
 		// er is geen javascript
 		return "";
+	}
+
+	public function createFormulier(FormulierBuilder $builder, $data, $options = [])
+	{
+		$builder->setAction($this->urlGenerator->generate('app_login_check'));
+
+		$builder->setFormId('loginform');
+		$builder->setShowMelding(false);
+
+		$fields = [];
+
+		$fields[] = new CsrfField($this->csrfTokenManager->getToken('authenticate'), '_csrf_token');
+
+		$fields['user'] = new TextField('_username', $options['lastUserName'] ?? "", null);
+		$fields['user']->placeholder = $this->translator->trans('Lidnummer of emailadres');
+
+		$fields['pass'] = new WachtwoordField('_password', null, null);
+		$fields['pass']->placeholder = $this->translator->trans('Wachtwoord');
+
+		if (isset($options['lastError'])) {
+			$fields[] = new HtmlComment('<p class="error">' . $this->formatError($options['lastError'], $options['lastUserName'] ?? "") . '</p>');
+		} else {
+			$fields[] = new HtmlComment('<div class="float-left">');
+			$fields[] = new HtmlComment('</div>');
+
+			$fields['remember'] = new CheckboxField('_remember_me', false, null, $this->translator->trans('Blijf ingelogd'));
+		}
+
+		$builder->addFields($fields);
+
+		$builder->setFormKnoppen(new TemplateFormKnoppen($this->twig, 'formulier/login_knoppen.html.twig'));
 	}
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -669,6 +669,12 @@
     "theseer/tokenizer": {
         "version": "1.2.0"
     },
+    "twig/extra-bundle": {
+        "version": "v3.2.1"
+    },
+    "twig/intl-extra": {
+        "version": "v3.2.1"
+    },
     "twig/twig": {
         "version": "v2.12.0"
     },

--- a/symfony.lock
+++ b/symfony.lock
@@ -607,6 +607,19 @@
     "symfony/templating": {
         "version": "v3.4.32"
     },
+    "symfony/translation": {
+        "version": "3.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "3.3",
+            "ref": "2ad9d2545bce8ca1a863e50e92141f0b9d87ffcd"
+        },
+        "files": [
+            "./config/packages/translation.yaml",
+            "./translations/.gitignore"
+        ]
+    },
     "symfony/translation-contracts": {
         "version": "v2.0.1"
     },

--- a/templates/extern/index.html.twig
+++ b/templates/extern/index.html.twig
@@ -41,16 +41,16 @@
 				<span class="image"><img src="/fotoalbum/Publiek/Voorpagina/_resized/CSR_Delft.jpg"
 																 alt="Foto vereniging"/></span>
 				<div class="content">
-					<h2 class="major">C.S.R. Delft</h2>
-					<p>De Civitas Studiosorum Reformatorum is een bruisende, actieve, christelijke studentenvereniging in
-						Delft, rijk aan tradities die zijn ontstaan in haar {{ vereniging_leeftijd() }}-jarig bestaan. Het is een
+					<h2 class="major">{% trans %}C.S.R. Delft{% endtrans %}</h2>
+					<p>{% trans with {'%leeftijd%': vereniging_leeftijd()} %}De Civitas Studiosorum Reformatorum is een bruisende, actieve, christelijke studentenvereniging in
+						Delft, rijk aan tradities die zijn ontstaan in haar %leeftijd%-jarig bestaan. Het is een
 						breed gezelschap
 						van zo'n 275 leden met een zeer gevarieerde (kerkelijke) achtergrond, maar met een duidelijke
 						eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede
 						vrienden van elkaar worden, op intellectueel en geestelijk gebied groeien en goede studentengrappen
-						uithalen.
+						uithalen.{% endtrans %}
 					</p>
-					<a href="{{ url('default', {naam: 'vereniging'}) }}" class="special">Lees meer over C.S.R.</a>
+					<a href="{{ url('default', {naam: 'vereniging'}) }}" class="special">{% trans %}Lees meer over C.S.R.{% endtrans %}</a>
 				</div>
 			</div>
 		</section>
@@ -61,7 +61,7 @@
 				<div class="content">
 					<div class="een-minuut">
 						<div id="hero">
-							<h1 class="major">C.S.R. IN 1 MINUUT</h1>
+							<h1 class="major">{% trans %}C.S.R. IN 1 MINUUT{% endtrans %}</h1>
 							<noscript class="lazy-load">
 								<div class="bb-video">
 									<iframe src="https://www.youtube-nocookie.com/embed/AE8RE8e5qI4?hl=nl"
@@ -74,8 +74,8 @@
 						<noscript class="lazy-load">
 							<div class="sociaal">
 								<div class="youtube">
-									<p>Wil je zien hoe
-										de vereniging in elkaar zit? Bekijk de serie 'Delft studie is maar de helft!'</p>
+									<p>{% trans %}Wil je zien hoe
+										de vereniging in elkaar zit? Bekijk de serie 'Delft studie is maar de helft!'{% endtrans %}</p>
 									<div class="bb-video">
 										<iframe src="https://www.youtube-nocookie.com/embed/a7hhtoo_kzY?hl=nl"
 														title="Delft studie is maar de helft! Aflevering 1 uit 3"
@@ -84,7 +84,7 @@
 									</div>
 								</div>
 								<div class="instagram">
-									<p>Bekijk en volg ook ons Instagram account voor meer van onze vereniging!</p>
+									<p>{% trans %}Bekijk en volg ook ons Instagram account voor meer van onze vereniging!{% endtrans %}</p>
 									<div class="insta-grid">
 										<a href="https://www.instagram.com/csrdelft/"><img
 												src="{{ absolute_url('/dist/images/instagram.svg') }}"
@@ -95,6 +95,7 @@
 							</div>
 						</noscript>
 
+						{% trans %}
 						<p>
 							De OWee gaat er anders uitzien, voor meer informatie zie de <a href="https://owee.nl">OWee
 								website</a>.<br>
@@ -107,6 +108,7 @@
 						</p>
 						<p>We hopen je snel te kunnen spreken, digitaal of op anderhalve meter.</p>
 						<p>Liefs,<br>OWeeCie en PromoCie</p>
+						{% endtrans %}
 					</div>
 				</div>
 			</div>
@@ -119,13 +121,13 @@
 																	 alt="Sfeerfoto buiten"/></span>
 				</noscript>
 				<div class="content">
-					<h2 class="major">C.S.R. in de OWee</h2>
-					<p>Ter aanvang van elk studiejaar wordt er een OntvangstWeek georganiseerd, ofwel de OWee.
+					<h2 class="major">{% trans %}C.S.R. in de OWee{% endtrans %}</h2>
+					<p>{% trans %}Ter aanvang van elk studiejaar wordt er een OntvangstWeek georganiseerd, ofwel de OWee.
 						Tijdens deze week is er de uitgelezen kans om kennis te maken met de universiteit en hogescholen,
 						studieverenigingen, studentenverenigingen, sport- en cultuurcentrum, kerken en nog veel meer! Al
 						deze groepen zullen zichzelf tijdens deze week op verschillende momenten en manieren presenteren.
 						Ook C.S.R. doet mee aan deze gezellige week. Van 14 t/m 16 augustus zijn wij online te zien en van
-						17 t/m 22 augustus heb je de gelegenheid om fysiek de sfeer van C.S.R. en Delft te proeven!</p>
+						17 t/m 22 augustus heb je de gelegenheid om fysiek de sfeer van C.S.R. en Delft te proeven!{% endtrans %}</p>
 				</div>
 			</div>
 		</section>
@@ -138,21 +140,22 @@
 																	 alt="Owee Commissie"/></span>
 				</noscript>
 				<div class="content">
-					<h2 class="major">Interesse/vragen</h2>
-					<p>Uiteraard is er de mogelijkheid om ons tijdens de OWee te spreken. Er is daarnaast ook gelegenheid
+					<h2 class="major">{% trans %}Interesse/vragen{% endtrans %}</h2>
+					<p>{% trans %}Uiteraard is er de mogelijkheid om ons tijdens de OWee te spreken. Er is daarnaast ook gelegenheid
 						om onze sociëteit Confide aan de Oude Delft 9 te bezoeken. Buiten de OWee om kan jij ook gewoon
 						al jouw vragen aan ons stellen.
 
 						Ben jij bijvoorbeeld geinteresseerd om een C.S.R. activiteit bij te wonen of een C.S.R. huis te bezoeken?
-						Laat dat dan aan ons weten en kom erachter wat er allemaal mogelijk is.</p>
-					<a href="{{ url('default', {naam: 'lidworden', _fragment: 'owee-form'}) }}" class="special">Laat je interesse
-						weten!</a>
-					<p class="lidworden">Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).
+						Laat dat dan aan ons weten en kom erachter wat er allemaal mogelijk is.{% endtrans %}</p>
+					<a href="{{ url('default', {naam: 'lidworden', _fragment: 'owee-form'}) }}" class="special">
+						{% trans %}Laat je interesse weten!{% endtrans %}
+					</a>
+					<p class="lidworden">{% trans with {'%lidworden%': url('default', {naam: 'lidworden', _fragment: 'owee-form'})} %}Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).
 						Voorinschrijven is zelfs ook al mogelijk, zodat er tijdens de OWee meteen contact met je kan worden
 						opgenomen.
-						Doe dit door <a href="{{ url('default', {naam: 'lidworden', _fragment: 'owee-form'}) }}">hier</a> te
-						klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek</p>
-					<a href="{{ url('default', {naam: 'lidworden'}) }}" class="special">Meer informatie over lid worden</a>
+						Doe dit door <a href="%lidworden%">hier</a> te
+						klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek{% endtrans %}</p>
+					<a href="{{ url('default', {naam: 'lidworden'}) }}" class="special">{% trans %}Meer informatie over lid worden{% endtrans %}</a>
 				</div>
 			</div>
 		</section>
@@ -230,9 +233,10 @@
 					</li>
 					<li class="fa-phone">06-19470413</li>
 					<li class="fa-envelope"><a href="mailto:{{ email_abactis }}">{{ email_abactis }}</a></li>
-					<li class="fa-instagram"><a href="https://www.instagram.com/csrdelft/" target="_blank"
-																			rel="noopener noreferrer">Like
-							onze foto's op Instagram en volg de laatste posts</a></li>
+					<li class="fa-instagram">
+						<a href="https://www.instagram.com/csrdelft/" target="_blank" rel="noopener noreferrer">
+							{% trans %}Like onze foto's op Instagram en volg de laatste posts{% endtrans %}
+						</a></li>
 					<li class="fa-map-marker">
 						<noscript class="lazy-load">
 							<iframe title="Confide op Google Maps" height="300" frameborder="0" style="border:0"

--- a/templates/extern/index.html.twig
+++ b/templates/extern/index.html.twig
@@ -42,8 +42,8 @@
 																 alt="Foto vereniging"/></span>
 				<div class="content">
 					<h2 class="major">{% trans %}C.S.R. Delft{% endtrans %}</h2>
-					<p>{% trans with {'%leeftijd%': vereniging_leeftijd()} %}De Civitas Studiosorum Reformatorum is een bruisende, actieve, christelijke studentenvereniging in
-						Delft, rijk aan tradities die zijn ontstaan in haar %leeftijd%-jarig bestaan. Het is een
+					<p>{% trans with {"leeftijd": vereniging_leeftijd()} %}De Civitas Studiosorum Reformatorum is een bruisende, actieve, christelijke studentenvereniging in
+						Delft, rijk aan tradities die zijn ontstaan in haar {leeftijd}-jarig bestaan. Het is een
 						breed gezelschap
 						van zo'n 275 leden met een zeer gevarieerde (kerkelijke) achtergrond, maar met een duidelijke
 						eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede
@@ -150,10 +150,10 @@
 					<a href="{{ url('default', {naam: 'lidworden', _fragment: 'owee-form'}) }}" class="special">
 						{% trans %}Laat je interesse weten!{% endtrans %}
 					</a>
-					<p class="lidworden">{% trans with {'%lidworden%': url('default', {naam: 'lidworden', _fragment: 'owee-form'})} %}Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).
+					<p class="lidworden">{% trans with {'lidworden': url('default', {naam: 'lidworden', _fragment: 'owee-form'})} %}Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).
 						Voorinschrijven is zelfs ook al mogelijk, zodat er tijdens de OWee meteen contact met je kan worden
 						opgenomen.
-						Doe dit door <a href="%lidworden%">hier</a> te
+						Doe dit door <a href="{lidworden}">hier</a> te
 						klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek{% endtrans %}</p>
 					<a href="{{ url('default', {naam: 'lidworden'}) }}" class="special">{% trans %}Meer informatie over lid worden{% endtrans %}</a>
 				</div>

--- a/templates/extern/layout.html.twig
+++ b/templates/extern/layout.html.twig
@@ -54,7 +54,7 @@
 				{% endif %}
 			{% endfor %}
 		</nav>
-		<nav style="margin-left: auto;">
+		{# <nav style="margin-left: auto;">
 			<span class="locale-switch dropdown-menu">
 				<a class="nav-link" href="#">
 					<img height="30" src="/images/locale_{{ app.request.locale }}.svg"
@@ -73,7 +73,7 @@
 					{% endif %}
 				</span>
 			</span>
-		</nav>
+		</nav> #}
 		<nav class="nav-login">
 			{% block loginbutton %}
 				<a class="login-knop" href="#login"><i class="fa fa-2x fa-fw fa-user"></i></a>

--- a/templates/extern/layout.html.twig
+++ b/templates/extern/layout.html.twig
@@ -57,7 +57,7 @@
 		<nav class="nav-login">
 			{% block loginbutton %}
 				<a class="login-knop" href="#login"><i class="fa fa-2x fa-fw fa-user"></i></a>
-				<a class="nav-link inloggen" href="#login">Inloggen</a>
+				<a class="nav-link inloggen" href="#login">{% trans %}Inloggen{% endtrans %}</a>
 			{% endblock %}
 			<a href="#menu" class="menu-knop"><i class="fa fa-2x fa-fw fa-bars"></i></a>
 		</nav>

--- a/templates/extern/layout.html.twig
+++ b/templates/extern/layout.html.twig
@@ -54,6 +54,26 @@
 				{% endif %}
 			{% endfor %}
 		</nav>
+		<nav style="margin-left: auto;">
+			<span class="locale-switch dropdown-menu">
+				<a class="nav-link" href="#">
+					<img height="30" src="/images/locale_{{ app.request.locale }}.svg"
+							 alt="{{ app.request.locale|locale_name(app.request.locale) }}" title="{{ app.request.locale|locale_name(app.request.locale) }}"/>
+				</a>
+				<span class="dropdown">
+					{% if app.request.locale != 'en' %}
+						<a class="dropdown-item" href="{{ path('default', {_locale: 'en'}) }}">
+						<img height="30" src="/images/locale_en.svg" alt="{{ "en"|locale_name("en") }}" title="{{ "en"|locale_name("en") }}"/>
+					</a>
+					{% endif %}
+					{% if app.request.locale != 'nl' %}
+						<a class="dropdown-item" href="{{ path('default', {_locale: 'nl'}) }}">
+						<img height="30" src="/images/locale_nl.svg" alt="{{ "nl"|locale_name("nl") }}" title="{{ "nl"|locale_name("nl") }}"/>
+					</a>
+					{% endif %}
+				</span>
+			</span>
+		</nav>
 		<nav class="nav-login">
 			{% block loginbutton %}
 				<a class="login-knop" href="#login"><i class="fa fa-2x fa-fw fa-user"></i></a>

--- a/templates/extern/layout.html.twig
+++ b/templates/extern/layout.html.twig
@@ -68,9 +68,9 @@
 		<nav id="login">
 			<a href="#_" class="overlay"></a>
 			<div class="inner">
-				<h2>Inloggen</h2>
+				<h2>{{ 'Inloggen'|trans }}</h2>
 				{{ login_form() }}
-				<a href="#_" class="close">Close</a>
+				<a href="#_" class="close">{{ 'Sluiten'|trans }}</a>
 			</div>
 		</nav>
 	{% endblock %}

--- a/templates/extern/layout.html.twig
+++ b/templates/extern/layout.html.twig
@@ -68,9 +68,9 @@
 		<nav id="login">
 			<a href="#_" class="overlay"></a>
 			<div class="inner">
-				<h2>{{ 'Inloggen'|trans }}</h2>
+				<h2>{% trans %}Inloggen{% endtrans %}</h2>
 				{{ login_form() }}
-				<a href="#_" class="close">{{ 'Sluiten'|trans }}</a>
+				<a href="#_" class="close">{% trans %}Sluiten{% endtrans %}</a>
 			</div>
 		</nav>
 	{% endblock %}

--- a/templates/extern/login.html.twig
+++ b/templates/extern/login.html.twig
@@ -1,6 +1,6 @@
 {% extends 'extern/layout.html.twig' %}
 
-{% block titel %}Login{% endblock %}
+{% block titel %}{{ 'Login'|trans }}{% endblock %}
 
 {% block styles %}
 	{{ css_asset('extern') }}
@@ -11,8 +11,8 @@
 
 {% block content %}
 	<div>
-		<h1>Inloggen</h1>
-		<p>U dient in te loggen om verder te gaan</p>
+		<h1>{{ 'Inloggen'|trans }}</h1>
+		<p>{{ 'U dient in te loggen om verder te gaan'|trans }}</p>
 		{{ loginForm.toString | raw }}
 	</div>
 {% endblock %}

--- a/templates/extern/login.html.twig
+++ b/templates/extern/login.html.twig
@@ -1,6 +1,6 @@
 {% extends 'extern/layout.html.twig' %}
 
-{% block titel %}{{ 'Login'|trans }}{% endblock %}
+{% block titel %}{% trans %}Login{% endtrans %}{% endblock %}
 
 {% block styles %}
 	{{ css_asset('extern') }}
@@ -11,8 +11,8 @@
 
 {% block content %}
 	<div>
-		<h1>{{ 'Inloggen'|trans }}</h1>
-		<p>{{ 'U dient in te loggen om verder te gaan'|trans }}</p>
+		<h1>{% trans %}Inloggen{% endtrans %}</h1>
+		<p>{% trans %}U dient in te loggen om verder te gaan{% endtrans %}</p>
 		{{ loginForm.toString | raw }}
 	</div>
 {% endblock %}

--- a/templates/formulier/login_knoppen.html.twig
+++ b/templates/formulier/login_knoppen.html.twig
@@ -1,0 +1,9 @@
+<ul class="login-buttons">
+	<li>
+		<input type="submit" value="{% trans %}Inloggen{% endtrans %} &raquo;" />
+		&nbsp;
+		<a href="{{ url('default', {naam: 'accountaanvragen'}) }}">{% trans %}Account aanvragen{% endtrans %} &raquo;</a>
+	</li>
+	<li><a href="{{ url('csrdelft_wachtwoord_vergeten') }}">{% trans %}Wachtwoord vergeten?{% endtrans %} &raquo;</a></li>
+</ul>
+

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="nl" target-language="en" datatype="plaintext" original="file.ext">
+    <header>
+      <tool tool-id="symfony" tool-name="Symfony"/>
+    </header>
+    <body>
+      <trans-unit id="kCpMKtp" resname="Inloggen">
+        <source>Inloggen</source>
+        <target>Login</target>
+      </trans-unit>
+      <trans-unit id="WkaEMPh" resname="Sluiten">
+        <source>Sluiten</source>
+        <target>Close</target>
+      </trans-unit>
+      <trans-unit id="nWMiwfT" resname="Login">
+        <source>Login</source>
+        <target>Login</target>
+      </trans-unit>
+      <trans-unit id="Hl3PbWW" resname="U dient in te loggen om verder te gaan">
+        <source>U dient in te loggen om verder te gaan</source>
+        <target>You need to login to continue</target>
+      </trans-unit>
+      <trans-unit id="hZbA9KW" resname="C.S.R. Delft">
+        <source>C.S.R. Delft</source>
+        <target>C.S.R. Delft</target>
+      </trans-unit>
+      <trans-unit id="iXRdDVv" resname="De Civitas Studiosorum Reformatorum is een bruisende, actieve, christelijke studentenvereniging in&#10;&#9;&#9;&#9;&#9;&#9;&#9;Delft, rijk aan tradities die zijn ontstaan in haar %leeftijd%-jarig bestaan. Het is een&#10;&#9;&#9;&#9;&#9;&#9;&#9;breed gezelschap&#10;&#9;&#9;&#9;&#9;&#9;&#9;van zo'n 275 leden met een zeer gevarieerde (kerkelijke) achtergrond, maar met een duidelijke&#10;&#9;&#9;&#9;&#9;&#9;&#9;eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede&#10;&#9;&#9;&#9;&#9;&#9;&#9;vrienden van elkaar worden, op intellectueel en geestelijk gebied groeien en goede studentengrappen&#10;&#9;&#9;&#9;&#9;&#9;&#9;uithalen.">
+        <source>De Civitas Studiosorum Reformatorum is een bruisende, actieve, christelijke studentenvereniging in
+						Delft, rijk aan tradities die zijn ontstaan in haar %leeftijd%-jarig bestaan. Het is een
+						breed gezelschap
+						van zo'n 275 leden met een zeer gevarieerde (kerkelijke) achtergrond, maar met een duidelijke
+						eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede
+						vrienden van elkaar worden, op intellectueel en geestelijk gebied groeien en goede studentengrappen
+						uithalen.</source>
+        <target>__De Civitas Studiosorum Reformatorum is een bruisende, actieve, christelijke studentenvereniging in
+						Delft, rijk aan tradities die zijn ontstaan in haar %leeftijd%-jarig bestaan. Het is een
+						breed gezelschap
+						van zo'n 275 leden met een zeer gevarieerde (kerkelijke) achtergrond, maar met een duidelijke
+						eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede
+						vrienden van elkaar worden, op intellectueel en geestelijk gebied groeien en goede studentengrappen
+						uithalen.</target>
+      </trans-unit>
+      <trans-unit id="pj.QOKC" resname="Lees meer over C.S.R.">
+        <source>Lees meer over C.S.R.</source>
+        <target>Read more about C.S.R.</target>
+      </trans-unit>
+      <trans-unit id="k23IuHj" resname="C.S.R. IN 1 MINUUT">
+        <source>C.S.R. IN 1 MINUUT</source>
+        <target>C.S.R. IN 1 MINUTE</target>
+      </trans-unit>
+      <trans-unit id="AiTuF4c" resname="Wil je zien hoe&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;de vereniging in elkaar zit? Bekijk de serie 'Delft studie is maar de helft!'">
+        <source>Wil je zien hoe
+										de vereniging in elkaar zit? Bekijk de serie 'Delft studie is maar de helft!'</source>
+        <target>__Wil je zien hoe
+										de vereniging in elkaar zit? Bekijk de serie 'Delft studie is maar de helft!'</target>
+      </trans-unit>
+      <trans-unit id="wMJ25_y" resname="Bekijk en volg ook ons Instagram account voor meer van onze vereniging!">
+        <source>Bekijk en volg ook ons Instagram account voor meer van onze vereniging!</source>
+        <target>__Bekijk en volg ook ons Instagram account voor meer van onze vereniging!</target>
+      </trans-unit>
+      <trans-unit id="1mtQLfN" resname="&lt;p&gt;&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;De OWee gaat er anders uitzien, voor meer informatie zie de &lt;a href=&quot;https://owee.nl&quot;&gt;OWee&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;website&lt;/a&gt;.&lt;br&gt;&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;Maar wij willen je wel vast digitaal een beetje van C.S.R. laten zien.&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;We willen jou daar goede handvaten voor geven. De belangrijkste informatie wordt gedeeld via deze website&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;dus kijk even rond.&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;Wil je meer weten? Kijk op ons &lt;a href=&quot;https://www.youtube.com/user/CivitasFilms&quot;&gt;YouTube kanaal&lt;/a&gt;,&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;onze &lt;a href=&quot;https://www.instagram.com/csrdelft&quot;&gt;Instagram pagina&lt;/a&gt; en de &lt;a&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;href=&quot;https://www.owee.nl&quot;&gt; OWee &lt;/a&gt; website.&#10;&#9;&#9;&#9;&#9;&#9;&#9;&lt;/p&gt;&#10;&#9;&#9;&#9;&#9;&#9;&#9;&lt;p&gt;We hopen je snel te kunnen spreken, digitaal of op anderhalve meter.&lt;/p&gt;&#10;&#9;&#9;&#9;&#9;&#9;&#9;&lt;p&gt;Liefs,&lt;br&gt;OWeeCie en PromoCie&lt;/p&gt;">
+        <source>&lt;p&gt;
+							De OWee gaat er anders uitzien, voor meer informatie zie de &lt;a href="https://owee.nl"&gt;OWee
+								website&lt;/a&gt;.&lt;br&gt;
+							Maar wij willen je wel vast digitaal een beetje van C.S.R. laten zien.
+							We willen jou daar goede handvaten voor geven. De belangrijkste informatie wordt gedeeld via deze website
+							dus kijk even rond.
+							Wil je meer weten? Kijk op ons &lt;a href="https://www.youtube.com/user/CivitasFilms"&gt;YouTube kanaal&lt;/a&gt;,
+							onze &lt;a href="https://www.instagram.com/csrdelft"&gt;Instagram pagina&lt;/a&gt; en de &lt;a
+								href="https://www.owee.nl"&gt; OWee &lt;/a&gt; website.
+						&lt;/p&gt;
+						&lt;p&gt;We hopen je snel te kunnen spreken, digitaal of op anderhalve meter.&lt;/p&gt;
+						&lt;p&gt;Liefs,&lt;br&gt;OWeeCie en PromoCie&lt;/p&gt;</source>
+        <target><![CDATA[__<p>
+							De OWee gaat er anders uitzien, voor meer informatie zie de <a href="https://owee.nl">OWee
+								website</a>.<br>
+							Maar wij willen je wel vast digitaal een beetje van C.S.R. laten zien.
+							We willen jou daar goede handvaten voor geven. De belangrijkste informatie wordt gedeeld via deze website
+							dus kijk even rond.
+							Wil je meer weten? Kijk op ons <a href="https://www.youtube.com/user/CivitasFilms">YouTube kanaal</a>,
+							onze <a href="https://www.instagram.com/csrdelft">Instagram pagina</a> en de <a
+								href="https://www.owee.nl"> OWee </a> website.
+						</p>
+						<p>We hopen je snel te kunnen spreken, digitaal of op anderhalve meter.</p>
+						<p>Liefs,<br>OWeeCie en PromoCie</p>]]></target>
+      </trans-unit>
+      <trans-unit id="_tFekif" resname="C.S.R. in de OWee">
+        <source>C.S.R. in de OWee</source>
+        <target>__C.S.R. in de OWee</target>
+      </trans-unit>
+      <trans-unit id="SK7m38T" resname="Ter aanvang van elk studiejaar wordt er een OntvangstWeek georganiseerd, ofwel de OWee.&#10;&#9;&#9;&#9;&#9;&#9;&#9;Tijdens deze week is er de uitgelezen kans om kennis te maken met de universiteit en hogescholen,&#10;&#9;&#9;&#9;&#9;&#9;&#9;studieverenigingen, studentenverenigingen, sport- en cultuurcentrum, kerken en nog veel meer! Al&#10;&#9;&#9;&#9;&#9;&#9;&#9;deze groepen zullen zichzelf tijdens deze week op verschillende momenten en manieren presenteren.&#10;&#9;&#9;&#9;&#9;&#9;&#9;Ook C.S.R. doet mee aan deze gezellige week. Van 14 t/m 16 augustus zijn wij online te zien en van&#10;&#9;&#9;&#9;&#9;&#9;&#9;17 t/m 22 augustus heb je de gelegenheid om fysiek de sfeer van C.S.R. en Delft te proeven!">
+        <source>Ter aanvang van elk studiejaar wordt er een OntvangstWeek georganiseerd, ofwel de OWee.
+						Tijdens deze week is er de uitgelezen kans om kennis te maken met de universiteit en hogescholen,
+						studieverenigingen, studentenverenigingen, sport- en cultuurcentrum, kerken en nog veel meer! Al
+						deze groepen zullen zichzelf tijdens deze week op verschillende momenten en manieren presenteren.
+						Ook C.S.R. doet mee aan deze gezellige week. Van 14 t/m 16 augustus zijn wij online te zien en van
+						17 t/m 22 augustus heb je de gelegenheid om fysiek de sfeer van C.S.R. en Delft te proeven!</source>
+        <target>__Ter aanvang van elk studiejaar wordt er een OntvangstWeek georganiseerd, ofwel de OWee.
+						Tijdens deze week is er de uitgelezen kans om kennis te maken met de universiteit en hogescholen,
+						studieverenigingen, studentenverenigingen, sport- en cultuurcentrum, kerken en nog veel meer! Al
+						deze groepen zullen zichzelf tijdens deze week op verschillende momenten en manieren presenteren.
+						Ook C.S.R. doet mee aan deze gezellige week. Van 14 t/m 16 augustus zijn wij online te zien en van
+						17 t/m 22 augustus heb je de gelegenheid om fysiek de sfeer van C.S.R. en Delft te proeven!</target>
+      </trans-unit>
+      <trans-unit id="WXbGaaE" resname="Interesse/vragen">
+        <source>Interesse/vragen</source>
+        <target>__Interesse/vragen</target>
+      </trans-unit>
+      <trans-unit id="jUUQQ.H" resname="Uiteraard is er de mogelijkheid om ons tijdens de OWee te spreken. Er is daarnaast ook gelegenheid&#10;&#9;&#9;&#9;&#9;&#9;&#9;om onze sociëteit Confide aan de Oude Delft 9 te bezoeken. Buiten de OWee om kan jij ook gewoon&#10;&#9;&#9;&#9;&#9;&#9;&#9;al jouw vragen aan ons stellen.&#10;&#10;&#9;&#9;&#9;&#9;&#9;&#9;Ben jij bijvoorbeeld geinteresseerd om een C.S.R. activiteit bij te wonen of een C.S.R. huis te bezoeken?&#10;&#9;&#9;&#9;&#9;&#9;&#9;Laat dat dan aan ons weten en kom erachter wat er allemaal mogelijk is.">
+        <source>Uiteraard is er de mogelijkheid om ons tijdens de OWee te spreken. Er is daarnaast ook gelegenheid
+						om onze sociëteit Confide aan de Oude Delft 9 te bezoeken. Buiten de OWee om kan jij ook gewoon
+						al jouw vragen aan ons stellen.
+
+						Ben jij bijvoorbeeld geinteresseerd om een C.S.R. activiteit bij te wonen of een C.S.R. huis te bezoeken?
+						Laat dat dan aan ons weten en kom erachter wat er allemaal mogelijk is.</source>
+        <target>__Uiteraard is er de mogelijkheid om ons tijdens de OWee te spreken. Er is daarnaast ook gelegenheid
+						om onze sociëteit Confide aan de Oude Delft 9 te bezoeken. Buiten de OWee om kan jij ook gewoon
+						al jouw vragen aan ons stellen.
+
+						Ben jij bijvoorbeeld geinteresseerd om een C.S.R. activiteit bij te wonen of een C.S.R. huis te bezoeken?
+						Laat dat dan aan ons weten en kom erachter wat er allemaal mogelijk is.</target>
+      </trans-unit>
+      <trans-unit id="DZuTr7f" resname="Laat je interesse weten!">
+        <source>Laat je interesse weten!</source>
+        <target>__Laat je interesse weten!</target>
+      </trans-unit>
+      <trans-unit id="vLigd3J" resname="Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).&#10;&#9;&#9;&#9;&#9;&#9;&#9;Voorinschrijven is zelfs ook al mogelijk, zodat er tijdens de OWee meteen contact met je kan worden&#10;&#9;&#9;&#9;&#9;&#9;&#9;opgenomen.&#10;&#9;&#9;&#9;&#9;&#9;&#9;Doe dit door &lt;a href=&quot;%lidworden%&quot;&gt;hier&lt;/a&gt; te&#10;&#9;&#9;&#9;&#9;&#9;&#9;klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek">
+        <source>Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).
+						Voorinschrijven is zelfs ook al mogelijk, zodat er tijdens de OWee meteen contact met je kan worden
+						opgenomen.
+						Doe dit door &lt;a href="%lidworden%"&gt;hier&lt;/a&gt; te
+						klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek</source>
+        <target><![CDATA[__Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).
+						Voorinschrijven is zelfs ook al mogelijk, zodat er tijdens de OWee meteen contact met je kan worden
+						opgenomen.
+						Doe dit door <a href="%lidworden%">hier</a> te
+						klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek]]></target>
+      </trans-unit>
+      <trans-unit id="zEMOsJp" resname="Meer informatie over lid worden">
+        <source>Meer informatie over lid worden</source>
+        <target>More information about becoming a member</target>
+      </trans-unit>
+      <trans-unit id="arGwqOE" resname="Like onze foto's op Instagram en volg de laatste posts">
+        <source>Like onze foto's op Instagram en volg de laatste posts</source>
+        <target>__Like onze foto's op Instagram en volg de laatste posts</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -137,6 +137,38 @@
         <source>Like onze foto's op Instagram en volg de laatste posts</source>
         <target>Like us on Instagram and check out the latest posts</target>
       </trans-unit>
+      <trans-unit id="ejF63GG" resname="Account aanvragen">
+        <source>Account aanvragen</source>
+        <target>Request account</target>
+      </trans-unit>
+      <trans-unit id="XeKy_KG" resname="Wachtwoord vergeten?">
+        <source>Wachtwoord vergeten?</source>
+        <target>Forgot password?</target>
+      </trans-unit>
+      <trans-unit id="nwpRdki" resname="Gebruiker '%username%' niet gevonden.">
+        <source>Gebruiker '%username%' niet gevonden.</source>
+        <target>User '%username%' not found.</target>
+      </trans-unit>
+      <trans-unit id="4_ZbLM." resname="Onjuist wachtwoord.">
+        <source>Onjuist wachtwoord.</source>
+        <target>Wrong password.</target>
+      </trans-unit>
+      <trans-unit id="1HsZ1Nx" resname="Er was een fout.">
+        <source>Er was een fout.</source>
+        <target>There was an error.</target>
+      </trans-unit>
+      <trans-unit id="44GkCgt" resname="Lidnummer of emailadres">
+        <source>Lidnummer of emailadres</source>
+        <target>Member id or emailaddress</target>
+      </trans-unit>
+      <trans-unit id="mivKO4K" resname="Wachtwoord">
+        <source>Wachtwoord</source>
+        <target>Password</target>
+      </trans-unit>
+      <trans-unit id="MhhxDgi" resname="Blijf ingelogd">
+        <source>Blijf ingelogd</source>
+        <target>Remember me</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -33,9 +33,9 @@
 						eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede
 						vrienden van elkaar worden, op intellectueel en geestelijk gebied groeien en goede studentengrappen
 						uithalen.</source>
-        <target>Civitas Studiosorum Reformatorum is a vibrant, enthusiastic christian student association in Delft,
+        <target>Civitas Studiosorum Reformatorum is a vibrant, enthusiastic Christian student association in Delft,
         rich in traditions that have developed over the past %leeftijd% years.
-        We are counting 275 members coming from all kinds of church denominations, united in christian faith. C.S.R. is a community
+        We are counting 275 members coming from all kinds of Christian backgrounds, united in the Christian faith. C.S.R. is a community
          in which friendships are made, where personal, intellectual, and spiritual development is encouraged and where we enjoy the fun of a good student prank.
         </target>
       </trans-unit>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -69,7 +69,7 @@
 						&lt;/p&gt;
 						&lt;p&gt;We hopen je snel te kunnen spreken, digitaal of op anderhalve meter.&lt;/p&gt;
 						&lt;p&gt;Liefs,&lt;br&gt;OWeeCie en PromoCie&lt;/p&gt;</source>
-        <target><![CDATA[__<p>
+        <target><![CDATA[<p>
 							This year the OWee (opening week) will not take place in the same fashion as usual. For more information and the latest updates please refer to the
 							Owee website <a href="https://owee.nl">OWee
 								website</a>.<br>.

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -33,13 +33,11 @@
 						eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede
 						vrienden van elkaar worden, op intellectueel en geestelijk gebied groeien en goede studentengrappen
 						uithalen.</source>
-        <target>__De Civitas Studiosorum Reformatorum is een bruisende, actieve, christelijke studentenvereniging in
-						Delft, rijk aan tradities die zijn ontstaan in haar %leeftijd%-jarig bestaan. Het is een
-						breed gezelschap
-						van zo'n 275 leden met een zeer gevarieerde (kerkelijke) achtergrond, maar met een duidelijke
-						eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede
-						vrienden van elkaar worden, op intellectueel en geestelijk gebied groeien en goede studentengrappen
-						uithalen.</target>
+        <target> Civitas Studiosorum Reformatorum is a vibrant, enthusiastic christian student association in Delft,
+        rich in traditions that have developed over the past %leeftijd% years.
+        We are counting 275 members coming from all kinds of church congregations, united in christian faith. C.S.R. is a community
+         in which friendships are made, personal intellectual and spiritual development is encouraged and where we enjoy the fun of a good student prank.
+        </target>
       </trans-unit>
       <trans-unit id="pj.QOKC" resname="Lees meer over C.S.R.">
         <source>Lees meer over C.S.R.</source>
@@ -52,12 +50,11 @@
       <trans-unit id="AiTuF4c" resname="Wil je zien hoe&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;de vereniging in elkaar zit? Bekijk de serie 'Delft studie is maar de helft!'">
         <source>Wil je zien hoe
 										de vereniging in elkaar zit? Bekijk de serie 'Delft studie is maar de helft!'</source>
-        <target>__Wil je zien hoe
-										de vereniging in elkaar zit? Bekijk de serie 'Delft studie is maar de helft!'</target>
+        <target>Do you want to see what our student association is like? Watch the short video series 'Delft: studies is only a part of student life!'</target>
       </trans-unit>
       <trans-unit id="wMJ25_y" resname="Bekijk en volg ook ons Instagram account voor meer van onze vereniging!">
         <source>Bekijk en volg ook ons Instagram account voor meer van onze vereniging!</source>
-        <target>__Bekijk en volg ook ons Instagram account voor meer van onze vereniging!</target>
+        <target>Follow us on our Instagram account to see more of our association!</target>
       </trans-unit>
       <trans-unit id="1mtQLfN" resname="&lt;p&gt;&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;De OWee gaat er anders uitzien, voor meer informatie zie de &lt;a href=&quot;https://owee.nl&quot;&gt;OWee&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;website&lt;/a&gt;.&lt;br&gt;&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;Maar wij willen je wel vast digitaal een beetje van C.S.R. laten zien.&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;We willen jou daar goede handvaten voor geven. De belangrijkste informatie wordt gedeeld via deze website&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;dus kijk even rond.&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;Wil je meer weten? Kijk op ons &lt;a href=&quot;https://www.youtube.com/user/CivitasFilms&quot;&gt;YouTube kanaal&lt;/a&gt;,&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;onze &lt;a href=&quot;https://www.instagram.com/csrdelft&quot;&gt;Instagram pagina&lt;/a&gt; en de &lt;a&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;href=&quot;https://www.owee.nl&quot;&gt; OWee &lt;/a&gt; website.&#10;&#9;&#9;&#9;&#9;&#9;&#9;&lt;/p&gt;&#10;&#9;&#9;&#9;&#9;&#9;&#9;&lt;p&gt;We hopen je snel te kunnen spreken, digitaal of op anderhalve meter.&lt;/p&gt;&#10;&#9;&#9;&#9;&#9;&#9;&#9;&lt;p&gt;Liefs,&lt;br&gt;OWeeCie en PromoCie&lt;/p&gt;">
         <source>&lt;p&gt;
@@ -73,21 +70,19 @@
 						&lt;p&gt;We hopen je snel te kunnen spreken, digitaal of op anderhalve meter.&lt;/p&gt;
 						&lt;p&gt;Liefs,&lt;br&gt;OWeeCie en PromoCie&lt;/p&gt;</source>
         <target><![CDATA[__<p>
-							De OWee gaat er anders uitzien, voor meer informatie zie de <a href="https://owee.nl">OWee
-								website</a>.<br>
-							Maar wij willen je wel vast digitaal een beetje van C.S.R. laten zien.
-							We willen jou daar goede handvaten voor geven. De belangrijkste informatie wordt gedeeld via deze website
-							dus kijk even rond.
-							Wil je meer weten? Kijk op ons <a href="https://www.youtube.com/user/CivitasFilms">YouTube kanaal</a>,
-							onze <a href="https://www.instagram.com/csrdelft">Instagram pagina</a> en de <a
-								href="https://www.owee.nl"> OWee </a> website.
+							This year the OWee (opening week) will not take place in the same fashion as usual. For more information and the latest updates please refer to the
+							Owee website <a href="https://owee.nl">OWee
+								website</a>.<br>.
+							Still, we want to show you already online what C.S.R. is. The most important information will be shared on this website, so please
+							take a look. For more information, check out our social media channels: <a href="https://www.youtube.com/user/CivitasFilms">YouTube channel</a>,
+							<a href="https://www.instagram.com/csrdelft">Instagram</a> and  <ahref="https://www.owee.nl"> OWee </a> website.
 						</p>
-						<p>We hopen je snel te kunnen spreken, digitaal of op anderhalve meter.</p>
-						<p>Liefs,<br>OWeeCie en PromoCie</p>]]></target>
+						<p> We hope to meet you soon, either online or at 1,5 m distance. </p>
+						<p>Warm regards,<br>OWeeCie and PromoCie</p>]]></target>
       </trans-unit>
       <trans-unit id="_tFekif" resname="C.S.R. in de OWee">
         <source>C.S.R. in de OWee</source>
-        <target>__C.S.R. in de OWee</target>
+        <target>__C.S.R. and the OWee</target>
       </trans-unit>
       <trans-unit id="SK7m38T" resname="Ter aanvang van elk studiejaar wordt er een OntvangstWeek georganiseerd, ofwel de OWee.&#10;&#9;&#9;&#9;&#9;&#9;&#9;Tijdens deze week is er de uitgelezen kans om kennis te maken met de universiteit en hogescholen,&#10;&#9;&#9;&#9;&#9;&#9;&#9;studieverenigingen, studentenverenigingen, sport- en cultuurcentrum, kerken en nog veel meer! Al&#10;&#9;&#9;&#9;&#9;&#9;&#9;deze groepen zullen zichzelf tijdens deze week op verschillende momenten en manieren presenteren.&#10;&#9;&#9;&#9;&#9;&#9;&#9;Ook C.S.R. doet mee aan deze gezellige week. Van 14 t/m 16 augustus zijn wij online te zien en van&#10;&#9;&#9;&#9;&#9;&#9;&#9;17 t/m 22 augustus heb je de gelegenheid om fysiek de sfeer van C.S.R. en Delft te proeven!">
         <source>Ter aanvang van elk studiejaar wordt er een OntvangstWeek georganiseerd, ofwel de OWee.
@@ -96,16 +91,16 @@
 						deze groepen zullen zichzelf tijdens deze week op verschillende momenten en manieren presenteren.
 						Ook C.S.R. doet mee aan deze gezellige week. Van 14 t/m 16 augustus zijn wij online te zien en van
 						17 t/m 22 augustus heb je de gelegenheid om fysiek de sfeer van C.S.R. en Delft te proeven!</source>
-        <target>__Ter aanvang van elk studiejaar wordt er een OntvangstWeek georganiseerd, ofwel de OWee.
-						Tijdens deze week is er de uitgelezen kans om kennis te maken met de universiteit en hogescholen,
-						studieverenigingen, studentenverenigingen, sport- en cultuurcentrum, kerken en nog veel meer! Al
-						deze groepen zullen zichzelf tijdens deze week op verschillende momenten en manieren presenteren.
-						Ook C.S.R. doet mee aan deze gezellige week. Van 14 t/m 16 augustus zijn wij online te zien en van
-						17 t/m 22 augustus heb je de gelegenheid om fysiek de sfeer van C.S.R. en Delft te proeven!</target>
+        <target> OWee is short for ‘OntvangstWeek’, which translates as ‘Opening Week’. During this week, you will get to know a great deal about the student city of Delft.
+        You will find out about the various student associations, go on a tour of the city, visit special places on the campus,
+        and there will surely be some unforgettable parties. The perfect start to your life as a student in Delft!
+        C.S.R. will also be present during this week. Between August 14 - 16 you can see us online and between August 17 - 22 you can
+        come visit and see C.S.R. in real life.
+        </target>
       </trans-unit>
       <trans-unit id="WXbGaaE" resname="Interesse/vragen">
         <source>Interesse/vragen</source>
-        <target>__Interesse/vragen</target>
+        <target>Get to know C.S.R./ Questions</target>
       </trans-unit>
       <trans-unit id="jUUQQ.H" resname="Uiteraard is er de mogelijkheid om ons tijdens de OWee te spreken. Er is daarnaast ook gelegenheid&#10;&#9;&#9;&#9;&#9;&#9;&#9;om onze sociëteit Confide aan de Oude Delft 9 te bezoeken. Buiten de OWee om kan jij ook gewoon&#10;&#9;&#9;&#9;&#9;&#9;&#9;al jouw vragen aan ons stellen.&#10;&#10;&#9;&#9;&#9;&#9;&#9;&#9;Ben jij bijvoorbeeld geinteresseerd om een C.S.R. activiteit bij te wonen of een C.S.R. huis te bezoeken?&#10;&#9;&#9;&#9;&#9;&#9;&#9;Laat dat dan aan ons weten en kom erachter wat er allemaal mogelijk is.">
         <source>Uiteraard is er de mogelijkheid om ons tijdens de OWee te spreken. Er is daarnaast ook gelegenheid
@@ -114,16 +109,15 @@
 
 						Ben jij bijvoorbeeld geinteresseerd om een C.S.R. activiteit bij te wonen of een C.S.R. huis te bezoeken?
 						Laat dat dan aan ons weten en kom erachter wat er allemaal mogelijk is.</source>
-        <target>__Uiteraard is er de mogelijkheid om ons tijdens de OWee te spreken. Er is daarnaast ook gelegenheid
-						om onze sociëteit Confide aan de Oude Delft 9 te bezoeken. Buiten de OWee om kan jij ook gewoon
-						al jouw vragen aan ons stellen.
-
-						Ben jij bijvoorbeeld geinteresseerd om een C.S.R. activiteit bij te wonen of een C.S.R. huis te bezoeken?
-						Laat dat dan aan ons weten en kom erachter wat er allemaal mogelijk is.</target>
+        <target> Of course there will be many opportunities to talk to us during the Owee. In addition, you can also visit our
+        own building called Confide, located at Oude Delft 9. Throughout the entire year you can always ask us any question you may have.
+         Would you like to join a C.S.R. activity, visit a C.S.R. student house or attend any of the other possibilities to discover what C.S.R. is like?
+         Please let us know and we will get in touch.
+        </target>
       </trans-unit>
       <trans-unit id="DZuTr7f" resname="Laat je interesse weten!">
         <source>Laat je interesse weten!</source>
-        <target>__Laat je interesse weten!</target>
+        <target>Let us know you are interested!</target>
       </trans-unit>
       <trans-unit id="vLigd3J" resname="Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).&#10;&#9;&#9;&#9;&#9;&#9;&#9;Voorinschrijven is zelfs ook al mogelijk, zodat er tijdens de OWee meteen contact met je kan worden&#10;&#9;&#9;&#9;&#9;&#9;&#9;opgenomen.&#10;&#9;&#9;&#9;&#9;&#9;&#9;Doe dit door &lt;a href=&quot;%lidworden%&quot;&gt;hier&lt;/a&gt; te&#10;&#9;&#9;&#9;&#9;&#9;&#9;klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek">
         <source>Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).
@@ -131,11 +125,9 @@
 						opgenomen.
 						Doe dit door &lt;a href="%lidworden%"&gt;hier&lt;/a&gt; te
 						klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek</source>
-        <target><![CDATA[__Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).
-						Voorinschrijven is zelfs ook al mogelijk, zodat er tijdens de OWee meteen contact met je kan worden
-						opgenomen.
-						Doe dit door <a href="%lidworden%">hier</a> te
-						klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek]]></target>
+        <target><![CDATA[Do you want to become a member? Registration is open during the Owee (August 17 -22). It is also possible
+        to register in advance so that we can get in contact with you right when the OWee starts. Join us by clicking  <a href="%lidworden%">here</a>.
+        Make sure to reserve the week of August 24-30 for the introduction week of C.S.R. ]]></target>
       </trans-unit>
       <trans-unit id="zEMOsJp" resname="Meer informatie over lid worden">
         <source>Meer informatie over lid worden</source>
@@ -143,7 +135,7 @@
       </trans-unit>
       <trans-unit id="arGwqOE" resname="Like onze foto's op Instagram en volg de laatste posts">
         <source>Like onze foto's op Instagram en volg de laatste posts</source>
-        <target>__Like onze foto's op Instagram en volg de laatste posts</target>
+        <target>Like us on Instagram and check out the latest posts</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -33,10 +33,10 @@
 						eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede
 						vrienden van elkaar worden, op intellectueel en geestelijk gebied groeien en goede studentengrappen
 						uithalen.</source>
-        <target> Civitas Studiosorum Reformatorum is a vibrant, enthusiastic christian student association in Delft,
+        <target>Civitas Studiosorum Reformatorum is a vibrant, enthusiastic christian student association in Delft,
         rich in traditions that have developed over the past %leeftijd% years.
-        We are counting 275 members coming from all kinds of church congregations, united in christian faith. C.S.R. is a community
-         in which friendships are made, personal intellectual and spiritual development is encouraged and where we enjoy the fun of a good student prank.
+        We are counting 275 members coming from all kinds of church denominations, united in christian faith. C.S.R. is a community
+         in which friendships are made, where personal, intellectual, and spiritual development is encouraged and where we enjoy the fun of a good student prank.
         </target>
       </trans-unit>
       <trans-unit id="pj.QOKC" resname="Lees meer over C.S.R.">
@@ -50,7 +50,7 @@
       <trans-unit id="AiTuF4c" resname="Wil je zien hoe&#10;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;&#9;de vereniging in elkaar zit? Bekijk de serie 'Delft studie is maar de helft!'">
         <source>Wil je zien hoe
 										de vereniging in elkaar zit? Bekijk de serie 'Delft studie is maar de helft!'</source>
-        <target>Do you want to see what our student association is like? Watch the short video series 'Delft: studies is only a part of student life!'</target>
+        <target>Do you want to see what our student association is like? Watch the short video series 'Delft: studying is just the half of it!'</target>
       </trans-unit>
       <trans-unit id="wMJ25_y" resname="Bekijk en volg ook ons Instagram account voor meer van onze vereniging!">
         <source>Bekijk en volg ook ons Instagram account voor meer van onze vereniging!</source>
@@ -73,16 +73,16 @@
 							This year the OWee (opening week) will not take place in the same fashion as usual. For more information and the latest updates please refer to the
 							Owee website <a href="https://owee.nl">OWee
 								website</a>.<br>.
-							Still, we want to show you already online what C.S.R. is. The most important information will be shared on this website, so please
-							take a look. For more information, check out our social media channels: <a href="https://www.youtube.com/user/CivitasFilms">YouTube channel</a>,
+							Still, we want to give you an online glimpse of what C.S.R. is all about. The most important information will be shared on this website, so please
+							take a look around. For more information, check out our social media channels: <a href="https://www.youtube.com/user/CivitasFilms">YouTube channel</a>,
 							<a href="https://www.instagram.com/csrdelft">Instagram</a> and  <ahref="https://www.owee.nl"> OWee </a> website.
 						</p>
-						<p> We hope to meet you soon, either online or at 1,5 m distance. </p>
+						<p>We hope to meet you soon, either online or at 1,5 m distance. </p>
 						<p>Warm regards,<br>OWeeCie and PromoCie</p>]]></target>
       </trans-unit>
       <trans-unit id="_tFekif" resname="C.S.R. in de OWee">
         <source>C.S.R. in de OWee</source>
-        <target>__C.S.R. and the OWee</target>
+        <target>C.S.R. and the OWee</target>
       </trans-unit>
       <trans-unit id="SK7m38T" resname="Ter aanvang van elk studiejaar wordt er een OntvangstWeek georganiseerd, ofwel de OWee.&#10;&#9;&#9;&#9;&#9;&#9;&#9;Tijdens deze week is er de uitgelezen kans om kennis te maken met de universiteit en hogescholen,&#10;&#9;&#9;&#9;&#9;&#9;&#9;studieverenigingen, studentenverenigingen, sport- en cultuurcentrum, kerken en nog veel meer! Al&#10;&#9;&#9;&#9;&#9;&#9;&#9;deze groepen zullen zichzelf tijdens deze week op verschillende momenten en manieren presenteren.&#10;&#9;&#9;&#9;&#9;&#9;&#9;Ook C.S.R. doet mee aan deze gezellige week. Van 14 t/m 16 augustus zijn wij online te zien en van&#10;&#9;&#9;&#9;&#9;&#9;&#9;17 t/m 22 augustus heb je de gelegenheid om fysiek de sfeer van C.S.R. en Delft te proeven!">
         <source>Ter aanvang van elk studiejaar wordt er een OntvangstWeek georganiseerd, ofwel de OWee.
@@ -91,11 +91,11 @@
 						deze groepen zullen zichzelf tijdens deze week op verschillende momenten en manieren presenteren.
 						Ook C.S.R. doet mee aan deze gezellige week. Van 14 t/m 16 augustus zijn wij online te zien en van
 						17 t/m 22 augustus heb je de gelegenheid om fysiek de sfeer van C.S.R. en Delft te proeven!</source>
-        <target> OWee is short for ‘OntvangstWeek’, which translates as ‘Opening Week’. During this week, you will get to know a great deal about the student city of Delft.
+        <target>OWee is short for ‘OntvangstWeek’, which translates as ‘Opening Week’. During this week, you will get to know a great deal about the student city of Delft.
         You will find out about the various student associations, go on a tour of the city, visit special places on the campus,
         and there will surely be some unforgettable parties. The perfect start to your life as a student in Delft!
         C.S.R. will also be present during this week. Between August 14 - 16 you can see us online and between August 17 - 22 you can
-        come visit and see C.S.R. in real life.
+        come visit and see C.S.R. in person.
         </target>
       </trans-unit>
       <trans-unit id="WXbGaaE" resname="Interesse/vragen">
@@ -109,8 +109,8 @@
 
 						Ben jij bijvoorbeeld geinteresseerd om een C.S.R. activiteit bij te wonen of een C.S.R. huis te bezoeken?
 						Laat dat dan aan ons weten en kom erachter wat er allemaal mogelijk is.</source>
-        <target> Of course there will be many opportunities to talk to us during the Owee. In addition, you can also visit our
-        own building called Confide, located at Oude Delft 9. Throughout the entire year you can always ask us any question you may have.
+        <target>Of course there will be ample opportunity to talk to us during the Owee. In addition, you can also visit us in our
+        own building called Confide, located at Oude Delft 9. Even outside of the OWee, you can always contact us with any question you may have.
          Would you like to join a C.S.R. activity, visit a C.S.R. student house or attend any of the other possibilities to discover what C.S.R. is like?
          Please let us know and we will get in touch.
         </target>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -25,16 +25,16 @@
         <source>C.S.R. Delft</source>
         <target>C.S.R. Delft</target>
       </trans-unit>
-      <trans-unit id="iXRdDVv" resname="De Civitas Studiosorum Reformatorum is een bruisende, actieve, christelijke studentenvereniging in&#10;&#9;&#9;&#9;&#9;&#9;&#9;Delft, rijk aan tradities die zijn ontstaan in haar %leeftijd%-jarig bestaan. Het is een&#10;&#9;&#9;&#9;&#9;&#9;&#9;breed gezelschap&#10;&#9;&#9;&#9;&#9;&#9;&#9;van zo'n 275 leden met een zeer gevarieerde (kerkelijke) achtergrond, maar met een duidelijke&#10;&#9;&#9;&#9;&#9;&#9;&#9;eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede&#10;&#9;&#9;&#9;&#9;&#9;&#9;vrienden van elkaar worden, op intellectueel en geestelijk gebied groeien en goede studentengrappen&#10;&#9;&#9;&#9;&#9;&#9;&#9;uithalen.">
+      <trans-unit id="iXRdDVv" resname="De Civitas Studiosorum Reformatorum is een bruisende, actieve, christelijke studentenvereniging in&#10;&#9;&#9;&#9;&#9;&#9;&#9;Delft, rijk aan tradities die zijn ontstaan in haar {leeftijd}-jarig bestaan. Het is een&#10;&#9;&#9;&#9;&#9;&#9;&#9;breed gezelschap&#10;&#9;&#9;&#9;&#9;&#9;&#9;van zo'n 275 leden met een zeer gevarieerde (kerkelijke) achtergrond, maar met een duidelijke&#10;&#9;&#9;&#9;&#9;&#9;&#9;eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede&#10;&#9;&#9;&#9;&#9;&#9;&#9;vrienden van elkaar worden, op intellectueel en geestelijk gebied groeien en goede studentengrappen&#10;&#9;&#9;&#9;&#9;&#9;&#9;uithalen.">
         <source>De Civitas Studiosorum Reformatorum is een bruisende, actieve, christelijke studentenvereniging in
-						Delft, rijk aan tradities die zijn ontstaan in haar %leeftijd%-jarig bestaan. Het is een
+						Delft, rijk aan tradities die zijn ontstaan in haar {leeftijd}-jarig bestaan. Het is een
 						breed gezelschap
 						van zo'n 275 leden met een zeer gevarieerde (kerkelijke) achtergrond, maar met een duidelijke
 						eenheid door het christelijk geloof. C.S.R. is de plek waar al tientallen jaren studenten goede
 						vrienden van elkaar worden, op intellectueel en geestelijk gebied groeien en goede studentengrappen
 						uithalen.</source>
         <target>Civitas Studiosorum Reformatorum is a vibrant, enthusiastic Christian student association in Delft,
-        rich in traditions that have developed over the past %leeftijd% years.
+        rich in traditions that have developed over the past {leeftijd} years.
         We are counting 275 members coming from all kinds of Christian backgrounds, united in the Christian faith. C.S.R. is a community
          in which friendships are made, where personal, intellectual, and spiritual development is encouraged and where we enjoy the fun of a good student prank.
         </target>
@@ -119,14 +119,14 @@
         <source>Laat je interesse weten!</source>
         <target>Let us know you are interested!</target>
       </trans-unit>
-      <trans-unit id="vLigd3J" resname="Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).&#10;&#9;&#9;&#9;&#9;&#9;&#9;Voorinschrijven is zelfs ook al mogelijk, zodat er tijdens de OWee meteen contact met je kan worden&#10;&#9;&#9;&#9;&#9;&#9;&#9;opgenomen.&#10;&#9;&#9;&#9;&#9;&#9;&#9;Doe dit door &lt;a href=&quot;%lidworden%&quot;&gt;hier&lt;/a&gt; te&#10;&#9;&#9;&#9;&#9;&#9;&#9;klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek">
+      <trans-unit id="vLigd3J" resname="Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).&#10;&#9;&#9;&#9;&#9;&#9;&#9;Voorinschrijven is zelfs ook al mogelijk, zodat er tijdens de OWee meteen contact met je kan worden&#10;&#9;&#9;&#9;&#9;&#9;&#9;opgenomen.&#10;&#9;&#9;&#9;&#9;&#9;&#9;Doe dit door &lt;a href=&quot;{lidworden}&quot;&gt;hier&lt;/a&gt; te&#10;&#9;&#9;&#9;&#9;&#9;&#9;klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek">
         <source>Wil je lid worden? Inschrijven kan in de OWee (17 t/m 22 augustus).
 						Voorinschrijven is zelfs ook al mogelijk, zodat er tijdens de OWee meteen contact met je kan worden
 						opgenomen.
-						Doe dit door &lt;a href="%lidworden%"&gt;hier&lt;/a&gt; te
+						Doe dit door &lt;a href="{lidworden}"&gt;hier&lt;/a&gt; te
 						klikken. Zorg ervoor dat je de week van 24 t/m 30 augustus vrij houdt voor de novitiaatsweek</source>
         <target><![CDATA[Do you want to become a member? Registration is open during the Owee (August 17 -22). It is also possible
-        to register in advance so that we can get in contact with you right when the OWee starts. Join us by clicking  <a href="%lidworden%">here</a>.
+        to register in advance so that we can get in contact with you right when the OWee starts. Join us by clicking  <a href="{lidworden}">here</a>.
         Make sure to reserve the week of August 24-30 for the introduction week of C.S.R. ]]></target>
       </trans-unit>
       <trans-unit id="zEMOsJp" resname="Meer informatie over lid worden">


### PR DESCRIPTION
Fixes #786

Gebruikt de standaard Symfony vertaling meuk.

Vertalingen van tekst in broncode zit in `translations/messages+intl-icu.en.xlf`, dit bestand wordt gegenereerd door `symfony console translation:update en --force --domain=messages`. In de templates wordt de `{% trans %} ... {% endtrans %}` tag of de `{{ 'bla bla'|trans }}` filter gebruikt, deze worden opgepikt door het console commando.

Voor cms paginas kun je de `[taal=...]` bb tag gebruiken om dingen in een specifieke taal te schrijven. Zo staat alles lekker dicht bij elkaar en krijg je niet dat de verschillende vertalingen van elkaar af groeien.

```
[taal=en]This is in English[/taal]
[taal=nl]Dit is in het Nederlands[/taal]
```

## TODO

- [x] Menu vertalen (meerdere menus maken? Voor iedere taal eentje)
- [x] Daadwerkelijke vertalingen toevoegen
- [x] Documentatie
- [x] Kijken of vertalen in PHP nodig is, of of dat dit te omzeilen is.
- [x] Knopje om van taal te switchen