### PR TITLE
Voeg oauth support toe

### DIFF
--- a/.env
+++ b/.env
@@ -99,3 +99,11 @@ CACHE_PORT=
 SENTRY_DSN=
 SENTRY_DSN_JS=
 ###< sentry/sentry-symfony ###
+
+###> trikoder/oauth2-bundle ###
+# Fallback OAuth2 encryption key
+# Please override this with a secure value: https://oauth2.thephpleague.com/installation/#string-password
+OAUTH2_ENCRYPTION_KEY=
+OAUTH2_PRIVATE_KEY_PATH=
+OAUTH2_PUBLIC_KEY_PATH=
+###< trikoder/oauth2-bundle ###

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,9 @@
 		"symfony/translation": "^5.0",
 		"twig/intl-extra": "^3.2",
 		"twig/extra-bundle": "^3.2",
-		"twig/cssinliner-extra": "^3.3"
+		"twig/cssinliner-extra": "^3.3",
+		"trikoder/oauth2-bundle": "3.x-dev",
+		"nyholm/psr7": "^1.4"
 	},
 	"config": {
 		"platform": {

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
 		"twig/extra-bundle": "^3.2",
 		"twig/cssinliner-extra": "^3.3",
 		"trikoder/oauth2-bundle": "3.x-dev",
-		"nyholm/psr7": "^1.4"
+		"nyholm/psr7": "^1.4",
+		"symfony/uid": "^5.0"
 	},
 	"config": {
 		"platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,73 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0fa5acef8943c13bf63c05c24e38cf11",
+    "content-hash": "4d2b430b2433de5e458875acece87e15",
     "packages": [
+        {
+            "name": "ajgarlag/psr-http-message-bundle",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ajgarlag/psr-http-message-bundle.git",
+                "reference": "2228f4bcab8d87c83aa6018cbc2c1cca89bbd146"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ajgarlag/psr-http-message-bundle/zipball/2228f4bcab8d87c83aa6018cbc2c1cca89bbd146",
+                "reference": "2228f4bcab8d87c83aa6018cbc2c1cca89bbd146",
+                "shasum": ""
+            },
+            "require": {
+                "psr/http-factory": "^1.0",
+                "symfony/framework-bundle": "^4.4|^5.0",
+                "symfony/psr-http-message-bridge": "^1.1|^2.0"
+            },
+            "conflict": {
+                "sensio/framework-extra-bundle": "<5.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.18",
+                "nyholm/psr7": "^1.1",
+                "sensio/framework-extra-bundle": "^5.3|^6.0",
+                "symfony/browser-kit": "^4.4|^5.0",
+                "symfony/monolog-bridge": "^4.0|^5.0",
+                "symfony/monolog-bundle": "^3.2",
+                "symfony/phpunit-bridge": "^4.4.11|^5.0.11",
+                "symfony/yaml": "^4.4|^5.0"
+            },
+            "suggest": {
+                "nyholm/psr7": "Provides autowiring aliases for PSR-17"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ajgarlag\\Bundle\\PsrHttpMessageBundle\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "/tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Antonio J. García Lagar",
+                    "email": "aj@garcialagar.es"
+                }
+            ],
+            "support": {
+                "issues": "https://github.com/ajgarlag/psr-http-message-bundle/issues",
+                "source": "https://github.com/ajgarlag/psr-http-message-bundle/tree/1.2.0"
+            },
+            "time": "2021-02-19T09:51:17+00:00"
+        },
         {
             "name": "beberlei/doctrineextensions",
             "version": "v1.3.0",
@@ -247,6 +312,73 @@
                 "source": "https://github.com/csrdelft/bb/tree/v1.3.3"
             },
             "time": "2021-02-16T16:19:45+00:00"
+        },
+        {
+            "name": "defuse/php-encryption",
+            "version": "v2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/defuse/php-encryption.git",
+                "reference": "0f407c43b953d571421e0020ba92082ed5fb7620"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/defuse/php-encryption/zipball/0f407c43b953d571421e0020ba92082ed5fb7620",
+                "reference": "0f407c43b953d571421e0020ba92082ed5fb7620",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "paragonie/random_compat": ">= 2",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^2.0|^3.0|^4.0",
+                "phpunit/phpunit": "^4|^5"
+            },
+            "bin": [
+                "bin/generate-defuse-key"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Defuse\\Crypto\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Hornby",
+                    "email": "taylor@defuse.ca",
+                    "homepage": "https://defuse.ca/"
+                },
+                {
+                    "name": "Scott Arciszewski",
+                    "email": "info@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "Secure PHP Encryption Library",
+            "keywords": [
+                "aes",
+                "authenticated encryption",
+                "cipher",
+                "crypto",
+                "cryptography",
+                "encrypt",
+                "encryption",
+                "openssl",
+                "security",
+                "symmetric key cryptography"
+            ],
+            "support": {
+                "issues": "https://github.com/defuse/php-encryption/issues",
+                "source": "https://github.com/defuse/php-encryption/tree/master"
+            },
+            "time": "2018-07-24T23:27:56+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -2520,6 +2652,224 @@
             "time": "2020-09-14T14:23:00+00:00"
         },
         {
+            "name": "lcobucci/jwt",
+            "version": "3.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "511629a54465e89a31d3d7e4cf0935feab8b14c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/511629a54465e89a31d3d7e4cf0935feab8b14c1",
+                "reference": "511629a54465e89a31d3d7e4cf0935feab8b14c1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "~1.5",
+                "phpmd/phpmd": "~2.2",
+                "phpunit/php-invoker": "~1.1",
+                "phpunit/phpunit": "^5.7 || ^7.3",
+                "squizlabs/php_codesniffer": "~2.3"
+            },
+            "suggest": {
+                "lcobucci/clock": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                },
+                "files": [
+                    "compat/class-aliases.php",
+                    "compat/json-exception-polyfill.php",
+                    "compat/lcobucci-clock-polyfill.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Otávio Cobucci Oblonczyk",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/3.4.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2021-02-16T09:40:01+00:00"
+        },
+        {
+            "name": "league/event",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/event.git",
+                "reference": "d2cc124cf9a3fab2bb4ff963307f60361ce4d119"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/event/zipball/d2cc124cf9a3fab2bb4ff963307f60361ce4d119",
+                "reference": "d2cc124cf9a3fab2bb4ff963307f60361ce4d119",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "~1.0.1",
+                "phpspec/phpspec": "^2.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Event\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Event package",
+            "keywords": [
+                "emitter",
+                "event",
+                "listener"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/event/issues",
+                "source": "https://github.com/thephpleague/event/tree/master"
+            },
+            "time": "2018-11-26T11:52:41+00:00"
+        },
+        {
+            "name": "league/oauth2-server",
+            "version": "8.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth2-server.git",
+                "reference": "622eaa1f28eb4a2dea0cfc7e4f5280fac794e83c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/622eaa1f28eb4a2dea0cfc7e4f5280fac794e83c",
+                "reference": "622eaa1f28eb4a2dea0cfc7e4f5280fac794e83c",
+                "shasum": ""
+            },
+            "require": {
+                "defuse/php-encryption": "^2.2.1",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "lcobucci/jwt": "^3.4 || ^4.0",
+                "league/event": "^2.2",
+                "php": "^7.2 || ^8.0",
+                "psr/http-message": "^1.0.1"
+            },
+            "replace": {
+                "league/oauth2server": "*",
+                "lncd/oauth2": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-diactoros": "^2.4.1",
+                "phpstan/phpstan": "^0.12.57",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "phpunit/phpunit": "^8.5.13",
+                "roave/security-advisories": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth2\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Bilbie",
+                    "email": "hello@alexbilbie.com",
+                    "homepage": "http://www.alexbilbie.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andy Millington",
+                    "email": "andrew@noexceptions.io",
+                    "homepage": "https://www.noexceptions.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A lightweight and powerful OAuth 2.0 authorization and resource server library with support for all the core specification grants. This library will allow you to secure your API with OAuth and allow your applications users to approve apps that want to access their data from your API.",
+            "homepage": "https://oauth2.thephpleague.com/",
+            "keywords": [
+                "Authentication",
+                "api",
+                "auth",
+                "authorisation",
+                "authorization",
+                "oauth",
+                "oauth 2",
+                "oauth 2.0",
+                "oauth2",
+                "protect",
+                "resource",
+                "secure",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth2-server/issues",
+                "source": "https://github.com/thephpleague/oauth2-server/tree/8.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sephster",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-10T11:35:44+00:00"
+        },
+        {
             "name": "maknz/slack",
             "version": "1.7.0",
             "source": {
@@ -2667,6 +3017,83 @@
                 }
             ],
             "time": "2020-12-14T13:15:25+00:00"
+        },
+        {
+            "name": "nyholm/psr7",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nyholm/psr7.git",
+                "reference": "23ae1f00fbc6a886cbe3062ca682391b9cc7c37b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/23ae1f00fbc6a886cbe3062ca682391b9cc7c37b",
+                "reference": "23ae1f00fbc6a886cbe3062ca682391b9cc7c37b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "php-http/message-factory": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "http-interop/http-factory-tests": "^0.8",
+                "php-http/psr7-integration-tests": "^1.0",
+                "phpunit/phpunit": "^7.5 || 8.5 || 9.4",
+                "symfony/error-handler": "^4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "A fast PHP7 implementation of PSR-7",
+            "homepage": "https://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/Nyholm/psr7/issues",
+                "source": "https://github.com/Nyholm/psr7/tree/1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-02-18T15:41:32+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -7528,6 +7955,94 @@
             "time": "2021-01-27T10:01:46+00:00"
         },
         {
+            "name": "symfony/psr-http-message-bridge",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/psr-http-message-bridge.git",
+                "reference": "81db2d4ae86e9f0049828d9343a72b9523884e5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/81db2d4ae86e9f0049828d9343a72b9523884e5d",
+                "reference": "81db2d4ae86e9f0049828d9343a72b9523884e5d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0",
+                "symfony/http-foundation": "^4.4 || ^5.0"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^1.1",
+                "psr/log": "^1.1",
+                "symfony/browser-kit": "^4.4 || ^5.0",
+                "symfony/config": "^4.4 || ^5.0",
+                "symfony/event-dispatcher": "^4.4 || ^5.0",
+                "symfony/framework-bundle": "^4.4 || ^5.0",
+                "symfony/http-kernel": "^4.4 || ^5.0",
+                "symfony/phpunit-bridge": "^4.4.19 || ^5.2"
+            },
+            "suggest": {
+                "nyholm/psr7": "For a super lightweight PSR-7/17 implementation"
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\PsrHttpMessage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "PSR HTTP message bridge",
+            "homepage": "http://symfony.com",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/symfony/psr-http-message-bridge/issues",
+                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-17T10:35:25+00:00"
+        },
+        {
             "name": "symfony/routing",
             "version": "v5.2.2",
             "source": {
@@ -9132,6 +9647,89 @@
                 "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/2.2.3"
             },
             "time": "2020-07-13T06:12:54+00:00"
+        },
+        {
+            "name": "trikoder/oauth2-bundle",
+            "version": "v3.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/trikoder/oauth2-bundle.git",
+                "reference": "f970a9c6f4275960d77f24b851563ce99e70ba8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/trikoder/oauth2-bundle/zipball/f970a9c6f4275960d77f24b851563ce99e70ba8d",
+                "reference": "f970a9c6f4275960d77f24b851563ce99e70ba8d",
+                "shasum": ""
+            },
+            "require": {
+                "ajgarlag/psr-http-message-bundle": "^1.1",
+                "doctrine/doctrine-bundle": "^1.8|^2.0",
+                "doctrine/orm": "^2.7",
+                "league/oauth2-server": "^8.0",
+                "php": ">=7.2",
+                "psr/http-factory": "^1.0",
+                "symfony/framework-bundle": "^4.4|^5.0",
+                "symfony/psr-http-message-bridge": "^2.0",
+                "symfony/security-bundle": "^4.4|^5.0"
+            },
+            "require-dev": {
+                "ext-timecop": "*",
+                "ext-xdebug": "*",
+                "laminas/laminas-diactoros": "^2.2",
+                "nyholm/psr7": "^1.2",
+                "phpunit/phpunit": "^8.5|^9.4",
+                "symfony/browser-kit": "^4.4|^5.0",
+                "symfony/phpunit-bridge": "^5.0"
+            },
+            "suggest": {
+                "defuse/php-encryption": "For better performance when doing encryption",
+                "nelmio/cors-bundle": "For handling CORS requests",
+                "nyholm/psr7": "For a super lightweight PSR-7/17 implementation"
+            },
+            "default-branch": true,
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Trikoder\\Bundle\\OAuth2Bundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Antonio Pauletich",
+                    "email": "antonio.pauletich@trikoder.net"
+                },
+                {
+                    "name": "Berislav Balogović",
+                    "email": "berislav.balogovic@trikoder.net"
+                },
+                {
+                    "name": "Petar Obradović",
+                    "email": "petar.obradovic@trikoder.net"
+                }
+            ],
+            "description": "Symfony bundle which provides OAuth 2.0 authorization/resource server capabilities.",
+            "homepage": "https://www.trikoder.net/",
+            "keywords": [
+                "oauth2"
+            ],
+            "support": {
+                "issues": "https://github.com/trikoder/oauth2-bundle/issues",
+                "source": "https://github.com/trikoder/oauth2-bundle/tree/v3.x"
+            },
+            "time": "2021-03-09T14:59:54+00:00"
         },
         {
             "name": "twig/cssinliner-extra",
@@ -11977,7 +12575,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "trikoder/oauth2-bundle": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d2b430b2433de5e458875acece87e15",
+    "content-hash": "867fa0fe4146ceae26e3674bd9972c3e",
     "packages": [
         {
             "name": "ajgarlag/psr-http-message-bundle",
@@ -9358,6 +9358,76 @@
                 }
             ],
             "time": "2021-01-27T10:15:41+00:00"
+        },
+        {
+            "name": "symfony/uid",
+            "version": "v5.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/uid.git",
+                "reference": "47d4347b762f0bab9b4ec02112ddfaaa6d79481b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/47d4347b762f0bab9b4ec02112ddfaaa6d79481b",
+                "reference": "47d4347b762f0bab9b4ec02112ddfaaa6d79481b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-uuid": "^1.15"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Uid\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to generate and represent UIDs",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "UID",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/uid/tree/v5.2.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-21T16:15:38+00:00"
         },
         {
             "name": "symfony/var-dumper",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -13,4 +13,6 @@ return [
     Sentry\SentryBundle\SentryBundle::class => ['all' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
+    Trikoder\Bundle\OAuth2Bundle\TrikoderOAuth2Bundle::class => ['all' => true],
+    Ajgarlag\Bundle\PsrHttpMessageBundle\AjgarlagPsrHttpMessageBundle::class => ['all' => true],
 ];

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -36,6 +36,7 @@ doctrine:
           enumCommissieSoort: CsrDelft\common\Doctrine\Type\CommissieSoortType
           enumGeslacht: CsrDelft\common\Doctrine\Type\Enum\GeslachtType
           enumGroepVersie: CsrDelft\common\Doctrine\Type\GroepVersieType
+          uuid: Symfony\Bridge\Doctrine\Types\UuidType
         mapping_types:
           enum: string
     orm:

--- a/config/packages/nyholm_psr7.yaml
+++ b/config/packages/nyholm_psr7.yaml
@@ -1,0 +1,21 @@
+services:
+    # Register nyholm/psr7 services for autowiring with PSR-17 (HTTP factories)
+    Psr\Http\Message\RequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@nyholm.psr7.psr17_factory'
+
+    # Register nyholm/psr7 services for autowiring with HTTPlug factories
+    Http\Message\MessageFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\RequestFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\ResponseFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\StreamFactory: '@nyholm.psr7.httplug_factory'
+    Http\Message\UriFactory: '@nyholm.psr7.httplug_factory'
+
+    nyholm.psr7.psr17_factory:
+        class: Nyholm\Psr7\Factory\Psr17Factory
+
+    nyholm.psr7.httplug_factory:
+        class: Nyholm\Psr7\Factory\HttplugFactory

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -11,10 +11,20 @@ security:
       pattern: ^/(_(profiler|wdt)|css|images|js)/
       security: false
     # Achter deze firewall zitten requests voor de api.
+    oauth_token:
+      pattern: ^/token$
+      security: false
+    oauth:
+      pattern: ^/api/v3/
+      security: true
+      stateless: true
+      guard:
+        authenticators:
+          - Trikoder\Bundle\OAuth2Bundle\Security\Guard\Authenticator\OAuth2Authenticator
     api:
       pattern: ^/API/2.0/
       stateless: true
-      custom_authenticators: [CsrDelft\service\security\ApiAuthenticator]
+      custom_authenticators: [ CsrDelft\service\security\ApiAuthenticator ]
       provider: accounts
       lazy: true
     # Achter deze firewall zitten requests die met een private token worden opgehaald.
@@ -24,14 +34,14 @@ security:
       request_matcher: CsrDelft\service\security\PrivateTokenAuthenticator
       provider: accounts
       stateless: true
-      custom_authenticators: [CsrDelft\service\security\PrivateTokenAuthenticator]
+      custom_authenticators: [ CsrDelft\service\security\PrivateTokenAuthenticator ]
     # Dit is de standaard firewall en wordt gebruikt als geen van de andere firewalls gebruikt worden.
     main:
       form_login:
         enable_csrf: true
         check_path: app_login_check
-      custom_authenticators: [CsrDelft\service\security\WachtwoordResetAuthenticator]
-#      lazy: true
+      custom_authenticators: [ CsrDelft\service\security\WachtwoordResetAuthenticator ]
+      #      lazy: true
       provider: accounts
       entry_point: form_login
       logout:
@@ -39,7 +49,7 @@ security:
         # where to redirect after logout
         target: default
       remember_me:
-        secret:   '%kernel.secret%'
+        secret: '%kernel.secret%'
         lifetime: 1209600 # 2 weken in seconden
         path: /
         token_provider: 'CsrDelft\common\Security\PersistentTokenProvider'
@@ -56,5 +66,6 @@ security:
   # Easy way to control access for large sections of your site
   # Note: Only the *first* access control that matches will be used
   access_control:
-  # - { path: ^/admin, roles: ROLE_ADMIN }
-  # - { path: ^/profile, roles: ROLE_USER }
+    # - { path: ^/admin, roles: ROLE_ADMIN }
+    # - { path: ^/profile, roles: ROLE_USER }
+    - { path: ^/authorize, roles: IS_AUTHENTICATED_FULLY }

--- a/config/packages/trikoder_oauth2.yaml
+++ b/config/packages/trikoder_oauth2.yaml
@@ -8,5 +8,8 @@ trikoder_oauth2:
   resource_server:
     public_key: '%env(string:OAUTH2_PUBLIC_KEY_PATH)%'
 
+  scopes:
+    - PROFIEL:EMAIL
+
   persistence:
     doctrine: null

--- a/config/packages/trikoder_oauth2.yaml
+++ b/config/packages/trikoder_oauth2.yaml
@@ -1,13 +1,12 @@
 trikoder_oauth2:
 
   authorization_server:
-    private_key: '%env(string:OAUTH2_PRIVATE_KEY_PATH)%'                     # Change this
+    private_key: '%env(string:OAUTH2_PRIVATE_KEY_PATH)%'
     private_key_passphrase: null                            # Passphrase of the private key, if any
-
-    encryption_key: '%env(string:OAUTH2_ENCRYPTION_KEY)%'   # (Optional) Change this
+    encryption_key: '%env(string:OAUTH2_ENCRYPTION_KEY)%'
 
   resource_server:
-    public_key: '%env(string:OAUTH2_PUBLIC_KEY_PATH)%'                       # Change this
+    public_key: '%env(string:OAUTH2_PUBLIC_KEY_PATH)%'
 
   persistence:
     doctrine: null

--- a/config/packages/trikoder_oauth2.yaml
+++ b/config/packages/trikoder_oauth2.yaml
@@ -1,0 +1,13 @@
+trikoder_oauth2:
+
+  authorization_server:
+    private_key: '%env(string:OAUTH2_PRIVATE_KEY_PATH)%'                     # Change this
+    private_key_passphrase: null                            # Passphrase of the private key, if any
+
+    encryption_key: '%env(string:OAUTH2_ENCRYPTION_KEY)%'   # (Optional) Change this
+
+  resource_server:
+    public_key: '%env(string:OAUTH2_PUBLIC_KEY_PATH)%'                       # Change this
+
+  persistence:
+    doctrine: null

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -6,6 +6,10 @@ app-controller-sub:
   resource: ../lib/controller/{fiscaat,maalcie,api}/*.php
   type: annotation
 
+api-controller:
+  resource: ../lib/controller/api/v3/*.php
+  type: annotation
+
 # Deze route is een catch-all als allerlaatste
 default:
   path: /{_locale<%app.supported_locales%>}/{naam}/{subnaam}

--- a/config/routes/trikoder_oauth2.yaml
+++ b/config/routes/trikoder_oauth2.yaml
@@ -1,0 +1,11 @@
+oauth2_authorize:
+  path: /authorize
+  controller: Trikoder\Bundle\OAuth2Bundle\Controller\AuthorizationController::indexAction
+  methods: GET
+
+oauth2_token:
+  path: /api/v3/token
+  controller: Trikoder\Bundle\OAuth2Bundle\Controller\TokenController::indexAction
+  methods: POST
+  defaults: { _csrfUnsafe: ja }
+

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -139,8 +139,6 @@ services:
 
   CsrDelft\events\OAuth2AuthorizeListener:
     arguments:
-      - '@security'
-      - '@session'
       - '@request_stack'
       - '@twig'
     tags:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -132,3 +132,18 @@ services:
   CsrDelft\command\WelkomCommand:
     arguments:
       - '%env(EMAIL_PUBCIE)%'
+
+  CsrDelft\events\UserResolveListener:
+    tags:
+      - { name: kernel.event_listener, event: trikoder.oauth2.user_resolve, method: onUserResolve }
+
+  CsrDelft\events\OAuth2AuthorizeListener:
+    arguments:
+      - '@security'
+      - '@session'
+      - '@request_stack'
+      - '@twig'
+    tags:
+      - { name: kernel.event_listener, event: trikoder.oauth2.authorization_request_resolve, method: onAuthorizationRequest }
+
+  Trikoder\Bundle\OAuth2Bundle\Security\Guard\Authenticator\OAuth2Authenticator:

--- a/db/doctrine_migrations/Version20210329134721.php
+++ b/db/doctrine_migrations/Version20210329134721.php
@@ -7,9 +7,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20210329134721 extends AbstractMigration
 {
     public function getDescription() : string
@@ -19,7 +16,6 @@ final class Version20210329134721 extends AbstractMigration
 
     public function up(Schema $schema) : void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('CREATE TABLE oauth2_access_token (identifier CHAR(80) NOT NULL, client VARCHAR(32) NOT NULL, expiry DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', user_identifier VARCHAR(128) DEFAULT NULL, scopes TEXT DEFAULT NULL COMMENT \'(DC2Type:oauth2_scope)\', revoked TINYINT(1) NOT NULL, INDEX IDX_454D9673C7440455 (client), PRIMARY KEY(identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE oauth2_authorization_code (identifier CHAR(80) NOT NULL, client VARCHAR(32) NOT NULL, expiry DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', user_identifier VARCHAR(128) DEFAULT NULL, scopes TEXT DEFAULT NULL COMMENT \'(DC2Type:oauth2_scope)\', revoked TINYINT(1) NOT NULL, INDEX IDX_509FEF5FC7440455 (client), PRIMARY KEY(identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE oauth2_client (identifier VARCHAR(32) NOT NULL, secret VARCHAR(128) DEFAULT NULL, redirect_uris TEXT DEFAULT NULL COMMENT \'(DC2Type:oauth2_redirect_uri)\', grants TEXT DEFAULT NULL COMMENT \'(DC2Type:oauth2_grant)\', scopes TEXT DEFAULT NULL COMMENT \'(DC2Type:oauth2_scope)\', active TINYINT(1) NOT NULL, allow_plain_text_pkce TINYINT(1) DEFAULT \'0\' NOT NULL, PRIMARY KEY(identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
@@ -31,7 +27,6 @@ final class Version20210329134721 extends AbstractMigration
 
     public function down(Schema $schema) : void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE oauth2_refresh_token DROP FOREIGN KEY FK_4DD90732B6A2DD68');
         $this->addSql('ALTER TABLE oauth2_access_token DROP FOREIGN KEY FK_454D9673C7440455');
         $this->addSql('ALTER TABLE oauth2_authorization_code DROP FOREIGN KEY FK_509FEF5FC7440455');

--- a/db/doctrine_migrations/Version20210329134721.php
+++ b/db/doctrine_migrations/Version20210329134721.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210329134721 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Installeer trikoder/oauth2-bundle';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE oauth2_access_token (identifier CHAR(80) NOT NULL, client VARCHAR(32) NOT NULL, expiry DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', user_identifier VARCHAR(128) DEFAULT NULL, scopes TEXT DEFAULT NULL COMMENT \'(DC2Type:oauth2_scope)\', revoked TINYINT(1) NOT NULL, INDEX IDX_454D9673C7440455 (client), PRIMARY KEY(identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE oauth2_authorization_code (identifier CHAR(80) NOT NULL, client VARCHAR(32) NOT NULL, expiry DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', user_identifier VARCHAR(128) DEFAULT NULL, scopes TEXT DEFAULT NULL COMMENT \'(DC2Type:oauth2_scope)\', revoked TINYINT(1) NOT NULL, INDEX IDX_509FEF5FC7440455 (client), PRIMARY KEY(identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE oauth2_client (identifier VARCHAR(32) NOT NULL, secret VARCHAR(128) DEFAULT NULL, redirect_uris TEXT DEFAULT NULL COMMENT \'(DC2Type:oauth2_redirect_uri)\', grants TEXT DEFAULT NULL COMMENT \'(DC2Type:oauth2_grant)\', scopes TEXT DEFAULT NULL COMMENT \'(DC2Type:oauth2_scope)\', active TINYINT(1) NOT NULL, allow_plain_text_pkce TINYINT(1) DEFAULT \'0\' NOT NULL, PRIMARY KEY(identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE oauth2_refresh_token (identifier CHAR(80) NOT NULL, access_token CHAR(80) DEFAULT NULL, expiry DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', revoked TINYINT(1) NOT NULL, INDEX IDX_4DD90732B6A2DD68 (access_token), PRIMARY KEY(identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE oauth2_access_token ADD CONSTRAINT FK_454D9673C7440455 FOREIGN KEY (client) REFERENCES oauth2_client (identifier) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE oauth2_authorization_code ADD CONSTRAINT FK_509FEF5FC7440455 FOREIGN KEY (client) REFERENCES oauth2_client (identifier) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE oauth2_refresh_token ADD CONSTRAINT FK_4DD90732B6A2DD68 FOREIGN KEY (access_token) REFERENCES oauth2_access_token (identifier) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE oauth2_refresh_token DROP FOREIGN KEY FK_4DD90732B6A2DD68');
+        $this->addSql('ALTER TABLE oauth2_access_token DROP FOREIGN KEY FK_454D9673C7440455');
+        $this->addSql('ALTER TABLE oauth2_authorization_code DROP FOREIGN KEY FK_509FEF5FC7440455');
+        $this->addSql('DROP TABLE oauth2_access_token');
+        $this->addSql('DROP TABLE oauth2_authorization_code');
+        $this->addSql('DROP TABLE oauth2_client');
+        $this->addSql('DROP TABLE oauth2_refresh_token');
+    }
+}

--- a/db/doctrine_migrations/Version20210331202456.php
+++ b/db/doctrine_migrations/Version20210331202456.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20210331202456 extends AbstractMigration
+{
+	public function getDescription(): string
+	{
+		return 'Voeg uuid toe aan account';
+	}
+
+	public function up(Schema $schema): void
+	{
+		$this->addSql('ALTER TABLE accounts ADD uuid BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid)\'');
+		// genereer nieuwe uuids
+		$this->addSql('UPDATE accounts SET uuid = (SELECT (UNHEX(REPLACE(UUID(), \'-\', \'\'))))');
+		$this->addSql('CREATE UNIQUE INDEX UNIQ_CAC89EACD17F50A6 ON accounts (uuid)');
+	}
+
+	public function down(Schema $schema): void
+	{
+		$this->addSql('DROP INDEX UNIQ_CAC89EACD17F50A6 ON accounts');
+		$this->addSql('ALTER TABLE accounts DROP uuid');
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ Lees hier meer over specifieke onderdelen van de stek, kijk hier als je denkt ie
 - [Tests](test.md)
 - [Vertalingen](translations.md)
 - [Editor](prosemirror.md)
+- [OAuth](oauth.md)
 
 ## Overig
 

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,25 @@
+# OAuth
+
+Werk in uitvoering hiero
+
+Maak het mogelijk voor externe partijen om in te loggen met een C.S.R. webstek account en ook om met eventuele api's te verbinden.
+
+Zie [`oauth2-bundle`](https://github.com/trikoder/oauth2-bundle) voor meer info en documentatie.
+
+We zitten op `3.x-dev` van oauth2-bundle omdat Guard Authenticators nog niet in een gereleasde versie zitten.
+
+De `trikoder:oauth2:` commands zijn er om clients te beheren.
+
+## Configuratie
+
+De volgende velden moeten worden gezet in `.env.local`:
+
+```
+OAUTH2_PRIVATE_KEY_PATH=
+OAUTH2_PUBLIC_KEY_PATH=
+OAUTH2_ENCRYPTION_KEY=
+```
+
+Zie https://oauth2.thephpleague.com/installation/#generating-public-and-private-keys voor info over het genereren van sleutels. Plaats deze sleutels in `OAUTH2_PRIVATE_KEY_PATH` en `OAUTH2_PUBLIC_KEY_PATH`.
+
+Stop een random string in `OAUTH2_ENCRYPTION_KEY`

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -23,3 +23,9 @@ OAUTH2_ENCRYPTION_KEY=
 Zie https://oauth2.thephpleague.com/installation/#generating-public-and-private-keys voor info over het genereren van sleutels. Plaats deze sleutels in `OAUTH2_PRIVATE_KEY_PATH` en `OAUTH2_PUBLIC_KEY_PATH`.
 
 Stop een random string in `OAUTH2_ENCRYPTION_KEY`
+
+## Een Client maken
+
+Zie hiervoor ook de docs van oauth2-bundle: https://github.com/trikoder/oauth2-bundle/blob/v3.x/docs/basic-setup.md
+
+Let op dat bij het `trikoder:oauth2:update-client` command je alle velden moet meegeven, anders worden ze leeg gemaakt.

--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -16,6 +16,8 @@ RewriteRule ^owee/?$			/csrindeowee [L]
 RewriteRule ^facebook			https://www.facebook.com/delftcsr [R,L]
 RewriteRule ^feuten				https://github.com/csrdelft/csrdelft.nl [R,L]
 
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
 # Symfony config
 RewriteCond %{REQUEST_URI}::$1 ^(/.+)/(.*)::\2$
 RewriteRule ^(.*) - [E=BASE:%1]

--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -16,6 +16,7 @@ RewriteRule ^owee/?$			/csrindeowee [L]
 RewriteRule ^facebook			https://www.facebook.com/delftcsr [R,L]
 RewriteRule ^feuten				https://github.com/csrdelft/csrdelft.nl [R,L]
 
+# Zorg dat Apache2 de http Authorization header doorstuurt naar PHP
 RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
 # Symfony config

--- a/lib/DataFixtures/AccountFixtures.php
+++ b/lib/DataFixtures/AccountFixtures.php
@@ -14,6 +14,7 @@ use CsrDelft\repository\security\AccountRepository;
 use CsrDelft\service\security\LoginService;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\Uid\Uuid;
 
 class AccountFixtures extends Fixture {
 	/**
@@ -50,6 +51,7 @@ class AccountFixtures extends Fixture {
 		$manager->persist($externProfiel);
 
 		$externAccount = new Account();
+		$externAccount->uuid = Uuid::v4();
 		$externAccount->username = '';
 		$externAccount->email = '';
 		$externAccount->pass_hash = '';

--- a/lib/command/CronCommand.php
+++ b/lib/command/CronCommand.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Trikoder\Bundle\OAuth2Bundle\Command\ClearExpiredTokensCommand;
+use Trikoder\Bundle\OAuth2Bundle\Command\ClearRevokedTokensCommand;
 
 class CronCommand extends Command {
 	protected static $defaultName = 'stek:cron';
@@ -136,6 +138,16 @@ class CronCommand extends Command {
 			$output->writeln($ret);
 			$this->debugLogRepository->log('cron.php', 'pin_transactie_download', [], 'exit ' . $ret);
 		}
+
+		// Verwijder verlopen oauth2 tokens
+		$this->getApplication()
+			->find(ClearExpiredTokensCommand::getDefaultName())
+			->run(new ArrayInput([]), $output);
+
+		// Verwijder revoked oauth2 tokens
+		$this->getApplication()
+			->find(ClearRevokedTokensCommand::getDefaultName())
+			->run(new ArrayInput([]), $output);
 
 		$finish = microtime(true) - $start;
 		$output->writeln(getDateTime() . ' Finished in ' . (int)$finish . ' seconds', OutputInterface::VERBOSITY_VERBOSE);

--- a/lib/common/Security/OAuth2Scope.php
+++ b/lib/common/Security/OAuth2Scope.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace CsrDelft\common\Security;
+
+
+class OAuth2Scope
+{
+	const PROFIEL_EMAIL = "PROFIEL:EMAIL";
+	const ROLE_PROFIEL_EMAIL = "ROLE_OAUTH2_PROFIEL:EMAIL";
+
+	const BESCHRIJVING = [
+		self::PROFIEL_EMAIL => 'Lezen van primair emailadres',
+	];
+
+	public static function getBeschrijving($scope) {
+		if (isset(self::BESCHRIJVING[$scope])) {
+			return self::BESCHRIJVING[$scope];
+		}
+
+		return $scope;
+	}
+}

--- a/lib/controller/LidInstellingenController.php
+++ b/lib/controller/LidInstellingenController.php
@@ -4,6 +4,7 @@ namespace CsrDelft\controller;
 
 use CsrDelft\common\Annotation\Auth;
 use CsrDelft\repository\instellingen\LidInstellingenRepository;
+use CsrDelft\view\login\OAuth2RefreshTokenTable;
 use CsrDelft\view\login\RememberLoginTable;
 use Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -35,6 +36,7 @@ class LidInstellingenController extends AbstractController {
 			'defaultInstellingen' => $this->lidInstellingenRepository->getAll(),
 			'instellingen' => $this->lidInstellingenRepository->getAllForLid($this->getUid()),
 			'rememberLoginTable' => new RememberLoginTable(),
+			'authorizationCodeTable' => new OAuth2RefreshTokenTable(),
 		]);
 	}
 

--- a/lib/controller/SessionController.php
+++ b/lib/controller/SessionController.php
@@ -13,9 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\RememberMe\PersistentTokenBasedRememberMeServices;
-use Trikoder\Bundle\OAuth2Bundle\League\Repository\AuthCodeRepository;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
-use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
 use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
 
 /**
@@ -29,7 +27,7 @@ class SessionController extends AbstractController
 	 */
 	private $rememberLoginRepository;
 
-	public function __construct(RememberLoginRepository $rememberLoginRepository, AuthCodeRepository $authCodeRepository)
+	public function __construct(RememberLoginRepository $rememberLoginRepository)
 	{
 		$this->rememberLoginRepository = $rememberLoginRepository;
 	}

--- a/lib/controller/SessionController.php
+++ b/lib/controller/SessionController.php
@@ -13,18 +13,24 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\RememberMe\PersistentTokenBasedRememberMeServices;
+use Trikoder\Bundle\OAuth2Bundle\League\Repository\AuthCodeRepository;
+use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
+use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
+use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
 
 /**
  * @author G.J.W. Oolbekkink <g.j.w.oolbekkink@gmail.com>
  * @since 28/07/2019
  */
-class SessionController extends AbstractController {
+class SessionController extends AbstractController
+{
 	/**
 	 * @var RememberLoginRepository
 	 */
 	private $rememberLoginRepository;
 
-	public function __construct(RememberLoginRepository $rememberLoginRepository) {
+	public function __construct(RememberLoginRepository $rememberLoginRepository, AuthCodeRepository $authCodeRepository)
+	{
 		$this->rememberLoginRepository = $rememberLoginRepository;
 	}
 
@@ -33,7 +39,8 @@ class SessionController extends AbstractController {
 	 * @Route("/session/rememberdata", methods={"POST"})
 	 * @Auth(P_LOGGED_IN)
 	 */
-	public function rememberdata() {
+	public function rememberdata()
+	{
 		return $this->tableData($this->rememberLoginRepository->findBy(['uid' => $this->getUid()]));
 	}
 
@@ -44,7 +51,8 @@ class SessionController extends AbstractController {
 	 * @Route("/session/remember", methods={"POST"})
 	 * @Auth(P_LOGGED_IN)
 	 */
-	public function remember(Request $request, PersistentTokenBasedRememberMeServices $rememberMeServices) {
+	public function remember(Request $request, PersistentTokenBasedRememberMeServices $rememberMeServices)
+	{
 		$selection = $this->getDataTableSelection();
 
 		if (empty($selection)) {
@@ -85,7 +93,8 @@ class SessionController extends AbstractController {
 	 * @Route("/session/forget-all", methods={"POST"})
 	 * @Auth(P_LOGGED_IN)
 	 */
-	public function forgetAll() {
+	public function forgetAll()
+	{
 		$remembers = $this->rememberLoginRepository->findBy(['uid' => $this->getUid()]);
 
 		$response = [];
@@ -104,7 +113,8 @@ class SessionController extends AbstractController {
 	 * @Route("/session/forget", methods={"POST"})
 	 * @Auth(P_LOGGED_IN)
 	 */
-	public function forget() {
+	public function forget()
+	{
 		$selection = $this->getDataTableSelection();
 		if (!$selection) {
 			throw $this->createAccessDeniedException();
@@ -122,5 +132,55 @@ class SessionController extends AbstractController {
 		}
 		$manager->flush();
 		return $this->tableData($response);
+	}
+
+	/**
+	 * @return GenericDataTableResponse
+	 * @Route("/session/oauth2-refresh-token", methods={"POST"})
+	 * @Auth(P_LOGGED_IN)
+	 */
+	public function oauth2Data()
+	{
+		$accessTokens = $this->getDoctrine()->getRepository(AccessToken::class)
+			->findBy(['userIdentifier' => $this->getUser()->uid]);
+
+		$refreshTokens = [];
+
+		foreach ($accessTokens as $accessToken) {
+			$refreshTokens[] = $this->getDoctrine()->getRepository(RefreshToken::class)
+				->findOneBy(['accessToken' => $accessToken->getIdentifier()]);
+		}
+
+		return $this->tableData(array_map(function (RefreshToken $token) {
+			return [
+				'UUID' => $token->getIdentifier() . '@RefreshToken.csrdelft.nl',
+				'identifier' => $token->getIdentifier(),
+				'client' => $token->getAccessToken()->getClient()->getIdentifier(),
+				'expiry' => $token->getExpiry(),
+				'revoked' => $token->isRevoked(),
+			];
+		}, $refreshTokens));
+	}
+
+	/**
+	 * @Route("/session/oauth2-refresh-token-revoke/{identifier}", methods={"POST"})
+	 * @Auth(P_LOGGED_IN)
+	 * @param RefreshToken $refreshToken
+	 * @return GenericDataTableResponse
+	 */
+	public function oauth2RefreshTokenRevoke(RefreshToken $refreshToken)
+	{
+		$refreshToken->revoke();
+		$refreshToken->getAccessToken()->revoke();
+
+		$this->getDoctrine()->getManager()->flush();
+
+		return $this->tableData([[
+			'UUID' => $refreshToken->getIdentifier() . '@RefreshToken.csrdelft.nl',
+			'identifier' => $refreshToken->getIdentifier(),
+			'client' => $refreshToken->getAccessToken()->getClient()->getIdentifier(),
+			'expiry' => $refreshToken->getExpiry(),
+			'revoked' => $refreshToken->isRevoked(),
+		]]);
 	}
 }

--- a/lib/controller/api/v3/ApiInfoController.php
+++ b/lib/controller/api/v3/ApiInfoController.php
@@ -8,20 +8,29 @@ use CsrDelft\common\Annotation\Auth;
 use CsrDelft\controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Security;
 
 class ApiInfoController extends AbstractController
 {
 	/**
+	 * @param Security $security
 	 * @return JsonResponse
 	 * @Route("/api/v3/profiel")
 	 * @Auth(P_LOGGED_IN)
 	 */
-	public function profiel() {
-		return new JsonResponse([
-			'id' => $this->getUser()->getUsername(),
-			'displayName' => $this->getUser()->profiel->getNaam('volledig'),
-			'email' => $this->getUser()->email,
-		]);
+	public function profiel(Security $security) {
+		if ($security->isGranted('ROLE_OAUTH2_PROFIEL:EMAIL')) {
+			return new JsonResponse([
+				'id' => $this->getUser()->getUsername(),
+				'displayName' => $this->getUser()->profiel->getNaam(),
+				'email' => $this->getUser()->email,
+			]);
+		} else {
+			return new JsonResponse([
+				'id' => $this->getUser()->getUsername(),
+				'displayName' => $this->getUser()->profiel->getNaam(),
+			]);
+		}
 	}
 
 }

--- a/lib/controller/api/v3/ApiInfoController.php
+++ b/lib/controller/api/v3/ApiInfoController.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace CsrDelft\controller\api\v3;
+
+
+use CsrDelft\common\Annotation\Auth;
+use CsrDelft\controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ApiInfoController extends AbstractController
+{
+	/**
+	 * @return JsonResponse
+	 * @Route("/api/v3/profiel")
+	 * @Auth(P_LOGGED_IN)
+	 */
+	public function profiel() {
+		return new JsonResponse([
+			'id' => $this->getUser()->getUsername(),
+			'displayName' => $this->getUser()->profiel->getNaam('volledig'),
+			'email' => $this->getUser()->email,
+		]);
+	}
+
+}

--- a/lib/controller/api/v3/ApiInfoController.php
+++ b/lib/controller/api/v3/ApiInfoController.php
@@ -18,19 +18,20 @@ class ApiInfoController extends AbstractController
 	 * @Route("/api/v3/profiel")
 	 * @Auth(P_LOGGED_IN)
 	 */
-	public function profiel(Security $security) {
+	public function profiel(Security $security)
+	{
+		$user = $this->getUser();
+
+		$json = [
+			'id' => $user->uuid->toRfc4122(),
+			'displayName' => $this->getUser()->profiel->getNaam(),
+		];
+
 		if ($security->isGranted('ROLE_OAUTH2_PROFIEL:EMAIL')) {
-			return new JsonResponse([
-				'id' => $this->getUser()->getUsername(),
-				'displayName' => $this->getUser()->profiel->getNaam(),
-				'email' => $this->getUser()->email,
-			]);
-		} else {
-			return new JsonResponse([
-				'id' => $this->getUser()->getUsername(),
-				'displayName' => $this->getUser()->profiel->getNaam(),
-			]);
+			$json['email'] = $user->email;
 		}
+
+		return new JsonResponse($json);
 	}
 
 }

--- a/lib/entity/security/Account.php
+++ b/lib/entity/security/Account.php
@@ -6,6 +6,7 @@ use CsrDelft\entity\profiel\Profiel;
 use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Account
@@ -27,6 +28,13 @@ class Account implements UserInterface {
 	 * @ORM\Id()
 	 */
 	public $uid;
+
+	/**
+	 * Unieke id voor externe applicaties
+	 * @var Uuid
+	 * @ORM\Column(type="uuid", unique=true)
+	 */
+	public $uuid;
 	/**
 	 * Gebruikersnaam
 	 * @var string

--- a/lib/events/AccessControlEventListener.php
+++ b/lib/events/AccessControlEventListener.php
@@ -29,6 +29,8 @@ class AccessControlEventListener
 		'CsrDelft\controller\ErrorController::handleException' => true,
 		'twig.controller.exception::showAction' => true,
 		'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction' => true,
+		'Trikoder\Bundle\OAuth2Bundle\Controller\TokenController::indexAction' => true,
+		'Trikoder\Bundle\OAuth2Bundle\Controller\AuthorizationController::indexAction' => true,
 	];
 	/**
 	 * @var CsrfService
@@ -75,7 +77,7 @@ class AccessControlEventListener
 		/** @var CsrfUnsafe $authAnnotation */
 		$csrfUnsafeAnnotation = $this->annotations->getMethodAnnotation($reflectionMethod, CsrfUnsafe::class);
 
-		$isInApi = startsWith($request->getPathInfo(), '/API/2.0');
+		$isInApi = startsWith($request->getPathInfo(), '/API/2.0') || startsWith($request->getPathInfo(), '/api/v3/');
 
 		if (
 			$isInApi === false

--- a/lib/events/OAuth2AuthorizeListener.php
+++ b/lib/events/OAuth2AuthorizeListener.php
@@ -1,0 +1,82 @@
+<?php
+
+
+namespace CsrDelft\events;
+
+
+use Nyholm\Psr7\Response;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
+use Symfony\Component\Security\Core\Security;
+use Trikoder\Bundle\OAuth2Bundle\Event\AuthorizationRequestResolveEvent;
+use Twig\Environment;
+
+class OAuth2AuthorizeListener
+{
+	/**
+	 * @var Security
+	 */
+	private $security;
+	/**
+	 * @var SessionBagInterface
+	 */
+	private $session;
+	/**
+	 * @var RequestStack
+	 */
+	private $requestStack;
+	/**
+	 * @var Environment
+	 */
+	private $twig;
+
+	public function __construct(
+		Security $security,
+		Session $session,
+		RequestStack $requestStack,
+		Environment $twig
+	)
+	{
+		$this->security = $security;
+		$this->session = $session;
+		$this->requestStack = $requestStack;
+		$this->twig = $twig;
+	}
+
+	public function onAuthorizationRequest(AuthorizationRequestResolveEvent $event): void
+	{
+
+		$request = $this->requestStack->getMasterRequest();
+		if (!$this->session->has('token')) {
+			$this->session->set('token', uniqid_safe('token_'));
+		}
+
+		if ($request->get('token') == $this->session->get('token')) {
+			$event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
+
+			return;
+		}
+
+		$user = $this->security->getUser() ? $this->security->getUser()->getUsername() : "Niemand";
+
+		$response = new Response(200,
+			[],
+			$this->twig->render('oauth2/authorize.html.twig', [
+				'client_id' => $event->getClient()->getIdentifier(),
+				'redirect_uri' => $request->get('redirect_uri'),
+				'response_type' => $request->get('response_type'),
+				'token' => $this->session->get('token'),
+			])
+//			"Hoi, ${user}. You need to accept <form>
+//<input type='hidden' value='" . $request->get('client_id') . "' name='client_id'>
+//<input type='hidden' value='" . $request->get('redirect_uri') . "' name='redirect_uri'>
+//<input type='hidden' value='" . $request->get('response_type') . "' name='response_type'>
+//<input type='hidden' value='" . $this->session->get('token') . "' name='token'>
+//<input type='submit'>dignen</input>
+//</form>"
+		);
+
+		$event->setResponse($response);
+	}
+}

--- a/lib/events/OAuth2AuthorizeListener.php
+++ b/lib/events/OAuth2AuthorizeListener.php
@@ -58,9 +58,11 @@ class OAuth2AuthorizeListener
 			return;
 		}
 
+		$allScopes = array_unique(array_merge($event->getScopes(), $event->getClient()->getScopes()));
+
 		$scopes = array_map(function ($scope) {
 			return OAuth2Scope::getBeschrijving((string)$scope);
-		}, array_merge($event->getScopes(), $event->getClient()->getScopes()));
+		}, $allScopes);
 
 		$response = new Response(200,
 			[],

--- a/lib/events/OAuth2AuthorizeListener.php
+++ b/lib/events/OAuth2AuthorizeListener.php
@@ -58,8 +58,6 @@ class OAuth2AuthorizeListener
 			return;
 		}
 
-		$user = $this->security->getUser() ? $this->security->getUser()->getUsername() : "Niemand";
-
 		$response = new Response(200,
 			[],
 			$this->twig->render('oauth2/authorize.html.twig', [
@@ -68,13 +66,6 @@ class OAuth2AuthorizeListener
 				'response_type' => $request->get('response_type'),
 				'token' => $this->session->get('token'),
 			])
-//			"Hoi, ${user}. You need to accept <form>
-//<input type='hidden' value='" . $request->get('client_id') . "' name='client_id'>
-//<input type='hidden' value='" . $request->get('redirect_uri') . "' name='redirect_uri'>
-//<input type='hidden' value='" . $request->get('response_type') . "' name='response_type'>
-//<input type='hidden' value='" . $this->session->get('token') . "' name='token'>
-//<input type='submit'>dignen</input>
-//</form>"
 		);
 
 		$event->setResponse($response);

--- a/lib/events/UserResolveListener.php
+++ b/lib/events/UserResolveListener.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace CsrDelft\events;
+
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Trikoder\Bundle\OAuth2Bundle\Event\UserResolveEvent;
+
+final class UserResolveListener
+{
+	/**
+	 * @var UserProviderInterface
+	 */
+	private $userProvider;
+
+	/**
+	 * @var UserPasswordEncoderInterface
+	 */
+	private $userPasswordEncoder;
+
+	/**
+	 * @param UserProviderInterface $userProvider
+	 * @param UserPasswordEncoderInterface $userPasswordEncoder
+	 */
+	public function __construct(UserProviderInterface $userProvider, UserPasswordEncoderInterface $userPasswordEncoder)
+	{
+		$this->userProvider = $userProvider;
+		$this->userPasswordEncoder = $userPasswordEncoder;
+	}
+
+	/**
+	 * @param UserResolveEvent $event
+	 */
+	public function onUserResolve(UserResolveEvent $event): void
+	{
+		$user = $this->userProvider->loadUserByUsername($event->getUsername());
+
+		if (null === $user) {
+			return;
+		}
+
+		if (!$this->userPasswordEncoder->isPasswordValid($user, $event->getPassword())) {
+			return;
+		}
+
+		$event->setUser($user);
+	}
+}

--- a/lib/repository/security/AccountRepository.php
+++ b/lib/repository/security/AccountRepository.php
@@ -16,6 +16,7 @@ use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * AccountRepository
@@ -130,6 +131,7 @@ class AccountRepository extends AbstractRepository implements PasswordUpgraderIn
 		}
 
 		$account = new Account();
+		$account->uuid = Uuid::v4();
 		$account->uid = $uid;
 		$account->profiel = $profiel;
 		$account->username = $uid;

--- a/lib/service/security/LoginService.php
+++ b/lib/service/security/LoginService.php
@@ -20,6 +20,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+use Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Token\OAuth2Token;
 
 /**
  * Deze service verteld je dingen over de op dit moment ingelogde gebruiker.
@@ -158,6 +159,7 @@ class LoginService {
 				break;
 			case RememberMeToken::class:
 			case JwtToken::class:
+			case OAuth2Token::class:
 				$method = AuthenticationMethod::cookie_token;
 				break;
 			default:

--- a/lib/view/datatable/DataTable.php
+++ b/lib/view/datatable/DataTable.php
@@ -29,8 +29,6 @@ class DataTable implements View, FormElement, ToResponse {
 	use ToHtmlResponse;
 	const POST_SELECTION = 'DataTableSelection';
 
-	public $model;
-
 	protected $dataUrl;
 	protected $titel;
 	protected $dataTableId;
@@ -74,7 +72,6 @@ class DataTable implements View, FormElement, ToResponse {
 	private $groupByColumn;
 
 	public function __construct($orm, $dataUrl, $titel = false, $groupByColumn = null) {
-		$this->model = new $orm();
 		$this->titel = $titel;
 
 		$this->dataUrl = $dataUrl;
@@ -344,7 +341,7 @@ class DataTable implements View, FormElement, ToResponse {
 	 * Hiermee wordt gepoogt af te dwingen dat een view een model heeft om te tonen
 	 */
 	public function getModel() {
-		return $this->model;
+		return null;
 	}
 
 	public function getType() {

--- a/lib/view/login/OAuth2RefreshTokenTable.php
+++ b/lib/view/login/OAuth2RefreshTokenTable.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace CsrDelft\view\login;
+
+
+use CsrDelft\view\datatable\CellRender;
+use CsrDelft\view\datatable\DataTable;
+use CsrDelft\view\datatable\knoppen\DataTableRowKnop;
+use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
+
+class OAuth2RefreshTokenTable extends DataTable
+{
+
+	public function __construct()
+	{
+		parent::__construct(RefreshToken::class, "/session/oauth2-refresh-token");
+		$this->deleteColumn('accessToken');
+		$this->addColumn('client', 'expiry');
+		$this->setOrder(['expiry' => 'desc']);
+
+		$this->addColumn('expiry', 'scopes', null, CellRender::DateTime());
+
+		$this->addRowKnop(new DataTableRowKnop("/session/oauth2-refresh-token-revoke/:identifier", "Revoke", "delete"));
+	}
+
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,4 +1,7 @@
 {
+    "ajgarlag/psr-http-message-bundle": {
+        "version": "1.2.0"
+    },
     "beberlei/doctrineextensions": {
         "version": "v1.2.6"
     },
@@ -7,6 +10,9 @@
     },
     "csrdelft/bb": {
         "version": "v1.1.3"
+    },
+    "defuse/php-encryption": {
+        "version": "v2.2.1"
     },
     "doctrine/annotations": {
         "version": "1.0",
@@ -159,6 +165,15 @@
     "laminas/laminas-zendframework-bridge": {
         "version": "1.1.1"
     },
+    "lcobucci/jwt": {
+        "version": "3.4.5"
+    },
+    "league/event": {
+        "version": "2.2.0"
+    },
+    "league/oauth2-server": {
+        "version": "8.2.4"
+    },
     "maknz/slack": {
         "version": "1.7.0"
     },
@@ -170,6 +185,18 @@
     },
     "nikic/php-parser": {
         "version": "v4.6.0"
+    },
+    "nyholm/psr7": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "0cd4d2d0e7f646fda75f9944f747a56e6ed13d4c"
+        },
+        "files": [
+            "./config/packages/nyholm_psr7.yaml"
+        ]
     },
     "ocramius/package-versions": {
         "version": "1.5.1"
@@ -558,6 +585,9 @@
     "symfony/proxy-manager-bridge": {
         "version": "v5.2.2"
     },
+    "symfony/psr-http-message-bridge": {
+        "version": "v2.1.0"
+    },
     "symfony/routing": {
         "version": "3.3",
         "recipe": {
@@ -677,6 +707,19 @@
     },
     "tijsverkoyen/css-to-inline-styles": {
         "version": "2.2.3"
+    },
+    "trikoder/oauth2-bundle": {
+        "version": "3.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "master",
+            "version": "3.0",
+            "ref": "a7511afeb7841ed7da530b0e11a82d245f00fb0e"
+        },
+        "files": [
+            "./config/packages/trikoder_oauth2.yaml",
+            "./config/routes/trikoder_oauth2.yaml"
+        ]
     },
     "twig/cssinliner-extra": {
         "version": "v3.3.0"

--- a/symfony.lock
+++ b/symfony.lock
@@ -679,6 +679,9 @@
     "symfony/twig-pack": {
         "version": "v1.0.0"
     },
+    "symfony/uid": {
+        "version": "v5.2.6"
+    },
     "symfony/var-dumper": {
         "version": "v3.4.32"
     },

--- a/templates/instellingen/lidinstellingen.html.twig
+++ b/templates/instellingen/lidinstellingen.html.twig
@@ -88,6 +88,8 @@
 			{% endfor %}
 
 			{{ rememberLoginTable.toString | raw }}
+
+			{{ authorizationCodeTable.toString | raw }}
 		</div>
 
 		<div class="col-md-4 d-none d-lg-block">

--- a/templates/oauth2/authorize.html.twig
+++ b/templates/oauth2/authorize.html.twig
@@ -1,44 +1,54 @@
-{% extends 'base.html.twig' %}
+{% extends 'default.html.twig' %}
 
-{% block content %}
-	<div class="jumbotron">
+{% block titel %}Autoriseer {{ client_id }}{% endblock %}
 
-		<h1 class="display-4">Autoriseer {{ client_id }}</h1>
-		<p>{{ client_id }} wil inloggen met je stekprofiel.</p>
+{% block content %}{{ cms('thuis') }}{% endblock %}
 
-		{% if scopes is not empty %}
-			<p>Deze applicatie vraagt toegang tot de volgende onderdelen:</p>
-		{% endif %}
-
-		{% for scope in scopes %}
-			<div class="card">
-				<div class="card-body">
-					{{ scope }}
+{% block modal %}
+	<div class="modal show" id="modal" data-backdrop="static">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h5 class="modal-title">Autoriseer {{ client_id }}</h5>
 				</div>
+				<div class="modal-body">
+					<p>{{ client_id }} wil inloggen met je stekprofiel.</p>
+
+					{% if scopes is not empty %}
+						<p>Deze applicatie vraagt toegang tot de volgende onderdelen:</p>
+					{% endif %}
+
+					{% for scope in scopes %}
+						<div class="card">
+							<div class="card-body">
+								{{ scope }}
+							</div>
+						</div>
+					{% endfor %}
+
+					<p class="mt-4">
+						Klik op Autoriseer als je <em>{{ client_id }}</em> aan je account wil koppelen. Na autoriseren
+						wordt je naam en bovenstaande onderdelen met de applicatie gedeeld.
+					</p>
+
+					<p>Na autoriseren wordt je naar <strong>{{ redirect_uri }}</strong> gestuurd</p>
+				</div>
+				<div class="modal-footer">
+
+					<form>
+						<input type="hidden" name="client_id" value="{{ client_id }}">
+						<input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
+						<input type="hidden" name="response_type" value="{{ response_type }}">
+						<input type="hidden" name="token" value="{{ token }}">
+						<input type="hidden" name="scope" value="{{ scope }}">
+
+						<input type="submit" value="Terug" class="btn btn-secondary" name="cancel">
+						<input type="submit" value="Autoriseer" class="btn btn-primary mr-2">
+					</form>
+
+				</div>
+
 			</div>
-		{% endfor %}
-
-		<hr class="my-4">
-
-		<div class="block">
-			Klik op Autoriseer als je <em>{{ client_id }}</em> aan je account wil koppelen. Na autoriseren
-			wordt je naam en bovenstaande onderdelen met de applicatie gedeeld.
 		</div>
-
-		<form>
-			<input type="hidden" name="client_id" value="{{ client_id }}">
-			<input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
-			<input type="hidden" name="response_type" value="{{ response_type }}">
-			<input type="hidden" name="token" value="{{ token }}">
-			<input type="hidden" name="scope" value="{{ scope }}">
-
-			<div class="btn-toolbar mt-4">
-				<input type="submit" value="Autoriseer" class="btn btn-primary mr-2">
-				<input type="submit" value="Terug" class="btn btn-secondary" name="cancel">
-			</div>
-		</form>
-
-		<p>Na autoriseren wordt je naar <strong>{{ redirect_uri }}</strong> gestuurd</p>
 	</div>
-
 {% endblock %}

--- a/templates/oauth2/authorize.html.twig
+++ b/templates/oauth2/authorize.html.twig
@@ -6,19 +6,35 @@
 		<h1 class="display-4">Autoriseer {{ client_id }}</h1>
 		<p>{{ client_id }} wil inloggen met je stekprofiel.</p>
 
+		{% if scopes is not empty %}
+			<p>Deze applicatie vraagt toegang tot de volgende onderdelen:</p>
+		{% endif %}
+
+		{% for scope in scopes %}
+			<div class="card">
+				<div class="card-body">
+					{{ scope }}
+				</div>
+			</div>
+		{% endfor %}
+
 		<hr class="my-4">
 
-		<div class="block">Klik op Autoriseer als je <em>{{ client_id }}</em> aan je account wil koppelen. Na autoriseren worden je naam, lidnummer en emailadres gedeeld.</div>
+		<div class="block">
+			Klik op Autoriseer als je <em>{{ client_id }}</em> aan je account wil koppelen. Na autoriseren
+			worden je naam, lidnummer en emailadres gedeeld.
+		</div>
 
 		<form>
 			<input type="hidden" name="client_id" value="{{ client_id }}">
 			<input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
 			<input type="hidden" name="response_type" value="{{ response_type }}">
 			<input type="hidden" name="token" value="{{ token }}">
+			<input type="hidden" name="scope" value="{{ scope }}">
 
 			<div class="btn-toolbar mt-4">
-			<input type="submit" value="Autoriseer" class="btn btn-primary mr-2">
-			<a href="/" class="btn btn-secondary">Terug</a>
+				<input type="submit" value="Autoriseer" class="btn btn-primary mr-2">
+				<input type="submit" value="Terug" class="btn btn-secondary" name="cancel">
 			</div>
 		</form>
 

--- a/templates/oauth2/authorize.html.twig
+++ b/templates/oauth2/authorize.html.twig
@@ -1,0 +1,28 @@
+{% extends 'base.html.twig' %}
+
+{% block content %}
+	<div class="jumbotron">
+
+		<h1 class="display-4">Autoriseer {{ client_id }}</h1>
+		<p>{{ client_id }} wil inloggen met je stekprofiel.</p>
+
+		<hr class="my-4">
+
+		<div class="block">Klik op Autoriseer als je <em>{{ client_id }}</em> aan je account wil koppelen. Na autoriseren worden je naam, lidnummer en emailadres gedeeld.</div>
+
+		<form>
+			<input type="hidden" name="client_id" value="{{ client_id }}">
+			<input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
+			<input type="hidden" name="response_type" value="{{ response_type }}">
+			<input type="hidden" name="token" value="{{ token }}">
+
+			<div class="btn-toolbar mt-4">
+			<input type="submit" value="Autoriseer" class="btn btn-primary mr-2">
+			<a href="/" class="btn btn-secondary">Terug</a>
+			</div>
+		</form>
+
+		<p>Na autoriseren wordt je naar <strong>{{ redirect_uri }}</strong> gestuurd</p>
+	</div>
+
+{% endblock %}

--- a/templates/oauth2/authorize.html.twig
+++ b/templates/oauth2/authorize.html.twig
@@ -22,7 +22,7 @@
 
 		<div class="block">
 			Klik op Autoriseer als je <em>{{ client_id }}</em> aan je account wil koppelen. Na autoriseren
-			worden je naam, lidnummer en emailadres gedeeld.
+			wordt je naam en bovenstaande onderdelen met de applicatie gedeeld.
 		</div>
 
 		<form>


### PR DESCRIPTION
Nog soort van wip.

Het werkt helemaal, maar het kan goed zijn dat ik nog iets over het hoofd heb gezien.

Nog te verbeteren:
- [x] Tekstje bij het autoriseren verduidelijken
- [x] ~Beschrijving / logo / leesbare naam bij een client opslaan~
- [x] Interface voor beheer geautoriseerde clients, om toegang te revoken.
- [x] Scopes, email in een losse scope
- [x] Nieuwe user id (uuid) voor delen met externen

Logische volgende stap is om naast de ozonspullen ook de wiki via oauth the doen (https://www.dokuwiki.org/plugin:oauth). Op deze manier kunnen we de verbinding tussen de stek en de wiki wat beter fixen.