### PR TITLE
Voorkom sommige false-positives bij 'is het al kring'

### DIFF
--- a/lib/repository/agenda/AgendaRepository.php
+++ b/lib/repository/agenda/AgendaRepository.php
@@ -281,15 +281,26 @@ class AgendaRepository extends AbstractRepository
 	 * Zoek in de activiteiten (titel en beschrijving) van vandaag
 	 * naar het woord $woord, geef de eerste terug.
 	 * @param $woord string
-	 * @return mixed|null
+	 * @return Agendeerbaar|null
 	 */
 	public function zoekWoordAgenda($woord)
 	{
-		$beginDag = date_create_immutable()->setTime(0, 0, 0);
+		return $this->zoekRegexAgenda('/' . preg_quote($woord, '/') . '/iu');
+	}
+
+	/**
+	 * Vind de eerste activiteit van vandaag waarvan de
+	 * titel of omschrijving wordt gematcht door $patroon.
+	 * @param $patroon string
+	 * @return Agendeerbaar|null
+	 */
+	public function zoekRegexAgenda($patroon)
+	{
+		$beginDag = date_create_immutable('today');
 		foreach ($this->getItemsByDay($beginDag) as $item) {
 			if (
-				stristr($item->getTitel(), $woord) !== false ||
-				stristr($item->getBeschrijving(), $woord) !== false
+				preg_match($patroon, $item->getTitel()) ||
+				preg_match($patroon, $item->getBeschrijving())
 			) {
 				return $item;
 			}

--- a/lib/view/IsHetAlView.php
+++ b/lib/view/IsHetAlView.php
@@ -134,6 +134,12 @@ class IsHetAlView implements View
 				$session->set('studeren', $tijd);
 				break;
 
+			case 'kring':
+				// Matcht 'kring 42', 'loremipsumkring', 'kringlezing', maar niet 'kringleidersinstructie'.
+				$vandaag = $agendaRepository->zoekRegexAgenda('/kring(?: \d+|\b|lezing\b)/i');
+				$this->ja = $vandaag instanceof AgendaItem;
+				break;
+
 			default:
 				$vandaag = $agendaRepository->zoekWoordAgenda($this->model);
 				if ($vandaag instanceof AgendaItem) {

--- a/lib/view/IsHetAlView.php
+++ b/lib/view/IsHetAlView.php
@@ -136,7 +136,9 @@ class IsHetAlView implements View
 
 			case 'kring':
 				// Matcht 'kring 42', 'loremipsumkring', 'kringlezing', maar niet 'kringleidersinstructie'.
-				$vandaag = $agendaRepository->zoekRegexAgenda('/kring(?: \d+|\b|lezing\b)/i');
+				$vandaag = $agendaRepository->zoekRegexAgenda(
+					'/kring(?: \d+|\b|lezing\b)/i'
+				);
 				$this->ja = $vandaag instanceof AgendaItem;
 				break;
 


### PR DESCRIPTION
Ik schrok me laatst een hoedje toen de stek beweerde dat er kring was die dag, maar er was alleen maar een kringleidersinstructie. In plaats van `stristr` werkt regex denk ik beter, dus bij deze.

NB: Ik heb geen idee hoe ik dit zou moeten testen, maar de regex werkt: https://regex101.com/r/YskPHI/1