### PR TITLE
Gebruik Rabo Smart Pay API

### DIFF
--- a/.env
+++ b/.env
@@ -62,9 +62,9 @@ LDAP_BASE_GROEPEN=ou=groepen,dc=csrdelft,dc=nl
 ###> pin_transactie_download ###
 PIN_MONITORING_EMAIL=
 PIN_URL=
-PIN_STORE=
-PIN_USERNAME=
-PIN_PASSWORD=
+PIN_CLIENT_ID=
+PIN_CERTIFICATE_PATH=
+PIN_PRIVATE_KEY_PATH=
 ###< pin_transactie_download ###
 
 ###> slack ###

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ etc/*.kdbx
 etc/bot.htpasswd
 etc/csrdelft.nl.csr
 etc/csrdelft.nl.key
+etc/**/*.pem
 htdocs/download
 htdocs/enquete
 htdocs/google*.html
@@ -34,6 +35,7 @@ sessie/*
 /tmp
 tmp/*
 /wiki
+config/keys/*
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ sessie/*
 /tmp
 tmp/*
 /wiki
-config/keys/*
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/docs/onderdelen/pinmatchtool.md
+++ b/docs/onderdelen/pinmatchtool.md
@@ -1,0 +1,47 @@
+---
+layout: default
+parent: Onderdelen
+nav_order: 1
+title: Pinmatchtool
+---
+
+# Pinmatchtool
+
+Pintransacties bij de bar worden handmatig ingevoerd in het SocCie-systeem.
+Helaas komt het regelmatig voor dat een bestelling wel ingevoerd wordt,
+maar de daadwerkelijke pintransactie niet slaagt, bijvoorbeeld door problemen
+met het pinapparaat, te weinig saldo of een verkeerde pincode. Ook wordt er
+zo nu en dan vergeten om een pinbestelling in te voeren in het SocCie-systeem
+en wordt er wel eens een typfout gemaakt.
+
+Om achteraf deze fouten te ontdekken en te herstellen is de pinmatchtool ontwikkeld.
+De pinmatchtool haalt pinbestellingen uit het SocCie-systeem op en probeert deze
+te matchen aan pintransacties van het pinapparaat.
+
+## Ophalen pintransacties
+Tot november 2022 werden pintransacties opgehaald van PayPlaza. Dit gebeurde door
+hun portaal te scrapen. Omdat dit bij veranderingen aan het portaal problemen opleverde
+en dus onbetrouwbaar was, is dit vervangen door een koppeling met de
+[Rabo Smart Pay Merchant Services API](https://developer.rabobank.nl/product/9773/api/9760#/RaboSmartPayMerchantServicesAPI_3214/overview).
+
+Voor deze koppeling is een overeenkomst met de Rabobank gesloten.
+De koppeling wordt gemaakt door middel van een x509 certificaat met public & private key.
+De public key is bekend aan de kant van de Rabobank. De private key blijft geheim aan onze kant.
+Beide keys worden bewaard op de server. De locatie hiervan wordt geconfigureerd in
+de environment variabelen `PIN_CERTIFICATE_PATH` en `PIN_PRIVATE_KEY_PATH`.
+Daarnaast is er een `PIN_URL` en `PIN_CLIENT_ID` configuratie.
+
+De koppeling is gebouwd door [Am. Nederveen](https://csrdelft.nl/profiel/1821) en is gekoppeld
+aan de organisatie C.S.R. Delft. Am. Nederveen heeft toegang tot de beheerdersconsole en kan hier als dit
+nodig is ook toegang tot geven. Het certificaat is een self-signed certificaat en is geldig tot
+16 november 2032. Mocht de pinmatchtool tegen die tijd nog steeds gebruikt worden, gaat het dus
+na deze datum stuk.
+
+## Toekomstbestendigere aanpak
+
+Als in de toekomst gekeken gaat worden naar vervanging van het pinapparaat, kan het lonen
+te switchen naar een werkwijze waarbij de pintransactie geïnitieerd wordt door het barsysteem
+en pas als bestelling aangemaakt wordt als de transactie daadwerkelijk gelukt is.
+De Rabobank heeft hier verschillende mogelijkheden voor, maar hiervoor moet het pinapparaat
+wel vervangen worden. Er zou ook gekeken kunnen worden naar het gebruik van een telefoon
+als pinapparaat.

--- a/docs/onderdelen/pinmatchtool.md
+++ b/docs/onderdelen/pinmatchtool.md
@@ -19,6 +19,7 @@ De pinmatchtool haalt pinbestellingen uit het SocCie-systeem op en probeert deze
 te matchen aan pintransacties van het pinapparaat.
 
 ## Ophalen pintransacties
+
 Tot november 2022 werden pintransacties opgehaald van PayPlaza. Dit gebeurde door
 hun portaal te scrapen. Omdat dit bij veranderingen aan het portaal problemen opleverde
 en dus onbetrouwbaar was, is dit vervangen door een koppeling met de

--- a/lib/command/PinTransactiesDownloadenCommand.php
+++ b/lib/command/PinTransactiesDownloadenCommand.php
@@ -181,9 +181,9 @@ class PinTransactiesDownloadenCommand extends Command
 		$pintransacties = $this->pinTransactieDownloader->download(
 			$from,
 			$_ENV['PIN_URL'],
-			$_ENV['PIN_STORE'],
-			$_ENV['PIN_USERNAME'],
-			$_ENV['PIN_PASSWORD']
+			$_ENV['PIN_CLIENT_ID'],
+			$_ENV['PIN_CERTIFICATE_PATH'],
+			$_ENV['PIN_PRIVATE_KEY_PATH']
 		);
 
 		// Haal pinbestellingen op.

--- a/lib/service/pin/PinDownloadException.php
+++ b/lib/service/pin/PinDownloadException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CsrDelft\service\pin;
+
+class PinDownloadException extends \Exception
+{
+
+}

--- a/lib/service/pin/PinDownloadException.php
+++ b/lib/service/pin/PinDownloadException.php
@@ -4,5 +4,4 @@ namespace CsrDelft\service\pin;
 
 class PinDownloadException extends \Exception
 {
-
 }

--- a/lib/service/pin/PinTransactieDownloader.php
+++ b/lib/service/pin/PinTransactieDownloader.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * @since 22/02/2018
  *
  * In november 2022 aangepast om de Rabo Smart Pay Merchant Services API v3.2.12 te gebruiken i.p.v. Payplaza.
- * https://developer-sandbox.rabobank.nl/product/48928/api/48925
+ * Zie documentatie in /docs/onderdelen/pinmatchtool.md.
  */
 class PinTransactieDownloader
 {

--- a/lib/service/pin/PinTransactieDownloader.php
+++ b/lib/service/pin/PinTransactieDownloader.php
@@ -120,7 +120,7 @@ class PinTransactieDownloader
 		$pinTransactie->brand = $transaction->payment_brand;
 		$pinTransactie->merchant = $transaction->merchant_name;
 		$pinTransactie->store = $transaction->shop_name;
-		$pinTransactie->terminal = $transaction->terminal_id; // TODO: checken of productie een veld teruggeeft wat lijkt op oude terminal veld.
+		$pinTransactie->terminal = $transaction->terminal_id;
 		$pinTransactie->TID = $transaction->terminal_id;
 		$pinTransactie->MID = $transaction->shop_id;
 		$pinTransactie->ref = $transaction->omnikassa_transaction_id;
@@ -130,7 +130,7 @@ class PinTransactieDownloader
 		$pinTransactie->amount =
 			$transaction->transaction_amount->currency . ' ' . $formattedAmount;
 		$pinTransactie->AUTRSP = $transaction->reference;
-		$pinTransactie->STAN = ''; // TODO: checken of productie een veld teruggeeft wat lijkt op oude STAN veld.
+		$pinTransactie->STAN = '';
 
 		return $pinTransactie;
 	}


### PR DESCRIPTION
Herschrijf pintransactiedownloader om de Rabo Smart Pay API te gebruiken i.p.v. het scrapen van Payplaza.

**Let op:** Graag niet direct mergen omdat er `.env` bij uitrol aangepast moet worden.