### PR TITLE
Workaround voor fotoalbumcrash

### DIFF
--- a/lib/controller/VoorpaginaController.php
+++ b/lib/controller/VoorpaginaController.php
@@ -117,7 +117,7 @@ class VoorpaginaController extends AbstractController
 			]);
 		}
 
-		throw $this->createNotFoundException();
+		return new Response();
 	}
 
 	/**

--- a/tests/lib/BrowserTestCase.php
+++ b/tests/lib/BrowserTestCase.php
@@ -82,11 +82,6 @@ class BrowserTestCase extends PantherTestCase
 
 	protected function setUp(): void
 	{
-		// Voorpagina crasht als er geen fotoalbum dir is.
-		if (!file_exists(PHOTOALBUM_PATH)) {
-			mkdir(PHOTOALBUM_PATH, 0777, true);
-		}
-
 		$this->client = static::createPantherClient();
 	}
 


### PR DESCRIPTION
Workaround voor #1102 zodat de voorpagina in elk geval kan laden wanneer de stek gevorkt is