### PR TITLE
Verwijder de CSR_ROOT constant

### DIFF
--- a/.env
+++ b/.env
@@ -81,7 +81,6 @@ SPONSOR_USERAGENT=
 
 ###> config ###
 FORCE_HTTPS=false
-CSR_ROOT=https://csrdelft.nl
 # ImageMagick ('magick' voor v7, 'convert' voor v6)
 IMAGEMAGICK=convert
 ###< config ###

--- a/.env.dev
+++ b/.env.dev
@@ -1,1 +1,0 @@
-CSR_ROOT=http://dev-csrdelft.nl

--- a/docker/dev/.env.local
+++ b/docker/dev/.env.local
@@ -1,6 +1,4 @@
 APP_ENV=dev
 DATABASE_URL=mysql://csrdelft:bl44t@stekdb/csrdelft
-CSR_DOMAIN=localhost
-CSR_ROOT=https://localhost:8080
 BASE_PATH=/app/
 IMAGEMAGICK=convert

--- a/lib/common/common.functions.php
+++ b/lib/common/common.functions.php
@@ -129,26 +129,32 @@ function group_by_distinct($prop, $in, $del = true) {
  * Invokes a client page (re)load the url.
  *
  * @param string $url
- * @param boolean $refresh allow a refresh; redirect to CSR_ROOT otherwise
+ * @param boolean $refresh allow a refresh; redirect to / otherwise
  * @deprecated Gebruik redirect in de controller
  */
 function redirect($url = null, $refresh = true) {
 	$request = ContainerFacade::getContainer()->get('request_stack')->getCurrentRequest();
-	if (empty($url) || $url === null) {
+	if (empty($url)) {
 		$url = $request->getRequestUri();
 	}
 	if (!$refresh && $url == $request->getRequestUri()) {
-		$url = $_ENV['CSR_ROOT'];
+		$url = $request->getSchemeAndHttpHost();
 	}
-	if (!str_starts_with($url, $_ENV['CSR_ROOT'])) {
+	if (!str_starts_with($url, $request->getSchemeAndHttpHost())) {
 		if (preg_match("/^[?#\/]/", $url) === 1) {
-			$url = $_ENV['CSR_ROOT'] . $url;
+			$url = $request->getSchemeAndHttpHost() . $url;
 		} else {
-			$url = $_ENV['CSR_ROOT'];
+			$url = $request->getSchemeAndHttpHost();
 		}
 	}
 	header('location: ' . $url);
 	exit;
+}
+
+function getCsrRoot() {
+	$request = ContainerFacade::getContainer()->get('request_stack')->getCurrentRequest();
+
+	return $request->getSchemeAndHttpHost();
 }
 
 /**
@@ -265,7 +271,7 @@ function url_like($url) {
 
 function external_url($url, $label) {
 	$url = filter_var($url, FILTER_SANITIZE_URL);
-	if ($url && (url_like($url) || url_like(CSR_ROOT . $url))) {
+	if ($url && (url_like($url) || url_like(getCsrRoot() . $url))) {
 		if (str_starts_with($url, 'http://') || str_starts_with($url, 'https://')) {
 			$extern = 'target="_blank" rel="noopener"';
 		} else {

--- a/lib/configuratie.include.php
+++ b/lib/configuratie.include.php
@@ -80,7 +80,7 @@ if (FORCE_HTTPS) {
 			// TODO: Log dit
 		}
 		// redirect to https
-		header('Location: ' . CSR_ROOT . $_SERVER['REQUEST_URI'], true, 301);
+		header('Location: ' . getCsrRoot() . $_SERVER['REQUEST_URI'], true, 301);
 		// we are in cleartext at the moment, prevent further execution and output
 		die();
 	}
@@ -98,13 +98,11 @@ if (!isCli()) {
 	ini_set('session.use_strict_mode', true);
 	ini_set('session.use_cookies', true);
 	ini_set('session.use_only_cookies', true);
-	ini_set('session.cookie_domain', CSR_DOMAIN);
 	ini_set('session.cookie_secure', FORCE_HTTPS);
 	ini_set('session.cookie_httponly', true);
 	ini_set('log_errors_max_len', 0);
 	ini_set('xdebug.max_nesting_level', 2000);
 	ini_set('intl.default_locale', 'nl');
-	session_set_cookie_params(0, '/', CSR_DOMAIN, FORCE_HTTPS, true);
 
 	$container->get(LogRepository::class)->log();
 }

--- a/lib/controller/AbstractController.php
+++ b/lib/controller/AbstractController.php
@@ -57,12 +57,20 @@ class AbstractController extends BaseController {
 	 */
 	protected function csrRedirect($url, $status = 302, $allowExternal = false): RedirectResponse
 	{
+
+		$request = $this->get('request_stack')->getCurrentRequest();
 			if (empty($url) || $url === null) {
-				$url = $this->get('request_stack')->getCurrentRequest()->getRequestUri();
+				$url = $request->getRequestUri();
 			}
-			if (!str_starts_with($url, $_ENV['CSR_ROOT']) && !$allowExternal) {
+
+			$url = $this->get('request_stack')->getAbsoluteUrl($url);
+
+			$root = $request->getSchemeAndHttpHost();
+
+			if (!str_starts_with($url, $root) && !$allowExternal) {
 				if (preg_match("/^[?#\/]/", $url) === 1) {
-					$url = $_ENV['CSR_ROOT'] . $url;
+
+					$url = $this->get('url_helper')->getAbsoluteUrl($url);
 				} else {
 					throw $this->createAccessDeniedException();
 				}

--- a/lib/controller/CmsPaginaController.php
+++ b/lib/controller/CmsPaginaController.php
@@ -132,7 +132,7 @@ class CmsPaginaController extends AbstractController {
 		$manager->flush();
 		setMelding('Pagina ' . $naam . ' succesvol verwijderd', 1);
 
-		return new JsonResponse(CSR_ROOT); // redirect
+		return new JsonResponse($this->generateUrl('default')); // redirect
 	}
 
 }

--- a/lib/controller/ForumController.php
+++ b/lib/controller/ForumController.php
@@ -740,7 +740,8 @@ class ForumController extends AbstractController {
 		if ($wacht_goedkeuring) {
 			setMelding('Uw bericht is opgeslagen en zal als het goedgekeurd is geplaatst worden.', 1);
 
-			mail('pubcie@csrdelft.nl', 'Nieuw bericht wacht op goedkeuring', CSR_ROOT . "/forum/onderwerp/" . $draad->draad_id . "/wacht#" . $post->post_id . "\n\nDe inhoud van het bericht is als volgt: \n\n" . str_replace('\r\n', "\n", $tekst) . "\n\nEINDE BERICHT", "From: pubcie@csrdelft.nl\r\nReply-To: " . $mailadres);
+			$url = $this->generateUrl('csrdelft_forum_onderwerp', ['draad_id' => $draad->draad_id, '_fragment' => $post->post_id]);
+			mail('pubcie@csrdelft.nl', 'Nieuw bericht wacht op goedkeuring', $url . "\n\nDe inhoud van het bericht is als volgt: \n\n" . str_replace('\r\n', "\n", $tekst) . "\n\nEINDE BERICHT", "From: pubcie@csrdelft.nl\r\nReply-To: " . $mailadres);
 		} else {
 
 			// direct goedkeuren voor ingelogd

--- a/lib/controller/ProfielController.php
+++ b/lib/controller/ProfielController.php
@@ -485,7 +485,8 @@ class ProfielController extends AbstractController {
 			throw new NotFoundHttpException();
 		}
 		try {
-			$this->googleSync->doRequestToken(CSR_ROOT . "/profiel/" . $profiel->uid . "/addToGoogleContacts");
+			$addToContactsUrl = $this->generateUrl('csrdelft_profiel_addtogooglecontacts', ['uid' => $profiel->uid]);
+			$this->googleSync->doRequestToken($addToContactsUrl);
 			$msg = $this->googleSync->syncLid($profiel);
 			setMelding('Opgeslagen in Google Contacts: ' . $msg, 1);
 		} catch (CsrException $e) {

--- a/lib/controller/SessionController.php
+++ b/lib/controller/SessionController.php
@@ -74,7 +74,7 @@ class SessionController extends AbstractController
 			} else if (!empty($_POST['redirect'])) {
 				$response = new JsonResponse($_POST['redirect']);
 			} else {
-				$response = new JsonResponse(CSR_ROOT);
+				$response = new JsonResponse($this->generateUrl('default'));
 			}
 
 			$this->getDoctrine()->getManager()->persist($remember);

--- a/lib/controller/WachtwoordController.php
+++ b/lib/controller/WachtwoordController.php
@@ -164,7 +164,7 @@ class WachtwoordController extends AbstractController {
 	private function verzendResetMail(Account $account, $token) {
 		$profiel = $account->profiel;
 
-		$url = CSR_ROOT . "/wachtwoord/reset?token=" . rawurlencode($token[0]);
+		$url = $this->generateUrl('wachtwoord_reset', ['token' => $token[0]]);
 		$bericht = $this->renderView('mail/bericht/wachtwoord_vergeten.mail.twig', [
 			'naam' => $profiel->getNaam('civitas'),
 			'mogelijkTot' => date_format_intl($token[1], DATETIME_FORMAT),

--- a/lib/defines.include.php
+++ b/lib/defines.include.php
@@ -18,9 +18,6 @@ define('DEBUG', $_SERVER['APP_DEBUG']);
 define('TIME_MEASURE', false);
 # redirect to https
 define('FORCE_HTTPS', $_ENV['FORCE_HTTPS'] == 'true');
-# urls ZONDER trailing slash
-define('CSR_ROOT', $_ENV['CSR_ROOT']);
-define('CSR_DOMAIN', parse_url(CSR_ROOT)['host']);
 # Toegestane API origins
 define('API_ORIGINS', 'http://localhost:8080,https://csrdelft.github.io,http://dev-csrdelft.nl');
 # paden MET trailing slash

--- a/lib/entity/forum/ForumPost.php
+++ b/lib/entity/forum/ForumPost.php
@@ -130,7 +130,7 @@ class ForumPost {
 	}
 
 	public function getLink($external = false) {
-		return ($external ? CSR_ROOT : '') . "/forum/reactie/" . $this->post_id . "#" . $this->post_id;
+		return ($external ? getCsrRoot() : '') . "/forum/reactie/" . $this->post_id . "#" . $this->post_id;
 	}
 
 }

--- a/lib/entity/fotoalbum/FotoAlbum.php
+++ b/lib/entity/fotoalbum/FotoAlbum.php
@@ -253,7 +253,7 @@ class FotoAlbum extends Map {
 		foreach ($this->getFotos() as $foto) {
 			$fotos[] = [
 				'url' => $foto->getResizedUrl(),
-				'fullUrl' => CSR_ROOT . $foto->getFullUrl(),
+				'fullUrl' => getCsrRoot() . $foto->getFullUrl(),
 				'thumbUrl' => $foto->getThumbUrl(),
 				'title' => '',
 				'hash' => str_replace(' ', '%20', urldecode($foto->getFullUrl())),
@@ -286,7 +286,7 @@ class FotoAlbum extends Map {
 		foreach ($this->getFotos() as $foto) {
 			$fotos[] = [
 				'url' => $foto->getResizedUrl(),
-				'fullUrl' => CSR_ROOT . $foto->getFullUrl(),
+				'fullUrl' => getCsrRoot() . $foto->getFullUrl(),
 				'thumbUrl' => $foto->getThumbUrl(),
 				'title' => '',
 				'hash' => str_replace(' ', '%20', urldecode($foto->getFullUrl())),

--- a/lib/entity/security/Account.php
+++ b/lib/entity/security/Account.php
@@ -114,7 +114,7 @@ class Account implements UserInterface {
 	}
 
 	public function getICalLink() {
-		$url = CSR_ROOT . '/agenda/ical/';
+		$url = '/agenda/ical/';
 		if (empty($this->private_token)) {
 			return $url . 'csrdelft.ics';
 		} else {
@@ -123,7 +123,7 @@ class Account implements UserInterface {
 	}
 
 	public function getRssLink() {
-		$url = CSR_ROOT . '/forum/rss/';
+		$url = '/forum/rss/';
 		if (empty($this->private_token)) {
 			return $url . 'csrdelft.xml';
 		} else {

--- a/lib/repository/ProfielRepository.php
+++ b/lib/repository/ProfielRepository.php
@@ -399,11 +399,11 @@ class ProfielRepository extends AbstractRepository {
 			if ($exemplaar->isBiebBoek()) {
 				$bkncsr['aantal']++;
 				$bkncsr['lijst'] .= "{$boek->titel} door {$boek->auteur}\n";
-				$bkncsr['lijst'] .= " - " . CSR_ROOT . "/bibliotheek/boek/{$boek->id}\n";
+				$bkncsr['lijst'] .= " - " . getCsrRoot() . "/bibliotheek/boek/{$boek->id}\n";
 			} else {
 				$bknleden['aantal']++;
 				$bknleden['lijst'] .= "{$boek->titel} door {$boek->auteur}\n";
-				$bknleden['lijst'] .= " - " . CSR_ROOT . "/bibliotheek/boek/{$boek->id}\n";
+				$bknleden['lijst'] .= " - " . getCsrRoot() . "/bibliotheek/boek/{$boek->id}\n";
 				$naam = $exemplaar->eigenaar->getNaam('volledig');
 				$bknleden['lijst'] .= " - boek is geleend van: $naam\n";
 			}

--- a/lib/service/GoogleSync.php
+++ b/lib/service/GoogleSync.php
@@ -2,6 +2,7 @@
 
 namespace CsrDelft\service;
 
+use CsrDelft\common\ContainerFacade;
 use CsrDelft\common\CsrException;
 use CsrDelft\common\CsrGebruikerException;
 use CsrDelft\entity\profiel\Profiel;
@@ -638,7 +639,7 @@ class GoogleSync {
 		}
 
 		$profielPagina = $doc->createElement('gContact:website');
-		$profielPagina->setAttribute('href', CSR_ROOT . '/profiel/' . $profiel->uid);
+		$profielPagina->setAttribute('href', getCsrRoot() . '/profiel/' . $profiel->uid);
 		$profielPagina->setAttribute('label', 'C.S.R. webstek profiel');
 		$entry->appendChild($profielPagina);
 
@@ -689,7 +690,8 @@ class GoogleSync {
 	 * @throws CsrException
 	 */
 	public static function createGoogleCLient() {
-		$redirect_uri = CSR_ROOT . '/google/callback';
+		$request = ContainerFacade::getContainer()->get('request_stack')->getCurrentRequest();
+		$redirect_uri = $request->getSchemeAndHttpHost() . '/google/callback';
 		$client = new Google_Client();
 		$client->setApplicationName('Stek');
 		$client->setClientId($_ENV['GOOGLE_CLIENT_ID']);

--- a/lib/view/bbcode/BbHelper.php
+++ b/lib/view/bbcode/BbHelper.php
@@ -3,6 +3,7 @@
 namespace CsrDelft\view\bbcode;
 
 use CsrDelft\bb\BbEnv;
+use CsrDelft\common\ContainerFacade;
 
 /**
  * Een paar helper functies voor bb.
@@ -22,7 +23,7 @@ final class BbHelper {
 	public static function lightLinkInline($env, $tag, $url, $content) {
 		if (isset($url[0]) && $url[0] === '/') {
 			// Zorg voor werkende link in e-mail
-			$url = CSR_ROOT . $url;
+			$url = ContainerFacade::getContainer()->get('url_helper')->getAbsoluteUrl($url);
 		}
 
 		return <<<HTML

--- a/lib/view/bbcode/tag/BbFoto.php
+++ b/lib/view/bbcode/tag/BbFoto.php
@@ -51,7 +51,7 @@ class BbFoto extends BbTag {
 	}
 
 	public function renderLight() {
-		return BbHelper::lightLinkThumbnail('foto', $this->foto->getAlbumUrl() . '#' . $this->foto->getResizedUrl(), CSR_ROOT . $this->foto->getThumbUrl());
+		return BbHelper::lightLinkThumbnail('foto', $this->foto->getAlbumUrl() . '#' . $this->foto->getResizedUrl(), getCsrRoot() . $this->foto->getThumbUrl());
 	}
 
 	public function render() {

--- a/lib/view/bbcode/tag/BbFotoalbum.php
+++ b/lib/view/bbcode/tag/BbFotoalbum.php
@@ -77,7 +77,7 @@ class BbFotoalbum extends BbTag {
 	public function renderLight() {
 		$album = $this->album;
 		$beschrijving = count($album->getFotos()) . ' foto\'s';
-		$cover = CSR_ROOT . $album->getCoverUrl();
+		$cover = getCsrRoot() . $album->getCoverUrl();
 		return BbHelper::lightLinkBlock('fotoalbum', $album->getUrl(), $album->dirname, $beschrijving, $cover);
 	}
 
@@ -125,7 +125,7 @@ class BbFotoalbum extends BbTag {
 				$album = $this->fotoAlbumRepository->getMostRecentFotoAlbum();
 			} else {
 				//vervang url met pad
-				$url = str_ireplace(CSR_ROOT, '', $url);
+				$url = str_ireplace(getCsrRoot(), '', $url);
 				//check fotoalbum in url
 				$url = str_ireplace('fotoalbum/', '', $url);
 				//check slash voor pad

--- a/lib/view/formulier/invoervelden/UrlField.php
+++ b/lib/view/formulier/invoervelden/UrlField.php
@@ -13,8 +13,8 @@ class UrlField extends TextField {
 
 	public function getValue() {
 		$this->value = parent::getValue();
-		if ($this->value && str_starts_with($this->value, CSR_ROOT)) {
-			$this->value = str_replace(CSR_ROOT, '', $this->value);
+		if ($this->value && str_starts_with($this->value, getCsrRoot())) {
+			$this->value = str_replace(getCsrRoot(), '', $this->value);
 		}
 		return $this->value;
 	}

--- a/lib/view/formulier/uploadvelden/BestandBehouden.php
+++ b/lib/view/formulier/uploadvelden/BestandBehouden.php
@@ -58,7 +58,7 @@ class BestandBehouden extends InputField {
 
 	public function getPreviewDiv() {
 		if ($this->model instanceof Afbeelding) {
-			return '<div id="imagePreview_' . $this->getId() . '" class="previewDiv"><img src="' . str_replace(PHOTOALBUM_PATH, CSR_ROOT . '/plaetjes/', $this->model->directory) . $this->model->filename . '" width="' . $this->model->width . '" height="' . $this->model->height . '" /></div>';
+			return '<div id="imagePreview_' . $this->getId() . '" class="previewDiv"><img src="' . str_replace(PHOTOALBUM_PATH, getCsrRoot() . '/plaetjes/', $this->model->directory) . $this->model->filename . '" width="' . $this->model->width . '" height="' . $this->model->height . '" /></div>';
 		}
 		return '';
 	}

--- a/templates/profiel/profiel.html.twig
+++ b/templates/profiel/profiel.html.twig
@@ -543,7 +543,7 @@
 				<dd>
 					{% if profiel.account.privateToken %}
 						<input title="ICal-feed" class="form-control" type="text"
-									 value="{{ profiel.account.iCalLink }}"
+									 value="{{ absolute_url(profiel.account.iCalLink) }}"
 									 onclick="this.setSelectionRange(0, this.value.length);" readonly/>
 					{% endif %}
 					&nbsp;
@@ -559,7 +559,7 @@
 					<dd>
 						{% if profiel.account.privateToken %}
 							<input title="RSS-feed" class="form-control" type="text"
-										 value="{{ profiel.account.rssLink }}"
+										 value="{{ absolute_url(profiel.account.rssLink) }}"
 										 onclick="this.setSelectionRange(0, this.value.length);" readonly/>
 						{% endif %}
 						<a id="tokenaanvragen" class="btn btn-primary"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,8 +7,6 @@ require dirname(__DIR__).'/vendor/autoload.php';
 // configuratie.include.php word niet uitgevoerd en deze constant moet bestaan
 define('MODE', 'TEST');
 
-$_ENV['CSR_ROOT'] = 'http://127.0.0.1:9080';
-
 if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
     require dirname(__DIR__).'/config/bootstrap.php';
 } elseif (method_exists(Dotenv::class, 'bootEnv')) {


### PR DESCRIPTION
Dit zorgt ervoor dat de boel een stuk flexibeler wordt, de webserver
configuratie zou er voor moeten zorgen dat de host enzo kloppen.

Maakt het minder omslachtig om te schakelen van hosts, ook handig voor situaties waar je pas op een laat moment de host weet (github codespaces).