### PR TITLE
Groepen Voter

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="MessDetectorOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCSFixerOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCodeSnifferOptionsConfiguration">
+    <option name="highlightLevel" value="WARNING" />
+    <option name="transferred" value="true" />
+  </component>
   <component name="PhpIncludePathManager">
     <include_path>
       <path value="$PROJECT_DIR$/vendor/csrdelft/bb" />
@@ -215,6 +225,10 @@
   <component name="PhpProjectSharedConfiguration" php_language_level="7.3">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
   </component>
+  <component name="PhpStanOptionsConfiguration">
+    <option name="config" value="$PROJECT_DIR$/phpstan.neon" />
+    <option name="transferred" value="true" />
+  </component>
   <component name="PhpUnit">
     <phpunit_settings>
       <PhpUnitSettings configuration_file_path="$PROJECT_DIR$/phpunit.xml.dist" custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" use_configuration_file="true" />
@@ -224,5 +238,9 @@
     <Psalm_settings>
       <PsalmConfiguration tool_path="$PROJECT_DIR$/vendor/bin/psalm" />
     </Psalm_settings>
+  </component>
+  <component name="PsalmOptionsConfiguration">
+    <option name="config" value="$PROJECT_DIR$/psalm.xml" />
+    <option name="transferred" value="true" />
   </component>
 </project>

--- a/docs/backend/test.md
+++ b/docs/backend/test.md
@@ -9,6 +9,8 @@ title: Tests
 
 Er zijn twee soorten tests in de stek, unit tests en functionele tests. Unit tests testen bijvoorbeeld een functie. Functionele tests testen of pagina's bezoekbaar zijn en of klikken op linkjes werkt zoals verwacht.
 
+Veel tests maken gebruik van de database, zorg hier voor dat de [Fixtures](./fixtures.md) geladen zijn.
+
 Chromedriver is te downloaden van https://chromedriver.chromium.org/
 
 ## Tests runnen

--- a/lib/common/Security/Voter/Entity/Groep/AbstractGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/AbstractGroepVoter.php
@@ -94,8 +94,9 @@ abstract class AbstractGroepVoter extends Voter
 				break;
 
 			default:
-				// Maker van groep mag alles
+				// Maker van groep mag alles, behalve bij nieuwe groepen
 				if (
+					$subject->id &&
 					$subject->maker &&
 					$subject->maker->uid === $token->getUserIdentifier()
 				) {

--- a/lib/common/Security/Voter/Entity/Groep/AbstractGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/AbstractGroepVoter.php
@@ -95,12 +95,15 @@ abstract class AbstractGroepVoter extends Voter
 
 			default:
 				// Maker van groep mag alles
-				if ($subject->maker->uid === $token->getUserIdentifier()) {
+				if (
+					$subject->maker &&
+					$subject->maker->uid === $token->getUserIdentifier()
+				) {
 					return true;
 				}
 				break;
 		}
-		return $this->magAlgemeen($attribute, $token);
+		return $this->magAlgemeen($attribute, $subject, $token);
 	}
 
 	protected function magAanmeldLimiet(
@@ -108,6 +111,9 @@ abstract class AbstractGroepVoter extends Voter
 		HeeftAanmeldLimiet $groep
 	): bool {
 		if ($attribute != self::AANMELDEN) {
+			return true;
+		}
+		if ($groep->getAanmeldLimiet() == null) {
 			return true;
 		}
 		// Controleer maximum leden
@@ -153,8 +159,11 @@ abstract class AbstractGroepVoter extends Voter
 		return true;
 	}
 
-	protected function magAlgemeen(string $attribute, TokenInterface $token): bool
-	{
+	protected function magAlgemeen(
+		string $attribute,
+		$subject,
+		TokenInterface $token
+	): bool {
 		switch ($attribute) {
 			case self::BEKIJKEN:
 				return $this->accessDecisionManager->decide($token, [

--- a/lib/common/Security/Voter/Entity/Groep/AbstractGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/AbstractGroepVoter.php
@@ -132,9 +132,9 @@ abstract class AbstractGroepVoter extends Voter
 					$nu <= $groep->getAanmeldenTot() &&
 					$nu >= $groep->getAanmeldenVanaf();
 			case self::BEWERKEN:
-				return $nu <= $groep->getBewerkenTot();
+				return !$groep->getBewerkenTot() || $nu <= $groep->getBewerkenTot();
 			case self::AFMELDEN:
-				return $nu <= $groep->getAfmeldenTot();
+				return !$groep->getAfmeldenTot() || $nu <= $groep->getAfmeldenTot();
 			default:
 				return true;
 		}

--- a/lib/common/Security/Voter/Entity/Groep/AbstractGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/AbstractGroepVoter.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\common\Security\Voter\CacheableVoterSupportsTrait;
+use CsrDelft\entity\groepen\Groep;
+use CsrDelft\entity\groepen\interfaces\HeeftAanmeldLimiet;
+use CsrDelft\entity\groepen\interfaces\HeeftAanmeldMoment;
+use CsrDelft\entity\groepen\interfaces\HeeftAanmeldRechten;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+abstract class AbstractGroepVoter extends Voter
+{
+	use CacheableVoterSupportsTrait;
+
+	const BEKIJKEN = 'groep.bekijken';
+	const AANMAKEN = 'groep.aanmaken';
+	const AANMELDEN = 'groep.aanmelden';
+	const BEWERKEN = 'groep.bewerken';
+	const AFMELDEN = 'groep.afmelden';
+	const BEHEREN = 'groep.beheren';
+	const WIJZIGEN = 'groep.wijzigen';
+	const VERWIJDEREN = 'groep.verwijderen';
+	const OPVOLGING = 'groep.opvolging';
+	/**
+	 * @var AccessDecisionManagerInterface
+	 */
+	protected $accessDecisionManager;
+
+	public function __construct(
+		AccessDecisionManagerInterface $accessDecisionManager
+	) {
+		$this->accessDecisionManager = $accessDecisionManager;
+	}
+
+	public function supportsType(string $subjectType): bool
+	{
+		return $subjectType == $this->getGroepType();
+	}
+
+	abstract protected function getGroepType(): string;
+
+	/**
+	 * @param string $attribute
+	 * @param Groep $subject
+	 * @param TokenInterface $token
+	 * @return bool
+	 */
+	protected function voteOnAttribute(
+		string $attribute,
+		$subject,
+		TokenInterface $token
+	) {
+		if (!$this->accessDecisionManager->decide($token, ['ROLE_LOGGED_IN'])) {
+			return false;
+		}
+
+		if (
+			$subject instanceof HeeftAanmeldLimiet &&
+			!$this->magAanmeldLimiet($attribute, $subject)
+		) {
+			return false;
+		}
+
+		if (
+			$subject instanceof HeeftAanmeldMoment &&
+			!$this->magAanmeldMoment($attribute, $subject)
+		) {
+			return false;
+		}
+
+		if (
+			$this instanceof HeeftAanmeldRechten &&
+			!$this->magAanmeldRechten($attribute, $subject, $token)
+		) {
+			return false;
+		}
+
+		$aangemeld = $subject->getLid($token->getUserIdentifier()) != null;
+		switch ($attribute) {
+			case self::AANMELDEN:
+				if ($aangemeld) {
+					return false;
+				}
+				break;
+
+			case self::BEWERKEN:
+			case self::AFMELDEN:
+				if (!$aangemeld) {
+					return false;
+				}
+				break;
+
+			default:
+				// Maker van groep mag alles
+				if ($subject->maker->uid === $token->getUserIdentifier()) {
+					return true;
+				}
+				break;
+		}
+		return $this->magAlgemeen($attribute, $token);
+	}
+
+	protected function magAanmeldLimiet(
+		string $attribute,
+		HeeftAanmeldLimiet $groep
+	): bool {
+		if ($attribute != self::AANMELDEN) {
+			return true;
+		}
+		// Controleer maximum leden
+		return $groep->aantalLeden() < $groep->getAanmeldLimiet();
+	}
+
+	protected function magAanmeldMoment(
+		string $attribute,
+		HeeftAanmeldMoment $groep
+	): bool {
+		$nu = date_create_immutable();
+		switch ($attribute) {
+			case self::AANMELDEN:
+				return $nu <= $groep->getAanmeldenTot() &&
+					$nu >= $groep->getAanmeldenVanaf();
+			case self::BEWERKEN:
+				return $nu <= $groep->getBewerkenTot();
+			case self::AFMELDEN:
+				return $nu <= $groep->getAfmeldenTot();
+			default:
+				return true;
+		}
+	}
+
+	protected function magAanmeldRechten(
+		string $action,
+		HeeftAanmeldRechten $groep,
+		TokenInterface $token
+	): bool {
+		$beschermdeActies = [
+			AbstractGroepVoter::BEKIJKEN,
+			AbstractGroepVoter::AANMELDEN,
+			AbstractGroepVoter::BEWERKEN,
+			AbstractGroepVoter::AFMELDEN,
+		];
+
+		if (in_array($action, $beschermdeActies)) {
+			return $this->accessDecisionManager->decide($token, [
+				$groep->getAanmeldRechten(),
+			]);
+		}
+
+		return true;
+	}
+
+	protected function magAlgemeen(string $attribute, TokenInterface $token): bool
+	{
+		switch ($attribute) {
+			case self::BEKIJKEN:
+				return $this->accessDecisionManager->decide($token, [
+					'ROLE_LEDEN_READ',
+				]);
+
+			// Voorkom dat moderators overal een normale aanmeldknop krijgen
+			case self::AANMELDEN:
+			case self::BEWERKEN:
+			case self::AFMELDEN:
+				return false;
+			default:
+				// Moderators mogen alles
+				return $this->accessDecisionManager->decide($token, ['ROLE_LEDEN_MOD']);
+		}
+	}
+}

--- a/lib/common/Security/Voter/Entity/Groep/AbstractGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/AbstractGroepVoter.php
@@ -72,7 +72,7 @@ abstract class AbstractGroepVoter extends Voter
 		}
 
 		if (
-			$this instanceof HeeftAanmeldRechten &&
+			$subject instanceof HeeftAanmeldRechten &&
 			!$this->magAanmeldRechten($attribute, $subject, $token)
 		) {
 			return false;
@@ -128,7 +128,8 @@ abstract class AbstractGroepVoter extends Voter
 		$nu = date_create_immutable();
 		switch ($attribute) {
 			case self::AANMELDEN:
-				return $nu <= $groep->getAanmeldenTot() &&
+				return $groep->getAanmeldenTot() &&
+					$nu <= $groep->getAanmeldenTot() &&
 					$nu >= $groep->getAanmeldenVanaf();
 			case self::BEWERKEN:
 				return $nu <= $groep->getBewerkenTot();
@@ -144,6 +145,9 @@ abstract class AbstractGroepVoter extends Voter
 		HeeftAanmeldRechten $groep,
 		TokenInterface $token
 	): bool {
+		if (!$groep->getAanmeldRechten()) {
+			return true;
+		}
 		$beschermdeActies = [
 			AbstractGroepVoter::BEKIJKEN,
 			AbstractGroepVoter::AANMELDEN,

--- a/lib/common/Security/Voter/Entity/Groep/ActiviteitGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/ActiviteitGroepVoter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\entity\groepen\Activiteit;
+use CsrDelft\entity\groepen\enum\ActiviteitSoort;
+use CsrDelft\entity\security\enum\AccessAction;
+use CsrDelft\service\security\LoginService;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class ActiviteitGroepVoter extends AbstractGroepVoter
+{
+	protected function getGroepType(): string
+	{
+		return Activiteit::class;
+	}
+
+	protected function magAlgemeen(string $attribute, TokenInterface $token): bool
+	{
+		switch ($attribute) {
+			case self::AANMAKEN:
+			case self::AANMELDEN:
+			case self::BEWERKEN:
+			case self::AFMELDEN:
+				return true;
+			default:
+				return parent::magAlgemeen($attribute, $token);
+		}
+	}
+}

--- a/lib/common/Security/Voter/Entity/Groep/ActiviteitGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/ActiviteitGroepVoter.php
@@ -15,8 +15,48 @@ class ActiviteitGroepVoter extends AbstractGroepVoter
 		return Activiteit::class;
 	}
 
-	protected function magAlgemeen(string $attribute, TokenInterface $token): bool
-	{
+	/**
+	 * @param string $attribute
+	 * @param Activiteit $subject
+	 * @param TokenInterface $token
+	 * @return bool
+	 */
+	protected function magAlgemeen(
+		string $attribute,
+		$subject,
+		TokenInterface $token
+	): bool {
+		if ($subject->getSoort() instanceof ActiviteitSoort) {
+			switch ($subject->getSoort()) {
+				case ActiviteitSoort::OWee():
+					if (
+						$this->accessDecisionManager->decide($token, ['commissie:OWeeCie'])
+					) {
+						return true;
+					}
+					break;
+
+				case ActiviteitSoort::Dies():
+					if (
+						$this->accessDecisionManager->decide($token, ['commissie:DiesCie'])
+					) {
+						return true;
+					}
+					break;
+
+				case ActiviteitSoort::Lustrum():
+					if (
+						$this->accessDecisionManager->decide($token, [
+							'commissie:LustrumCie',
+						])
+					) {
+						return true;
+					}
+					break;
+				default:
+					break;
+			}
+		}
 		switch ($attribute) {
 			case self::AANMAKEN:
 			case self::AANMELDEN:
@@ -24,7 +64,7 @@ class ActiviteitGroepVoter extends AbstractGroepVoter
 			case self::AFMELDEN:
 				return true;
 			default:
-				return parent::magAlgemeen($attribute, $token);
+				return parent::magAlgemeen($attribute, $subject, $token);
 		}
 	}
 }

--- a/lib/common/Security/Voter/Entity/Groep/BestuurGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/BestuurGroepVoter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\entity\groepen\Bestuur;
+
+class BestuurGroepVoter extends AbstractGroepVoter
+{
+	protected function getGroepType(): string
+	{
+		return Bestuur::class;
+	}
+}

--- a/lib/common/Security/Voter/Entity/Groep/CommissieGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/CommissieGroepVoter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\entity\groepen\Commissie;
+
+class CommissieGroepVoter extends AbstractGroepVoter
+{
+	protected function getGroepType(): string
+	{
+		return Commissie::class;
+	}
+}

--- a/lib/common/Security/Voter/Entity/Groep/CommissieGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/CommissieGroepVoter.php
@@ -3,11 +3,31 @@
 namespace CsrDelft\common\Security\Voter\Entity\Groep;
 
 use CsrDelft\entity\groepen\Commissie;
+use CsrDelft\entity\groepen\enum\CommissieSoort;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class CommissieGroepVoter extends AbstractGroepVoter
 {
 	protected function getGroepType(): string
 	{
 		return Commissie::class;
+	}
+
+	/**
+	 * @param string $attribute
+	 * @param Commissie $subject
+	 * @param TokenInterface $token
+	 * @return bool|void
+	 */
+	protected function magAlgemeen(
+		string $attribute,
+		$subject,
+		TokenInterface $token
+	): bool {
+		if ($subject->getSoort() == CommissieSoort::SjaarCie()) {
+			return true;
+		}
+
+		return parent::magAlgemeen($attribute, $subject, $token);
 	}
 }

--- a/lib/common/Security/Voter/Entity/Groep/CommissieGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/CommissieGroepVoter.php
@@ -17,14 +17,17 @@ class CommissieGroepVoter extends AbstractGroepVoter
 	 * @param string $attribute
 	 * @param Commissie $subject
 	 * @param TokenInterface $token
-	 * @return bool|void
+	 * @return bool
 	 */
 	protected function magAlgemeen(
 		string $attribute,
 		$subject,
 		TokenInterface $token
 	): bool {
-		if ($subject->getSoort() == CommissieSoort::SjaarCie()) {
+		if (
+			$subject->getSoort() === CommissieSoort::SjaarCie() &&
+			$this->accessDecisionManager->decide($token, ['commissie:NovCie'])
+		) {
 			return true;
 		}
 

--- a/lib/common/Security/Voter/Entity/Groep/KetzerGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/KetzerGroepVoter.php
@@ -13,8 +13,11 @@ class KetzerGroepVoter extends AbstractGroepVoter
 		return Ketzer::class;
 	}
 
-	protected function magAlgemeen(string $attribute, TokenInterface $token): bool
-	{
+	protected function magAlgemeen(
+		string $attribute,
+		$subject,
+		TokenInterface $token
+	): bool {
 		switch ($attribute) {
 			case self::AANMAKEN:
 			case self::AANMELDEN:
@@ -22,7 +25,7 @@ class KetzerGroepVoter extends AbstractGroepVoter
 			case self::AFMELDEN:
 				return true;
 			default:
-				return parent::magAlgemeen($attribute, $token);
+				return parent::magAlgemeen($attribute, $subject, $token);
 		}
 	}
 }

--- a/lib/common/Security/Voter/Entity/Groep/KetzerGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/KetzerGroepVoter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\entity\groepen\Ketzer;
+use CsrDelft\entity\security\enum\AccessAction;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class KetzerGroepVoter extends AbstractGroepVoter
+{
+	protected function getGroepType(): string
+	{
+		return Ketzer::class;
+	}
+
+	protected function magAlgemeen(string $attribute, TokenInterface $token): bool
+	{
+		switch ($attribute) {
+			case self::AANMAKEN:
+			case self::AANMELDEN:
+			case self::BEWERKEN:
+			case self::AFMELDEN:
+				return true;
+			default:
+				return parent::magAlgemeen($attribute, $token);
+		}
+	}
+}

--- a/lib/common/Security/Voter/Entity/Groep/KringGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/KringGroepVoter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\entity\groepen\Kring;
+
+class KringGroepVoter extends AbstractGroepVoter
+{
+	protected function getGroepType(): string
+	{
+		return Kring::class;
+	}
+}

--- a/lib/common/Security/Voter/Entity/Groep/LichtingGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/LichtingGroepVoter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\entity\groepen\Lichting;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class LichtingGroepVoter extends AbstractGroepVoter
+{
+	protected function getGroepType(): string
+	{
+		return Lichting::class;
+	}
+
+	protected function voteOnAttribute(
+		string $attribute,
+		$subject,
+		TokenInterface $token
+	) {
+		return $attribute == AbstractGroepVoter::BEKIJKEN;
+	}
+}

--- a/lib/common/Security/Voter/Entity/Groep/OnderverenigingGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/OnderverenigingGroepVoter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\entity\groepen\Ondervereniging;
+
+class OnderverenigingGroepVoter extends AbstractGroepVoter
+{
+	protected function getGroepType(): string
+	{
+		return Ondervereniging::class;
+	}
+}

--- a/lib/common/Security/Voter/Entity/Groep/RechtenGroepGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/RechtenGroepGroepVoter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\entity\groepen\RechtenGroep;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class RechtenGroepGroepVoter extends AbstractGroepVoter
+{
+	protected function getGroepType(): string
+	{
+		return RechtenGroep::class;
+	}
+
+	protected function magAlgemeen(string $attribute, TokenInterface $token): bool
+	{
+		switch ($attribute) {
+			case self::AANMAKEN:
+			case self::AANMELDEN:
+			case self::BEWERKEN:
+			case self::AFMELDEN:
+				return true;
+			default:
+				return parent::magAlgemeen($attribute, $token);
+		}
+	}
+}

--- a/lib/common/Security/Voter/Entity/Groep/RechtenGroepGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/RechtenGroepGroepVoter.php
@@ -12,8 +12,11 @@ class RechtenGroepGroepVoter extends AbstractGroepVoter
 		return RechtenGroep::class;
 	}
 
-	protected function magAlgemeen(string $attribute, TokenInterface $token): bool
-	{
+	protected function magAlgemeen(
+		string $attribute,
+		$subject,
+		TokenInterface $token
+	): bool {
 		switch ($attribute) {
 			case self::AANMAKEN:
 			case self::AANMELDEN:
@@ -21,7 +24,7 @@ class RechtenGroepGroepVoter extends AbstractGroepVoter
 			case self::AFMELDEN:
 				return true;
 			default:
-				return parent::magAlgemeen($attribute, $token);
+				return parent::magAlgemeen($attribute, $subject, $token);
 		}
 	}
 }

--- a/lib/common/Security/Voter/Entity/Groep/VerticaleGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/VerticaleGroepVoter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\entity\groepen\Verticale;
+use CsrDelft\entity\security\enum\AccessAction;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class VerticaleGroepVoter extends AbstractGroepVoter
+{
+	protected function getGroepType(): string
+	{
+		return Verticale::class;
+	}
+
+	protected function voteOnAttribute(
+		string $attribute,
+		$subject,
+		TokenInterface $token
+	) {
+		switch ($attribute) {
+			case self::BEKIJKEN:
+			case self::AANMAKEN:
+			case self::WIJZIGEN:
+				return parent::voteOnAttribute($attribute, $subject, $token);
+			default:
+				return false;
+		}
+	}
+}

--- a/lib/common/Security/Voter/Entity/Groep/WerkgroepGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/WerkgroepGroepVoter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\entity\groepen\Werkgroep;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class WerkgroepGroepVoter extends AbstractGroepVoter
+{
+	protected function getGroepType(): string
+	{
+		return Werkgroep::class;
+	}
+
+	protected function magAlgemeen(string $attribute, TokenInterface $token): bool
+	{
+		if (
+			$attribute == self::AANMAKEN &&
+			!$this->accessDecisionManager->decide($token, ['ROLE_LEDEN_MOD'])
+		) {
+			return false;
+		}
+
+		return parent::magAlgemeen($attribute, $token);
+	}
+}

--- a/lib/common/Security/Voter/Entity/Groep/WerkgroepGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/WerkgroepGroepVoter.php
@@ -12,8 +12,11 @@ class WerkgroepGroepVoter extends AbstractGroepVoter
 		return Werkgroep::class;
 	}
 
-	protected function magAlgemeen(string $attribute, TokenInterface $token): bool
-	{
+	protected function magAlgemeen(
+		string $attribute,
+		$subject,
+		TokenInterface $token
+	): bool {
 		if (
 			$attribute == self::AANMAKEN &&
 			!$this->accessDecisionManager->decide($token, ['ROLE_LEDEN_MOD'])
@@ -21,6 +24,6 @@ class WerkgroepGroepVoter extends AbstractGroepVoter
 			return false;
 		}
 
-		return parent::magAlgemeen($attribute, $token);
+		return parent::magAlgemeen($attribute, $subject, $token);
 	}
 }

--- a/lib/common/Security/Voter/Entity/Groep/WoonoordGroepVoter.php
+++ b/lib/common/Security/Voter/Entity/Groep/WoonoordGroepVoter.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity\Groep;
+
+use CsrDelft\entity\groepen\Woonoord;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class WoonoordGroepVoter extends AbstractGroepVoter
+{
+	protected function getGroepType(): string
+	{
+		return Woonoord::class;
+	}
+
+	protected function voteOnAttribute(
+		string $attribute,
+		$subject,
+		TokenInterface $token
+	) {
+		switch ($attribute) {
+			case self::BEHEREN:
+			case self::WIJZIGEN:
+				// Huidige bewoners mogen beheren
+				if (
+					$this->accessDecisionManager->decide($token, [
+						'woonoord:' . $subject->familie,
+					])
+				) {
+					// HuisStatus wijzigen wordt geblokkeerd in GroepForm->validate()
+					return true;
+				}
+				break;
+			default:
+				break;
+		}
+		return parent::voteOnAttribute($attribute, $subject, $token);
+	}
+}

--- a/lib/common/Security/Voter/Entity/GroepLidVoter.php
+++ b/lib/common/Security/Voter/Entity/GroepLidVoter.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace CsrDelft\common\Security\Voter\Entity;
+
+use CsrDelft\common\Security\Voter\CacheableVoterSupportsTrait;
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
+use CsrDelft\entity\groepen\GroepLid;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class GroepLidVoter extends Voter
+{
+	use CacheableVoterSupportsTrait;
+
+	/**
+	 * @var AccessDecisionManagerInterface
+	 */
+	private $accessDecisionManager;
+
+	public function __construct(
+		AccessDecisionManagerInterface $accessDecisionManager
+	) {
+		$this->accessDecisionManager = $accessDecisionManager;
+	}
+
+	public function supportsType(string $subjectType): bool
+	{
+		// Ook subclasses van Groep
+		return $subjectType == GroepLid::class;
+	}
+
+	/**
+	 * @param string $attribute
+	 * @param GroepLid $subject
+	 * @param TokenInterface $token
+	 * @return bool|void
+	 */
+	protected function voteOnAttribute(
+		string $attribute,
+		$subject,
+		TokenInterface $token
+	) {
+		if (
+			!$this->accessDecisionManager->decide(
+				$token,
+				[$attribute],
+				$subject->groep
+			)
+		) {
+			return false;
+		}
+		switch ($attribute) {
+			case AbstractGroepVoter::AFMELDEN:
+			case AbstractGroepVoter::BEWERKEN:
+				return $this->magLid($token, $subject);
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * @param string $groepAttribute
+	 * @param TokenInterface $token
+	 * @param GroepLid $subject
+	 * @return bool
+	 */
+	private function magLid(TokenInterface $token, GroepLid $subject): bool
+	{
+		if ($token->getUserIdentifier() == $subject->uid) {
+			return true;
+		}
+
+		// LEDEN_MOD mag sowieso
+		return $this->accessDecisionManager->decide($token, ['ROLE_LEDEN_MOD']);
+	}
+}

--- a/lib/controller/api/ApiActiviteitenController.php
+++ b/lib/controller/api/ApiActiviteitenController.php
@@ -3,6 +3,8 @@
 namespace CsrDelft\controller\api;
 
 use CsrDelft\common\Annotation\Auth;
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
+use CsrDelft\common\Security\Voter\Entity\Groep\ActiviteitGroepVoter;
 use CsrDelft\controller\AbstractController;
 use CsrDelft\entity\security\enum\AccessAction;
 use CsrDelft\repository\ChangeLogRepository;
@@ -41,11 +43,11 @@ class ApiActiviteitenController extends AbstractController
 	{
 		$activiteit = $this->activiteitenRepository->get($id);
 
-		if (!$activiteit || !$activiteit->mag(AccessAction::Bekijken())) {
-			throw new NotFoundHttpException('Activiteit bestaat niet');
+		if (!$this->isGranted(ActiviteitGroepVoter::BEKIJKEN, $activiteit)) {
+			throw $this->createNotFoundException('Activiteit bestaat niet');
 		}
 
-		if (!$activiteit->mag(AccessAction::Aanmelden())) {
+		if (!$this->isGranted(ActiviteitGroepVoter::AANMELDEN, $activiteit)) {
 			throw $this->createAccessDeniedException('Aanmelden niet mogelijk');
 		}
 
@@ -70,11 +72,11 @@ class ApiActiviteitenController extends AbstractController
 	{
 		$activiteit = $this->activiteitenRepository->get($id);
 
-		if (!$activiteit || !$activiteit->mag(AccessAction::Bekijken())) {
+		if (!$this->isGranted(ActiviteitGroepVoter::BEKIJKEN, $activiteit)) {
 			throw new NotFoundHttpException('Activiteit bestaat niet');
 		}
 
-		if (!$activiteit->mag(AccessAction::Afmelden())) {
+		if (!$this->isGranted(ActiviteitGroepVoter::AFMELDEN, $activiteit)) {
 			throw $this->createAccessDeniedException('Afmelden niet mogelijk');
 		}
 

--- a/lib/controller/api/ApiAgendaController.php
+++ b/lib/controller/api/ApiAgendaController.php
@@ -3,6 +3,7 @@
 namespace CsrDelft\controller\api;
 
 use CsrDelft\common\Annotation\Auth;
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
 use CsrDelft\controller\AbstractController;
 use CsrDelft\entity\agenda\AgendaItem;
 use CsrDelft\entity\groepen\Activiteit;
@@ -96,7 +97,7 @@ class ApiAgendaController extends AbstractController
 					ActiviteitSoort::Extern(),
 					ActiviteitSoort::OWee(),
 					ActiviteitSoort::IFES(),
-				]) or $activiteit->mag(AccessAction::Bekijken())
+				]) or $this->isGranted(AbstractGroepVoter::BEKIJKEN, $activiteit)
 			) {
 				$activiteitenFiltered[] = $activiteit;
 			}

--- a/lib/controller/groepen/AbstractGroepenController.php
+++ b/lib/controller/groepen/AbstractGroepenController.php
@@ -467,7 +467,8 @@ abstract class AbstractGroepenController extends AbstractController implements
 		$form = new GroepForm(
 			$groep,
 			$this->repository->getUrl() . '/aanmaken',
-			AccessAction::Aanmaken()
+			$this->isGranted(AbstractGroepVoter::AANMAKEN, $groep),
+			false
 		);
 		if ($request->getMethod() == 'GET') {
 			$table = new GroepenBeheerTable($this->repository);
@@ -541,7 +542,8 @@ abstract class AbstractGroepenController extends AbstractController implements
 		$form = new GroepForm(
 			$groep,
 			$groep->getUrl() . '/wijzigen',
-			AccessAction::Wijzigen()
+			$this->isGranted(AbstractGroepVoter::WIJZIGEN, $groep),
+			true
 		);
 		if ($request->getMethod() == 'GET') {
 			$this->beheren($request);

--- a/lib/controller/groepen/AbstractGroepenController.php
+++ b/lib/controller/groepen/AbstractGroepenController.php
@@ -4,6 +4,8 @@ namespace CsrDelft\controller\groepen;
 
 use CsrDelft\common\CsrGebruikerException;
 use CsrDelft\common\FlashType;
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
+use CsrDelft\common\Security\Voter\Entity\GroepLidVoter;
 use CsrDelft\common\Util\ArrayUtil;
 use CsrDelft\common\Util\ReflectionUtil;
 use CsrDelft\Component\DataTable\RemoveDataTableEntry;
@@ -279,7 +281,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 			throw $this->createNotFoundException();
 		}
 
-		if (!$groep->mag(AccessAction::Bekijken())) {
+		if (!$this->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 
@@ -297,7 +299,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 	public function omschrijving($id)
 	{
 		$groep = $this->repository->get($id);
-		if (!$groep->mag(AccessAction::Bekijken())) {
+		if (!$this->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 		return $this->render('groep/omschrijving.html.twig', ['groep' => $groep]);
@@ -306,7 +308,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 	public function pasfotos($id)
 	{
 		$groep = $this->repository->get($id);
-		if (!$groep->mag(AccessAction::Bekijken())) {
+		if (!$this->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 		return new GroepPasfotosView($this->container->get('twig'), $groep);
@@ -315,7 +317,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 	public function lijst($id)
 	{
 		$groep = $this->repository->get($id);
-		if (!$groep->mag(AccessAction::Bekijken())) {
+		if (!$this->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 		return new GroepLijstView($this->container->get('twig'), $groep);
@@ -324,7 +326,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 	public function stats($id)
 	{
 		$groep = $this->repository->get($id);
-		if (!$groep->mag(AccessAction::Bekijken())) {
+		if (!$this->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 
@@ -340,7 +342,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 	public function emails($id)
 	{
 		$groep = $this->repository->get($id);
-		if (!$groep->mag(AccessAction::Bekijken())) {
+		if (!$this->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 		return new GroepEmailsView($this->container->get('twig'), $groep);
@@ -349,7 +351,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 	public function eetwens($id)
 	{
 		$groep = $this->repository->get($id);
-		if (!$groep->mag(AccessAction::Bekijken())) {
+		if (!$this->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 		return new GroepEetwensView($this->container->get('twig'), $groep);
@@ -532,7 +534,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 			throw $this->createNotFoundException();
 		}
 
-		if (!$groep->mag(AccessAction::Wijzigen())) {
+		if (!$this->isGranted(AbstractGroepVoter::WIJZIGEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 		// checks rechten wijzigen
@@ -571,7 +573,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 		$groep = $this->repository->retrieveByUUID($id);
 		if (
 			$groep &&
-			$groep->mag(AccessAction::Verwijderen()) &&
+			$this->isGranted(AbstractGroepVoter::VERWIJDEREN, $groep) &&
 			count($groep->getLeden()) === 0
 		) {
 			$old = $serializer->serialize($groep, 'json', [
@@ -603,7 +605,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 		if ($form->validate()) {
 			$response = [];
 			$groep = $this->repository->retrieveByUUID($id);
-			if ($groep && $groep->mag(AccessAction::Opvolging())) {
+			if ($this->isGranted(AbstractGroepVoter::OPVOLGING, $groep)) {
 				$this->changeLogRepository->log(
 					$groep,
 					'familie',
@@ -644,7 +646,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 			$converteer = get_class($model) !== get_class($this->repository);
 			$response = [];
 			$groep = $this->repository->retrieveByUUID($id);
-			if ($groep && $groep->mag(AccessAction::Wijzigen())) {
+			if ($this->isGranted(AbstractGroepVoter::WIJZIGEN, $groep)) {
 				if ($converteer) {
 					$this->changeLogRepository->log(
 						$groep,
@@ -696,7 +698,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 			$groep &&
 			$groep instanceof HeeftAanmeldMoment &&
 			date_create_immutable() <= $groep->getAanmeldenTot() &&
-			$groep->mag(AccessAction::Wijzigen())
+			$this->isGranted(AbstractGroepVoter::WIJZIGEN, $groep)
 		) {
 			$this->changeLogRepository->log(
 				$groep,
@@ -714,7 +716,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 	public function voorbeeld($id)
 	{
 		$groep = $this->repository->retrieveByUUID($id);
-		if (!$groep || !$groep->mag(AccessAction::Bekijken())) {
+		if (!$this->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 		return new GroepPreviewForm($this->container->get('twig'), $groep);
@@ -730,7 +732,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 		// data request
 		if ($request->getMethod() == 'POST') {
 			$groep = $this->repository->get($id);
-			if (!$groep->mag(AccessAction::Bekijken())) {
+			if (!$this->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 				throw $this->createAccessDeniedException();
 			}
 			$data = $this->changeLogRepository->findBy([
@@ -741,7 +743,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 		// popup request
 		else {
 			$groep = $this->repository->retrieveByUUID($id);
-			if (!$groep || !$groep->mag(AccessAction::Bekijken())) {
+			if (!$this->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 				throw $this->createAccessDeniedException('Kan logboek niet vinden');
 			}
 			return new GroepLogboekForm($groep);
@@ -751,13 +753,16 @@ abstract class AbstractGroepenController extends AbstractController implements
 	public function leden(Request $request, $id)
 	{
 		$groep = $this->repository->get($id);
-		if (!$groep->mag(AccessAction::Bekijken())) {
+		if (!$this->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 		if ($request->getMethod() == 'POST') {
 			return $this->tableData($groep->getLeden());
 		} else {
-			return new GroepLedenTable($groep);
+			return new GroepLedenTable(
+				$groep,
+				$this->isGranted(AbstractGroepVoter::BEHEREN, $groep)
+			);
 		}
 	}
 
@@ -776,7 +781,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 			throw new BadRequestHttpException('Groep is niet van versie 2.');
 		}
 
-		if (!$groep->mag(AccessAction::Aanmelden())) {
+		if (!$this->isGranted(AbstractGroepVoter::AANMELDEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 		$lid = $this->groepLidRepository->nieuw($groep, $uid);
@@ -809,7 +814,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 			throw new BadRequestHttpException('Groep is niet van versie 1.');
 		}
 
-		if (!$groep->mag(AccessAction::Aanmelden())) {
+		if (!$this->isGranted(AbstractGroepVoter::AANMELDEN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 
@@ -832,7 +837,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 	{
 		$groep = $this->repository->get($id);
 
-		if (!$groep->mag(AccessAction::Beheren())) {
+		if (!$this->isGranted(AbstractGroepVoter::BEHEREN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 
@@ -868,7 +873,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 		$groep = $this->repository->get($id);
 
 		$lid = $groep->getLid($uid);
-		if (!$groep->magLid(AccessAction::Bewerken(), $lid)) {
+		if (!$this->isGranted(AbstractGroepVoter::BEWERKEN, $lid)) {
 			throw $this->createAccessDeniedException();
 		}
 		$form = new GroepBewerkenForm($lid, $groep);
@@ -896,7 +901,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 			throw $this->createAccessDeniedException();
 		}
 
-		if (!$groep->magLid(AccessAction::Beheren(), $lid)) {
+		if (!$this->isGranted(AbstractGroepVoter::BEHEREN, $lid)) {
 			throw $this->createAccessDeniedException();
 		}
 
@@ -923,7 +928,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 	{
 		$groep = $this->repository->get($id);
 
-		if ($uid && !$groep->mag(AccessAction::Beheren())) {
+		if ($uid && !$this->isGranted(AbstractGroepVoter::BEHEREN, $groep)) {
 			throw $this->createAccessDeniedException(
 				'Mag niet afmelden via context menu'
 			);
@@ -941,8 +946,8 @@ abstract class AbstractGroepenController extends AbstractController implements
 		}
 
 		if (
-			!$groep->magLid(AccessAction::Afmelden(), $lid) &&
-			!$groep->magLid(AccessAction::Beheren(), $lid)
+			!$this->isGranted(AbstractGroepVoter::AFMELDEN, $lid) &&
+			!$this->isGranted(AbstractGroepVoter::BEHEREN, $lid)
 		) {
 			throw $this->createAccessDeniedException();
 		}
@@ -958,7 +963,7 @@ abstract class AbstractGroepenController extends AbstractController implements
 	{
 		$groep = $this->repository->get($id);
 
-		if (!$groep->mag(AccessAction::Beheren())) {
+		if (!$this->isGranted(AbstractGroepVoter::BEHEREN, $groep)) {
 			throw $this->createAccessDeniedException();
 		}
 
@@ -989,9 +994,9 @@ abstract class AbstractGroepenController extends AbstractController implements
 
 		// A::Beheren voor afmelden via context-menu
 		if (
-			!$groep->mag(AccessAction::Afmelden()) &&
-			!$groep->mag(AccessAction::Beheren()) &&
-			!$otGroep->mag(AccessAction::Aanmelden())
+			!$this->isGranted(AbstractGroepVoter::AFMELDEN, $groep) &&
+			!$this->isGranted(AbstractGroepVoter::BEHEREN, $groep) &&
+			!$this->isGranted(AbstractGroepVoter::AANMAKEN, $otGroep)
 		) {
 			throw new CsrGebruikerException();
 		}

--- a/lib/controller/groepen/AbstractGroepenController.php
+++ b/lib/controller/groepen/AbstractGroepenController.php
@@ -417,6 +417,10 @@ abstract class AbstractGroepenController extends AbstractController implements
 		if (!$id) {
 			$vorige = null;
 			$groep = $this->repository->nieuw($soort);
+			// Rechtencheck op lege groep
+			if (!$this->isGranted(AbstractGroepVoter::AANMAKEN, $groep)) {
+				throw $this->createAccessDeniedException();
+			}
 			$profiel = $this->getProfiel();
 			if ($groep instanceof Activiteit && empty($groep->rechtenAanmelden)) {
 				switch ($groep->activiteitSoort) {
@@ -451,6 +455,10 @@ abstract class AbstractGroepenController extends AbstractController implements
 				$soort = $vorige->getSoort();
 			}
 			$groep = $this->repository->nieuw($soort);
+			// Rechtencheck op lege groep
+			if (!$this->isGranted(AbstractGroepVoter::AANMAKEN, $groep)) {
+				throw $this->createAccessDeniedException();
+			}
 			$groep->naam = $vorige->naam;
 			$groep->familie = $vorige->familie;
 			$groep->samenvatting = $vorige->samenvatting;

--- a/lib/entity/groepen/Activiteit.php
+++ b/lib/entity/groepen/Activiteit.php
@@ -2,7 +2,6 @@
 
 namespace CsrDelft\entity\groepen;
 
-use CsrDelft\common\Enum;
 use CsrDelft\common\Util\InstellingUtil;
 use CsrDelft\entity\agenda\Agendeerbaar;
 use CsrDelft\entity\groepen\enum\ActiviteitSoort;
@@ -11,7 +10,6 @@ use CsrDelft\entity\groepen\interfaces\HeeftAanmeldMoment;
 use CsrDelft\entity\groepen\interfaces\HeeftAanmeldRechten;
 use CsrDelft\entity\groepen\interfaces\HeeftMoment;
 use CsrDelft\entity\groepen\interfaces\HeeftSoort;
-use CsrDelft\entity\security\enum\AccessAction;
 use CsrDelft\service\security\LoginService;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation as Serializer;
@@ -57,46 +55,6 @@ class Activiteit extends Groep implements
 	 * @Serializer\Groups("datatable")
 	 */
 	public $inAgenda;
-
-	/**
-	 * Rechten voor de gehele klasse of soort groep?
-	 *
-	 * @param AccessAction $action
-	 * @param Enum $soort
-	 * @return boolean
-	 */
-	public static function magAlgemeen($action, $soort = null)
-	{
-		if ($soort && $soort instanceof ActiviteitSoort) {
-			switch ($soort) {
-				case ActiviteitSoort::OWee():
-					if (LoginService::mag('commissie:OWeeCie')) {
-						return true;
-					}
-					break;
-
-				case ActiviteitSoort::Dies():
-					if (LoginService::mag('commissie:DiesCie')) {
-						return true;
-					}
-					break;
-
-				case ActiviteitSoort::Lustrum():
-					if (LoginService::mag('commissie:LustrumCie')) {
-						return true;
-					}
-					break;
-			}
-		}
-		switch ($action) {
-			case AccessAction::Aanmaken():
-			case AccessAction::Aanmelden():
-			case AccessAction::Bewerken():
-			case AccessAction::Afmelden():
-				return true;
-		}
-		return parent::magAlgemeen($action, $soort);
-	}
 
 	public function getUUID()
 	{

--- a/lib/entity/groepen/Commissie.php
+++ b/lib/entity/groepen/Commissie.php
@@ -2,12 +2,9 @@
 
 namespace CsrDelft\entity\groepen;
 
-use CsrDelft\common\Enum;
 use CsrDelft\entity\groepen\enum\CommissieSoort;
 use CsrDelft\entity\groepen\interfaces\HeeftMoment;
 use CsrDelft\entity\groepen\interfaces\HeeftSoort;
-use CsrDelft\entity\security\enum\AccessAction;
-use CsrDelft\service\security\LoginService;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation as Serializer;
 
@@ -34,25 +31,6 @@ class Commissie extends Groep implements HeeftSoort, HeeftMoment
 	public function getUrl()
 	{
 		return '/groepen/commissies/' . $this->id;
-	}
-
-	/**
-	 * Rechten voor de gehele klasse of soort groep?
-	 *
-	 * @param AccessAction $action
-	 * @param Enum $soort
-	 * @return boolean
-	 */
-	public static function magAlgemeen($action, $soort = null)
-	{
-		switch ($soort) {
-			case CommissieSoort::SjaarCie():
-				if (LoginService::mag('commissie:NovCie')) {
-					return true;
-				}
-				break;
-		}
-		return parent::magAlgemeen($action, $soort);
 	}
 
 	public function getSoort()

--- a/lib/entity/groepen/GroepAanmeldLimiet.php
+++ b/lib/entity/groepen/GroepAanmeldLimiet.php
@@ -2,7 +2,6 @@
 
 namespace CsrDelft\entity\groepen;
 
-use CsrDelft\entity\security\enum\AccessAction;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation as Serializer;
 
@@ -15,18 +14,4 @@ trait GroepAanmeldLimiet
 	 * @Serializer\Groups("datatable")
 	 */
 	public $aanmeldLimiet;
-
-	public function magAanmeldLimiet(AccessAction $action)
-	{
-		// Controleer maximum leden
-		if (
-			AccessAction::isAanmelden($action) &&
-			isset($this->aanmeldLimiet) &&
-			$this->aantalLeden() >= $this->aanmeldLimiet
-		) {
-			return false;
-		} else {
-			return true;
-		}
-	}
 }

--- a/lib/entity/groepen/GroepAanmeldMoment.php
+++ b/lib/entity/groepen/GroepAanmeldMoment.php
@@ -2,7 +2,6 @@
 
 namespace CsrDelft\entity\groepen;
 
-use CsrDelft\entity\security\enum\AccessAction;
 use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation as Serializer;
@@ -37,31 +36,6 @@ trait GroepAanmeldMoment
 	 * @Serializer\Groups("datatable")
 	 */
 	public $afmeldenTot;
-
-	/**
-	 * @param AccessAction $action
-	 * @return boolean
-	 */
-	public function magAanmeldMoment($action)
-	{
-		$nu = date_create_immutable();
-
-		if (
-			AccessAction::isAanmelden($action) &&
-			($nu > $this->aanmeldenTot || $nu < $this->aanmeldenVanaf)
-		) {
-			// Controleer aanmeldperiode
-			return false;
-		} elseif (AccessAction::isBewerken($action) && $nu > $this->bewerkenTot) {
-			// Controleer bewerkperiode
-			return false;
-		} elseif (AccessAction::isAfmelden($action) && $nu > $this->afmeldenTot) {
-			// Controleer afmeldperiode
-			return false;
-		} else {
-			return true;
-		}
-	}
 
 	/**
 	 * @return DateTimeImmutable

--- a/lib/entity/groepen/GroepAanmeldRechten.php
+++ b/lib/entity/groepen/GroepAanmeldRechten.php
@@ -3,8 +3,6 @@
 namespace CsrDelft\entity\groepen;
 
 use CsrDelft\entity\groepen\interfaces\HeeftAanmeldRechten;
-use CsrDelft\entity\security\enum\AccessAction;
-use CsrDelft\service\security\LoginService;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation as Serializer;
 
@@ -29,30 +27,5 @@ trait GroepAanmeldRechten
 	public function setAanmeldRechten($rechten)
 	{
 		$this->rechtenAanmelden = $rechten;
-	}
-
-	/**
-	 * Has permission for action?
-	 *
-	 * @param AccessAction $action
-	 * @return boolean
-	 */
-	public function magAanmeldRechten($action)
-	{
-		$beschermdeActies = [
-			AccessAction::Bekijken(),
-			AccessAction::Aanmelden(),
-			AccessAction::Bewerken(),
-			AccessAction::Afmelden(),
-		];
-
-		if (
-			in_array($action, $beschermdeActies) &&
-			!LoginService::mag($this->rechtenAanmelden)
-		) {
-			return false;
-		}
-
-		return true;
 	}
 }

--- a/lib/entity/groepen/GroepLid.php
+++ b/lib/entity/groepen/GroepLid.php
@@ -35,6 +35,7 @@ class GroepLid
 			strtolower(ReflectionUtil::short_class($this)) .
 			'.csrdelft.nl';
 	}
+
 	/**
 	 * Shared primary key
 	 * Foreign key
@@ -98,6 +99,7 @@ class GroepLid
 	 * @ORM\JoinColumn(name="groep_id", referencedColumnName="id")
 	 */
 	public $groep;
+
 	/**
 	 * @return string|null
 	 * @Serializer\Groups("datatable")
@@ -153,5 +155,11 @@ class GroepLid
 		} else {
 			return '';
 		}
+	}
+
+	public function setProfiel(Profiel $profiel)
+	{
+		$this->profiel = $profiel;
+		$this->uid = $profiel->uid;
 	}
 }

--- a/lib/entity/groepen/Ketzer.php
+++ b/lib/entity/groepen/Ketzer.php
@@ -4,7 +4,6 @@ namespace CsrDelft\entity\groepen;
 
 use CsrDelft\entity\groepen\interfaces\HeeftAanmeldLimiet;
 use CsrDelft\entity\groepen\interfaces\HeeftAanmeldMoment;
-use CsrDelft\entity\security\enum\AccessAction;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -20,25 +19,6 @@ class Ketzer extends Groep implements HeeftAanmeldLimiet, HeeftAanmeldMoment
 {
 	use GroepAanmeldMoment;
 	use GroepAanmeldLimiet;
-
-	/**
-	 * Rechten voor de gehele klasse of soort groep?
-	 *
-	 * @param AccessAction $action
-	 * @param null $soort
-	 * @return boolean
-	 */
-	public static function magAlgemeen(AccessAction $action, $soort = null)
-	{
-		switch ($action) {
-			case AccessAction::Aanmaken():
-			case AccessAction::Aanmelden():
-			case AccessAction::Bewerken():
-			case AccessAction::Afmelden():
-				return true;
-		}
-		return parent::magAlgemeen($action, $soort);
-	}
 
 	public function getUrl()
 	{

--- a/lib/entity/groepen/Lichting.php
+++ b/lib/entity/groepen/Lichting.php
@@ -3,7 +3,6 @@
 namespace CsrDelft\entity\groepen;
 
 use CsrDelft\common\ContainerFacade;
-use CsrDelft\entity\security\enum\AccessAction;
 use CsrDelft\repository\ProfielRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
@@ -25,17 +24,6 @@ class Lichting extends Groep
 	 * @Serializer\Groups({"datatable", "log", "vue"})
 	 */
 	public $lidjaar;
-
-	/**
-	 * Read-only: generated group
-	 * @param $action
-	 * @param null $soort
-	 * @return bool
-	 */
-	public static function magAlgemeen(AccessAction $action, $soort = null)
-	{
-		return AccessAction::isBekijken($action);
-	}
 
 	/**
 	 * Stiekem hebben we helemaal geen leden
@@ -69,16 +57,5 @@ class Lichting extends Groep
 	public function getUrl()
 	{
 		return '/groepen/lichtingen/' . $this->lidjaar;
-	}
-
-	/**
-	 * Read-only: generated group
-	 * @param AccessAction $action
-	 * @param null $allowedAuthenticationMethods
-	 * @return bool
-	 */
-	public function mag(AccessAction $action)
-	{
-		return AccessAction::isBekijken($action);
 	}
 }

--- a/lib/entity/groepen/RechtenGroep.php
+++ b/lib/entity/groepen/RechtenGroep.php
@@ -3,7 +3,6 @@
 namespace CsrDelft\entity\groepen;
 
 use CsrDelft\entity\groepen\interfaces\HeeftAanmeldRechten;
-use CsrDelft\entity\security\enum\AccessAction;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -21,32 +20,5 @@ class RechtenGroep extends Groep implements HeeftAanmeldRechten
 	public function getUrl()
 	{
 		return '/groepen/overig/' . $this->id;
-	}
-
-	/**
-	 * Rechten voor de gehele klasse of soort groep?
-	 *
-	 * @param AccessAction $action
-	 * @param null $soort
-	 * @return boolean
-	 */
-	public static function magAlgemeen(AccessAction $action, $soort = null)
-	{
-		switch ($action) {
-			case AccessAction::Aanmaken():
-			case AccessAction::Aanmelden():
-			case AccessAction::Bewerken():
-			case AccessAction::Afmelden():
-				return true;
-		}
-		return parent::magAlgemeen($action, $soort);
-	}
-
-	public function mag(AccessAction $action)
-	{
-		if (AccessAction::isBekijken($action)) {
-			return true;
-		}
-		return parent::mag($action);
 	}
 }

--- a/lib/entity/groepen/Verticale.php
+++ b/lib/entity/groepen/Verticale.php
@@ -4,7 +4,6 @@ namespace CsrDelft\entity\groepen;
 
 use CsrDelft\common\ContainerFacade;
 use CsrDelft\entity\profiel\Profiel;
-use CsrDelft\entity\security\enum\AccessAction;
 use CsrDelft\model\entity\LidStatus;
 use CsrDelft\repository\ProfielRepository;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -74,39 +73,5 @@ class Verticale extends Groep
 	public function getUrl()
 	{
 		return '/groepen/verticalen/' . $this->letter;
-	}
-
-	/**
-	 * Limit functionality: leden generated
-	 * @param AccessAction $action
-	 * @param null $allowedAuthenticationMethods
-	 * @return bool
-	 */
-	public function mag(AccessAction $action)
-	{
-		switch ($action) {
-			case AccessAction::Bekijken():
-			case AccessAction::Aanmaken():
-			case AccessAction::Wijzigen():
-				return parent::mag($action);
-		}
-		return false;
-	}
-
-	/**
-	 * Limit functionality: leden generated
-	 * @param AccessAction $action
-	 * @param null $soort
-	 * @return bool
-	 */
-	public static function magAlgemeen(AccessAction $action, $soort = null)
-	{
-		switch ($action) {
-			case AccessAction::Bekijken():
-			case AccessAction::Aanmaken():
-			case AccessAction::Wijzigen():
-				return parent::magAlgemeen($action, $soort);
-		}
-		return false;
 	}
 }

--- a/lib/entity/groepen/Werkgroep.php
+++ b/lib/entity/groepen/Werkgroep.php
@@ -3,8 +3,6 @@
 namespace CsrDelft\entity\groepen;
 
 use CsrDelft\entity\groepen\interfaces\HeeftMoment;
-use CsrDelft\entity\security\enum\AccessAction;
-use CsrDelft\service\security\LoginService;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -21,20 +19,5 @@ class Werkgroep extends Groep implements HeeftMoment
 	public function getUrl()
 	{
 		return '/groepen/werkgroepen/' . $this->id;
-	}
-
-	/**
-	 * Rechten voor de gehele klasse of soort groep?
-	 *
-	 * @param AccessAction $action
-	 * @param null $soort
-	 * @return boolean
-	 */
-	public static function magAlgemeen(AccessAction $action, $soort = null)
-	{
-		if (AccessAction::isAanmaken($action) && !LoginService::mag(P_LEDEN_MOD)) {
-			return false;
-		}
-		return parent::magAlgemeen($action, $soort);
 	}
 }

--- a/lib/entity/groepen/Woonoord.php
+++ b/lib/entity/groepen/Woonoord.php
@@ -5,8 +5,6 @@ namespace CsrDelft\entity\groepen;
 use CsrDelft\entity\groepen\enum\HuisStatus;
 use CsrDelft\entity\groepen\interfaces\HeeftMoment;
 use CsrDelft\entity\groepen\interfaces\HeeftSoort;
-use CsrDelft\entity\security\enum\AccessAction;
-use CsrDelft\service\security\LoginService;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation as Serializer;
 
@@ -41,29 +39,6 @@ class Woonoord extends Groep implements HeeftSoort, HeeftMoment
 	public function getUrl()
 	{
 		return '/groepen/woonoorden/' . $this->id;
-	}
-
-	/**
-	 * Has permission for action?
-	 *
-	 * @param AccessAction $action
-	 * @param string $soort
-	 *
-	 * @return boolean
-	 */
-	public function mag($action, $soort = null)
-	{
-		switch ($action) {
-			case AccessAction::Beheren():
-			case AccessAction::Wijzigen():
-				// Huidige bewoners mogen beheren
-				if (LoginService::mag('woonoord:' . $this->familie)) {
-					// HuisStatus wijzigen wordt geblokkeerd in GroepForm->validate()
-					return true;
-				}
-				break;
-		}
-		return parent::mag($action);
 	}
 
 	public function getSoort()

--- a/lib/entity/groepen/interfaces/HeeftAanmeldLimiet.php
+++ b/lib/entity/groepen/interfaces/HeeftAanmeldLimiet.php
@@ -1,7 +1,6 @@
 <?php
-namespace CsrDelft\entity\groepen\interfaces;
 
-use CsrDelft\entity\security\enum\AccessAction;
+namespace CsrDelft\entity\groepen\interfaces;
 
 /**
  * Interface HeeftAanmeldLimiet
@@ -13,5 +12,4 @@ use CsrDelft\entity\security\enum\AccessAction;
 interface HeeftAanmeldLimiet
 {
 	function getAanmeldLimiet();
-	function magAanmeldLimiet(AccessAction $action);
 }

--- a/lib/entity/groepen/interfaces/HeeftAanmeldMoment.php
+++ b/lib/entity/groepen/interfaces/HeeftAanmeldMoment.php
@@ -6,8 +6,6 @@ use DateTimeImmutable;
 
 interface HeeftAanmeldMoment
 {
-	function magAanmeldMoment($action);
-
 	/**
 	 * @return DateTimeImmutable
 	 */

--- a/lib/entity/groepen/interfaces/HeeftAanmeldRechten.php
+++ b/lib/entity/groepen/interfaces/HeeftAanmeldRechten.php
@@ -4,8 +4,6 @@ namespace CsrDelft\entity\groepen\interfaces;
 
 interface HeeftAanmeldRechten
 {
-	function magAanmeldRechten($action);
-
 	function getAanmeldRechten();
 	function setAanmeldRechten($rechten);
 }

--- a/lib/repository/GroepRepository.php
+++ b/lib/repository/GroepRepository.php
@@ -2,6 +2,7 @@
 
 namespace CsrDelft\repository;
 
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
 use CsrDelft\common\Util\FlashUtil;
 use CsrDelft\common\Util\ReflectionUtil;
 use CsrDelft\common\Util\SqlUtil;
@@ -22,6 +23,7 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\Persistence\ManagerRegistry;
 use ReflectionClass;
 use ReflectionProperty;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Throwable;
 
@@ -37,13 +39,21 @@ use Throwable;
 abstract class GroepRepository extends AbstractRepository
 {
 	/**
+	 * @var Security
+	 */
+	private $security;
+
+	/**
 	 * AbstractGroepenModel constructor.
 	 * @param ManagerRegistry $managerRegistry
 	 * @param Groep|string $entityClass
 	 */
-	public function __construct(ManagerRegistry $managerRegistry)
-	{
+	public function __construct(
+		ManagerRegistry $managerRegistry,
+		Security $security
+	) {
 		parent::__construct($managerRegistry, $this->getEntityClassName());
+		$this->security = $security;
 	}
 
 	/**
@@ -405,7 +415,9 @@ abstract class GroepRepository extends AbstractRepository
 		$num = 0;
 		while ($num < $limit && ($object = $result->next()) !== false) {
 			/** @var $object Groep[] */
-			if ($object[0]->mag(AccessAction::Bekijken())) {
+			if (
+				$this->security->isGranted(AbstractGroepVoter::BEKIJKEN, $object[0])
+			) {
 				$num++;
 				yield $object[0];
 			}
@@ -461,7 +473,9 @@ abstract class GroepRepository extends AbstractRepository
 
 		$aantal = 0;
 		foreach ($activiteiten as $activiteit) {
-			if ($activiteit->mag(AccessAction::Bekijken())) {
+			if (
+				$this->security->isGranted(AbstractGroepVoter::BEKIJKEN, $activiteit)
+			) {
 				$aantal++;
 			}
 		}

--- a/lib/repository/GroepRepository.php
+++ b/lib/repository/GroepRepository.php
@@ -12,7 +12,6 @@ use CsrDelft\entity\groepen\GroepStatistiekDTO;
 use CsrDelft\entity\groepen\interfaces\HeeftAanmeldLimiet;
 use CsrDelft\entity\groepen\interfaces\HeeftMoment;
 use CsrDelft\entity\profiel\Profiel;
-use CsrDelft\entity\security\enum\AccessAction;
 use CsrDelft\service\security\LoginService;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Exception\ORMException;
@@ -253,9 +252,8 @@ abstract class GroepRepository extends AbstractRepository
 	 * @param null $soort
 	 * @return Groep
 	 */
-	public function nieuw(
-		/* @noinspection PhpUnusedParameterInspection */ $soort = null
-	) {
+	public function nieuw($soort = null)
+	{
 		$orm = $this->getClassName();
 		$groep = new $orm();
 		$groep->naam = null;

--- a/lib/repository/agenda/AgendaRepository.php
+++ b/lib/repository/agenda/AgendaRepository.php
@@ -2,6 +2,7 @@
 
 namespace CsrDelft\repository\agenda;
 
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
 use CsrDelft\common\Util\InstellingUtil;
 use CsrDelft\common\Util\SqlUtil;
 use CsrDelft\entity\agenda\AgendaItem;
@@ -220,7 +221,9 @@ class AgendaRepository extends AbstractRepository
 			$tot
 		);
 		foreach ($activiteiten as $activiteit) {
-			if ($activiteit->mag(AccessAction::Bekijken(), $auth)) {
+			if (
+				$this->security->isGranted(AbstractGroepVoter::BEKIJKEN, $activiteit)
+			) {
 				$result[] = $activiteit;
 			}
 		}

--- a/lib/repository/groepen/RechtenGroepenRepository.php
+++ b/lib/repository/groepen/RechtenGroepenRepository.php
@@ -8,6 +8,7 @@ use CsrDelft\repository\GroepLidRepository;
 use CsrDelft\repository\GroepRepository;
 use CsrDelft\repository\ProfielRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Security\Core\Security;
 
 class RechtenGroepenRepository extends GroepRepository
 {
@@ -22,9 +23,10 @@ class RechtenGroepenRepository extends GroepRepository
 		BesturenRepository $besturenRepository,
 		CommissiesRepository $commissiesRepository,
 		GroepLidRepository $groepLidRepository,
+		Security $security,
 		ManagerRegistry $registry
 	) {
-		parent::__construct($registry);
+		parent::__construct($registry, $security);
 
 		$this->besturenRepository = $besturenRepository;
 		$this->commissiesRepository = $commissiesRepository;

--- a/lib/view/bbcode/tag/groep/BbTagGroep.php
+++ b/lib/view/bbcode/tag/groep/BbTagGroep.php
@@ -5,18 +5,18 @@ namespace CsrDelft\view\bbcode\tag\groep;
 use CsrDelft\bb\BbException;
 use CsrDelft\bb\BbTag;
 use CsrDelft\common\CsrException;
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
 use CsrDelft\common\Util\VueUtil;
 use CsrDelft\entity\groepen\enum\GroepVersie;
 use CsrDelft\entity\groepen\Groep;
-use CsrDelft\entity\security\enum\AccessAction;
 use CsrDelft\repository\GroepRepository;
 use CsrDelft\repository\ProfielRepository;
 use CsrDelft\service\security\LoginService;
 use CsrDelft\view\bbcode\BbHelper;
 use CsrDelft\view\groepen\GroepView;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Serializer\SerializerInterface;
 use Twig\Environment;
 
 /**
@@ -41,8 +41,13 @@ abstract class BbTagGroep extends BbTag
 	 * @var NormalizerInterface
 	 */
 	private $normalizer;
+	/**
+	 * @var Security
+	 */
+	private $security;
 
 	public function __construct(
+		Security $security,
 		EntityManagerInterface $entityManager,
 		Environment $twig,
 		NormalizerInterface $normalizer
@@ -50,6 +55,7 @@ abstract class BbTagGroep extends BbTag
 		$this->twig = $twig;
 		$this->entityManager = $entityManager;
 		$this->normalizer = $normalizer;
+		$this->security = $security;
 	}
 
 	public function getId()
@@ -63,7 +69,10 @@ abstract class BbTagGroep extends BbTag
 	 */
 	public function isAllowed()
 	{
-		return $this->getGroep()->mag(AccessAction::Bekijken());
+		return $this->security->isGranted(
+			AbstractGroepVoter::BEKIJKEN,
+			$this->getGroep()
+		);
 	}
 
 	/**

--- a/lib/view/groepen/GroepView.php
+++ b/lib/view/groepen/GroepView.php
@@ -9,6 +9,7 @@
 namespace CsrDelft\view\groepen;
 
 use CsrDelft\common\ContainerFacade;
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
 use CsrDelft\common\Util\ReflectionUtil;
 use CsrDelft\entity\groepen\Groep;
 use CsrDelft\entity\groepen\enum\GroepTab;
@@ -114,7 +115,8 @@ class GroepView implements FormElement, ToResponse
 			'"><div id="groep-samenvatting-' .
 			$this->groep->id .
 			'" class="groep-samenvatting">';
-		if ($this->groep->mag(AccessAction::Wijzigen())) {
+		$security = ContainerFacade::getContainer()->get('security');
+		if ($security->isGranted(AbstractGroepVoter::WIJZIGEN, $this->groep)) {
 			$html .=
 				'<div class="float-end"><a class="btn" href="' .
 				$this->groep->getUrl() .

--- a/lib/view/groepen/GroepenView.php
+++ b/lib/view/groepen/GroepenView.php
@@ -7,6 +7,7 @@ use CsrDelft\common\Enum;
 use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
 use CsrDelft\entity\groepen\enum\GroepTab;
 use CsrDelft\entity\groepen\Groep;
+use CsrDelft\entity\groepen\interfaces\HeeftSoort;
 use CsrDelft\entity\security\enum\AccessAction;
 use CsrDelft\repository\CmsPaginaRepository;
 use CsrDelft\repository\groepen\BesturenRepository;
@@ -112,7 +113,13 @@ class GroepenView implements View
 	{
 		$orm = $this->model->getEntityClassName();
 		$html = '';
-		if ($orm::magAlgemeen(AccessAction::Aanmaken(), $this->soort)) {
+		$security = ContainerFacade::getContainer()->get('security');
+		$entity = new $orm();
+		// Maak een dummy entity met de soort om een rechtencheck te kunnen doen
+		if ($entity instanceof HeeftSoort) {
+			$entity->setSoort($this->soort);
+		}
+		if ($security->isGranted(AbstractGroepVoter::AANMAKEN, $entity)) {
 			$html .=
 				'<a class="btn" href="' .
 				$this->model->getUrl() .

--- a/lib/view/groepen/GroepenView.php
+++ b/lib/view/groepen/GroepenView.php
@@ -4,6 +4,7 @@ namespace CsrDelft\view\groepen;
 
 use CsrDelft\common\ContainerFacade;
 use CsrDelft\common\Enum;
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
 use CsrDelft\entity\groepen\enum\GroepTab;
 use CsrDelft\entity\groepen\Groep;
 use CsrDelft\entity\security\enum\AccessAction;
@@ -139,9 +140,10 @@ class GroepenView implements View
 		}
 		$view = new CmsPaginaView($this->pagina);
 		$html .= $view->__toString();
+		$security = ContainerFacade::getContainer()->get('security');
 		foreach ($this->groepen as $groep) {
 			// Controleer rechten
-			if (!$groep->mag(AccessAction::Bekijken())) {
+			if (!$security->isGranted(AbstractGroepVoter::BEKIJKEN, $groep)) {
 				continue;
 			}
 			$html .= '<hr>';

--- a/lib/view/groepen/formulier/GroepForm.php
+++ b/lib/view/groepen/formulier/GroepForm.php
@@ -2,6 +2,8 @@
 
 namespace CsrDelft\view\groepen\formulier;
 
+use CsrDelft\common\ContainerFacade;
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
 use CsrDelft\common\Util\FlashUtil;
 use CsrDelft\common\Util\ReflectionUtil;
 use CsrDelft\entity\groepen\enum\HuisStatus;
@@ -30,9 +32,10 @@ class GroepForm extends ModalForm
 {
 	/**
 	 * Aanmaken/Wijzigen
-	 * @var AccessAction
+	 * @var bool
 	 */
-	private $mode;
+	private $magWijzigen;
+	private $isWijzigen;
 
 	/**
 	 * GroepForm constructor.
@@ -42,15 +45,20 @@ class GroepForm extends ModalForm
 	 * @param false $nocancel
 	 * @throws \Exception
 	 */
-	public function __construct(Groep $groep, $action, $mode, $nocancel = false)
-	{
+	public function __construct(
+		Groep $groep,
+		$action,
+		$magWijzigen,
+		$isWijzigen,
+		$nocancel = false
+	) {
 		parent::__construct(
 			$groep,
 			$action,
 			ReflectionUtil::classNameZonderNamespace(get_class($groep)),
 			true
 		);
-		$this->mode = $mode;
+		$this->magWijzigen = $magWijzigen;
 		if ($groep->id) {
 			$this->titel .= ' wijzigen';
 		} else {
@@ -119,6 +127,7 @@ class GroepForm extends ModalForm
 		$this->addFields($fields);
 
 		$this->formKnoppen = new FormDefaultKnoppen($nocancel ? false : null);
+		$this->isWijzigen = $isWijzigen;
 	}
 
 	public function validate()
@@ -132,11 +141,13 @@ class GroepForm extends ModalForm
 		} else {
 			$soort = null;
 		}
+
+		$security = ContainerFacade::getContainer()->get('security');
 		/**
 		 * @Notice: Similar function in GroepSoortField->validate()
 		 */
-		if (!$groep->magAlgemeen($this->mode, $soort)) {
-			if (!$groep->mag($this->mode)) {
+		if (!$security->isGranted(AbstractGroepVoter::BEHEREN, $groep)) {
+			if (!$this->magWijzigen) {
 				// beide aanroepen vanwege niet doorsturen van param $soort door mag() naar magAlgemeen()
 				if ($soort) {
 					$naam = $soort->getDescription();
@@ -154,10 +165,7 @@ class GroepForm extends ModalForm
 			 * op moment van uitvoeren van deze funtie, hier een extra check:
 			 *
 			 * N.B.: Deze check staat binnen de !magAlgemeen zodat P_LEDEN_MOD deze check overslaat
-			 */ elseif (
-				AccessAction::isWijzigen($this->mode) &&
-				$groep instanceof Woonoord
-			) {
+			 */ elseif ($this->isWijzigen && $groep instanceof Woonoord) {
 				$vorigeHuisStatus = HuisStatus::from(
 					$this->findByName('huisStatus')->getOrigValue()
 				);

--- a/lib/view/groepen/formulier/GroepForm.php
+++ b/lib/view/groepen/formulier/GroepForm.php
@@ -159,23 +159,25 @@ class GroepForm extends ModalForm
 					-1
 				);
 				return false;
-			} /**
-			 * Omdat wijzigen wel is toegestaan met hetzelfde formulier
-			 * en groep->mag() @runtime niet weet wat de orig value was (door form auto property set)
-			 * op moment van uitvoeren van deze funtie, hier een extra check:
-			 *
-			 * N.B.: Deze check staat binnen de !magAlgemeen zodat P_LEDEN_MOD deze check overslaat
-			 */ elseif ($this->isWijzigen && $groep instanceof Woonoord) {
-				$vorigeHuisStatus = HuisStatus::from(
-					$this->findByName('huisStatus')->getOrigValue()
+			}
+		}
+		/**
+		 * Voorkom wijzigen van huis status door bewoners.
+		 * Bewoners mogen wel een Woonoord beheren, maar niet zomaar de huisstatus aanpassen.
+		 */
+		if ($this->isWijzigen && $groep instanceof Woonoord) {
+			$vorigeHuisStatus = HuisStatus::from(
+				$this->findByName('huisStatus')->getOrigValue()
+			);
+			if (
+				$vorigeHuisStatus !== $soort &&
+				!$security->isGranted('ROLE_LEDEN_MOD')
+			) {
+				FlashUtil::setFlashWithContainerFacade(
+					'U mag de huisstatus niet wijzigen',
+					-1
 				);
-				if ($vorigeHuisStatus !== $soort) {
-					FlashUtil::setFlashWithContainerFacade(
-						'U mag de huisstatus niet wijzigen',
-						-1
-					);
-					return false;
-				}
+				return false;
 			}
 		}
 

--- a/lib/view/groepen/formulier/GroepForm.php
+++ b/lib/view/groepen/formulier/GroepForm.php
@@ -58,7 +58,6 @@ class GroepForm extends ModalForm
 			ReflectionUtil::classNameZonderNamespace(get_class($groep)),
 			true
 		);
-		$this->magWijzigen = $magWijzigen;
 		if ($groep->id) {
 			$this->titel .= ' wijzigen';
 		} else {
@@ -136,51 +135,6 @@ class GroepForm extends ModalForm
 		 * @var Groep $groep
 		 */
 		$groep = $this->getModel();
-		if ($groep instanceof HeeftSoort) {
-			$soort = $groep->getSoort();
-		} else {
-			$soort = null;
-		}
-
-		$security = ContainerFacade::getContainer()->get('security');
-		/**
-		 * @Notice: Similar function in GroepSoortField->validate()
-		 */
-		if (!$security->isGranted(AbstractGroepVoter::BEHEREN, $groep)) {
-			if (!$this->magWijzigen) {
-				// beide aanroepen vanwege niet doorsturen van param $soort door mag() naar magAlgemeen()
-				if ($soort) {
-					$naam = $soort->getDescription();
-				} else {
-					$naam = ReflectionUtil::classNameZonderNamespace(get_class($groep));
-				}
-				FlashUtil::setFlashWithContainerFacade(
-					'U mag geen ' . $naam . ' aanmaken',
-					-1
-				);
-				return false;
-			}
-		}
-		/**
-		 * Voorkom wijzigen van huis status door bewoners.
-		 * Bewoners mogen wel een Woonoord beheren, maar niet zomaar de huisstatus aanpassen.
-		 */
-		if ($this->isWijzigen && $groep instanceof Woonoord) {
-			$vorigeHuisStatus = HuisStatus::from(
-				$this->findByName('huisStatus')->getOrigValue()
-			);
-			if (
-				$vorigeHuisStatus !== $soort &&
-				!$security->isGranted('ROLE_LEDEN_MOD')
-			) {
-				FlashUtil::setFlashWithContainerFacade(
-					'U mag de huisstatus niet wijzigen',
-					-1
-				);
-				return false;
-			}
-		}
-
 		$fields = $this->getFields();
 		if (
 			isset($fields['eindMoment']) &&

--- a/lib/view/groepen/formulier/GroepSoortField.php
+++ b/lib/view/groepen/formulier/GroepSoortField.php
@@ -2,7 +2,9 @@
 
 namespace CsrDelft\view\groepen\formulier;
 
+use CsrDelft\common\ContainerFacade;
 use CsrDelft\common\Enum;
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
 use CsrDelft\entity\groepen\Activiteit;
 use CsrDelft\entity\groepen\Bestuur;
 use CsrDelft\entity\groepen\Commissie;
@@ -123,7 +125,14 @@ JS;
 		/**
 		 * @Warning: Duplicate function in GroepForm->validate()
 		 */
-		if (!$this->groep->magAlgemeen(AccessAction::Beheren(), $soort)) {
+		$security = ContainerFacade::getContainer()->get('security');
+
+		$testGroep = new $class();
+		if ($testGroep instanceof HeeftSoort) {
+			$testGroep->setSoort($soort);
+		}
+
+		if (!$security->isGranted(AbstractGroepVoter::BEHEREN, $testGroep)) {
 			if ($model instanceof ActiviteitenRepository) {
 				$naam = $soort->getDescription();
 			} elseif ($model instanceof CommissiesRepository) {

--- a/lib/view/groepen/formulier/KetzerSoortField.php
+++ b/lib/view/groepen/formulier/KetzerSoortField.php
@@ -2,9 +2,13 @@
 
 namespace CsrDelft\view\groepen\formulier;
 
+use CsrDelft\common\ContainerFacade;
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
+use CsrDelft\common\Security\Voter\Entity\Groep\ActiviteitGroepVoter;
 use CsrDelft\entity\groepen\Activiteit;
 use CsrDelft\entity\groepen\enum\ActiviteitSoort;
 use CsrDelft\entity\groepen\Groep;
+use CsrDelft\entity\groepen\interfaces\HeeftSoort;
 use CsrDelft\entity\groepen\Ketzer;
 use CsrDelft\entity\security\enum\AccessAction;
 use CsrDelft\repository\groepen\ActiviteitenRepository;
@@ -59,7 +63,15 @@ class KetzerSoortField extends GroepSoortField
 		$model = $this->doctrine->getRepository($class[0]);
 		/** @var Groep|string $orm */
 		$orm = $model->getClassName();
-		if (!$orm::magAlgemeen(AccessAction::Aanmaken(), $soort)) {
+
+		$security = ContainerFacade::getContainer()->get('security');
+		$entity = new $orm();
+		// Maak een dummy entity met de soort om een rechtencheck te kunnen doen
+		if ($entity instanceof HeeftSoort) {
+			$entity->setSoort($soort);
+		}
+
+		if (!$security->isGranted(AbstractGroepVoter::AANMAKEN, $entity)) {
 			if ($model instanceof ActiviteitenRepository) {
 				$naam = ActiviteitSoort::from($soort)->getDescription();
 			} else {

--- a/lib/view/groepen/leden/GroepLedenTable.php
+++ b/lib/view/groepen/leden/GroepLedenTable.php
@@ -2,6 +2,8 @@
 
 namespace CsrDelft\view\groepen\leden;
 
+use CsrDelft\common\ContainerFacade;
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
 use CsrDelft\entity\groepen\Groep;
 use CsrDelft\entity\groepen\enum\GroepStatus;
 use CsrDelft\entity\groepen\GroepLid;
@@ -19,7 +21,7 @@ use CsrDelft\view\datatable\Multiplicity;
  */
 class GroepLedenTable extends DataTable
 {
-	public function __construct(Groep $groep)
+	public function __construct(Groep $groep, bool $magBeheren)
 	{
 		parent::__construct(
 			GroepLid::class,
@@ -34,7 +36,7 @@ class GroepLedenTable extends DataTable
 		$this->setColumnTitle('lid', 'Lidnaam');
 		$this->setColumnTitle('door_uid', 'Aangemeld door');
 
-		if ($groep->mag(AccessAction::Beheren())) {
+		if ($magBeheren) {
 			$this->addKnop(
 				new DataTableKnop(
 					Multiplicity::Zero(),

--- a/templates/agenda/details.html.twig
+++ b/templates/agenda/details.html.twig
@@ -40,7 +40,7 @@
 						{{ icon('calendar-plus', null, 'Exporteer dit agenda item') }}
 					</a>
 
-					{% if item is abstractgroep and item.magWijzigen %}
+					{% if item is abstractgroep and is_granted('groep.wijzigen', item) %}
 						<a href="{{ item.url }}/wijzigen" class="beheren btn" title="Wijzig {{ item.naam }}">
 							{{ icon('bewerken', null, 'Bewerk dit agenda item') }}
 						</a>

--- a/templates/groep/lijst.html.twig
+++ b/templates/groep/lijst.html.twig
@@ -5,7 +5,7 @@
 {% block tabcontent %}
 	<table class="groep-lijst table table-sm table-striped" role="presentation">
 		<tbody>
-		{% if groep.magTwig('aanmelden') %}
+		{% if is_granted('groep.aanmelden', groep) %}
 			<tr>
 				<td colspan="2">
 					{{ aanmeldForm|raw }}
@@ -17,14 +17,14 @@
 		{% for lid in groep.ledenOpAchternaamGesorteerd %}
 			<tr>
 				<td>
-					{% if groep.magTwigLid('afmelden', lid) %}
+					{% if is_granted('groep.afmelden', lid) %}
 						<a href="{{ groep.url }}/ketzer/afmelden" class="post confirm float-start" title="Afmelden">' .
 							{{ icon('circle-minus') }}
 						</a>
 					{% endif %}
 					{{ lid.link | raw }}
 				</td><td>
-					{% if groep.magTwigLid('bewerken', lid) %}
+					{% if is_granted('groep.bewerken', lid) %}
 						{{ groep_bewerken_form(lid, groep) }}
 					{% else %}
 						{{ lid.opmerking }}

--- a/templates/groep/pasfotos.html.twig
+++ b/templates/groep/pasfotos.html.twig
@@ -3,7 +3,7 @@
 {% block type %}pasfotos{% endblock %}
 
 {% block tabcontent %}
-	{% if groep.magTwig('aanmelden') %}
+	{% if is_granted('groep.aanmelden', groep) %}
 		{{ aanmeldForm | raw }}
 	{% endif %}
 

--- a/templates/groep/tab.html.twig
+++ b/templates/groep/tab.html.twig
@@ -63,7 +63,7 @@
 					tabContent.height(availableHeight);
 				}
 
-				{% if groep.magTwig('beheren') %}
+				{% if is_granted('groep.beheren', groep) %}
 
 				$('#groep-leden-content-{{ groep.id }} a.lidLink').contextMenu({
 					menuSelector: "#groep-context-menu-{{ groep.id }}",
@@ -85,7 +85,7 @@
 		{% set percent = ((aantal * 100) / groep.aanmeldLimiet) | round %}
 
 		{# Aanmelden mogelijk? #}
-		{% if groep is heeftaanmeldmoment and groep.magTwig('aanmelden') %}
+		{% if groep is heeftaanmeldmoment and is_granted('groep.aanmelden', groep) %}
 			{% set verschil = groep.aanmeldLimiet - aantal %}
 			{% if verschil == 0 %}
 				{% set title = 'Inschrijvingen vol!' %}
@@ -95,7 +95,7 @@
 				{% set color = ' progress-bar-success' %}
 			{% endif %}
 			{# bewerken mogelijk? #}
-		{% elseif groep is heeftaanmeldmoment and groep.magTwig('bewerken') %}
+		{% elseif groep is heeftaanmeldmoment and is_granted('groep.bewerken', groep) %}
 			{% set title = 'Inschrijvingen gesloten! Inschrijving bewerken is nog wel toegestaan.' %}
 			{% set color = ' progress-bar-warning' %}
 		{% else %}

--- a/tests/Voters/GroepVoterAanmakenTest.php
+++ b/tests/Voters/GroepVoterAanmakenTest.php
@@ -4,10 +4,11 @@ namespace Voters;
 
 use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
 use CsrDelft\DataFixtures\AccountFixtures;
+use CsrDelft\entity\groepen\Activiteit;
 use CsrDelft\entity\groepen\Commissie;
 use CsrDelft\tests\AbstractVoterTestCase;
 
-class GroepVoterTest extends AbstractVoterTestCase
+class GroepVoterAanmakenTest extends AbstractVoterTestCase
 {
 	public function testCommissieAanmaken()
 	{
@@ -23,6 +24,23 @@ class GroepVoterTest extends AbstractVoterTestCase
 			$this->getToken(AccountFixtures::UID_BESTUUR_FISCUS),
 			AbstractGroepVoter::AANMAKEN,
 			$commissie
+		);
+	}
+
+	public function testActiviteitAanmaken()
+	{
+		$activiteit = new Activiteit();
+		// Lid mag activiteit maken
+		$this->assertToegang(
+			$this->getToken(AccountFixtures::UID_LID_MAN),
+			AbstractGroepVoter::AANMAKEN,
+			$activiteit
+		);
+		// Bestuur mag activiteit maken
+		$this->assertToegang(
+			$this->getToken(AccountFixtures::UID_BESTUUR_FISCUS),
+			AbstractGroepVoter::AANMAKEN,
+			$activiteit
 		);
 	}
 }

--- a/tests/Voters/GroepVoterAanmeldenTest.php
+++ b/tests/Voters/GroepVoterAanmeldenTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Voters;
+
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
+use CsrDelft\DataFixtures\AccountFixtures;
+use CsrDelft\entity\groepen\Activiteit;
+use CsrDelft\entity\groepen\GroepLid;
+use CsrDelft\tests\AbstractVoterTestCase;
+
+class GroepVoterAanmeldenTest extends AbstractVoterTestCase
+{
+	public function testActiviteitAanmelden_aanmeldLimiet()
+	{
+		$activiteit = new Activiteit();
+		$activiteit->aanmeldLimiet = 2;
+		$activiteit->setAanmeldenTot(date_create_immutable('+3 days'));
+		$activiteit->setAanmeldenVanaf(date_create_immutable('-2 days'));
+
+		$activiteit->getLeden()->add(new GroepLid());
+		$lid2 = new GroepLid();
+		$activiteit->getLeden()->add($lid2);
+
+		$this->assertGeenToegang(
+			$this->getToken(AccountFixtures::UID_LID_MAN),
+			AbstractGroepVoter::AANMELDEN,
+			$activiteit
+		);
+
+		$activiteit->getLeden()->removeElement($lid2);
+
+		$this->assertToegang(
+			$this->getToken(AccountFixtures::UID_LID_MAN),
+			AbstractGroepVoter::AANMELDEN,
+			$activiteit
+		);
+	}
+
+	/**
+	 * Mag niet aanmelden als aanmeldenVanaf in de toekomst is.
+	 */
+	public function testActiviteitAanmelden_aanmeldenVanaf()
+	{
+		$activiteit = new Activiteit();
+		$activiteit->aanmeldLimiet = 2;
+		$activiteit->setAanmeldenTot(date_create_immutable('+3 days'));
+		$activiteit->setAanmeldenVanaf(date_create_immutable('+2 days'));
+
+		$this->assertGeenToegang(
+			$this->getToken(AccountFixtures::UID_LID_MAN),
+			AbstractGroepVoter::AANMELDEN,
+			$activiteit
+		);
+	}
+
+	/**
+	 * Mag niet aanmelden als aanmeldenTot in het verleden is.
+	 */
+	public function testActiviteitAanmelden_aanmeldenTot()
+	{
+		$activiteit = new Activiteit();
+		$activiteit->aanmeldLimiet = 2;
+		$activiteit->setAanmeldenTot(date_create_immutable('-1 days'));
+		$activiteit->setAanmeldenVanaf(date_create_immutable('-2 days'));
+
+		$this->assertGeenToegang(
+			$this->getToken(AccountFixtures::UID_LID_MAN),
+			AbstractGroepVoter::AANMELDEN,
+			$activiteit
+		);
+	}
+
+	/**
+	 * Mag alleen aanmelden als je aanmeldRechten hebt.
+	 */
+	public function testActiviteitAanmelden_aanmeldRechten()
+	{
+		$activiteit = new Activiteit();
+		$activiteit->aanmeldLimiet = 2;
+		$activiteit->setAanmeldenTot(date_create_immutable('+3 days'));
+		$activiteit->setAanmeldenVanaf(date_create_immutable('-2 days'));
+		$activiteit->setAanmeldRechten(AccountFixtures::UID_LID_VROUW);
+
+		$this->assertGeenToegang(
+			$this->getToken(AccountFixtures::UID_LID_MAN),
+			AbstractGroepVoter::AANMELDEN,
+			$activiteit
+		);
+		$this->assertToegang(
+			$this->getToken(AccountFixtures::UID_LID_VROUW),
+			AbstractGroepVoter::AANMELDEN,
+			$activiteit
+		);
+		$this->assertGeenToegang(
+			$this->getToken(AccountFixtures::UID_PUBCIE),
+			AbstractGroepVoter::AANMELDEN,
+			$activiteit
+		);
+	}
+
+	/**
+	 * Mag niet aanmelden als al aangemeld.
+	 */
+	public function testActiviteitAanmelden_alAangemeld()
+	{
+		$activiteit = new Activiteit();
+		$activiteit->aanmeldLimiet = 3;
+		$activiteit->setAanmeldenTot(date_create_immutable('+3 days'));
+		$activiteit->setAanmeldenVanaf(date_create_immutable('-2 days'));
+
+		$token = $this->getToken(AccountFixtures::UID_LID_VROUW);
+		$this->assertToegang($token, AbstractGroepVoter::AANMELDEN, $activiteit);
+
+		$groepLid = new GroepLid();
+		$groepLid->setProfiel($token->getUser()->profiel);
+		$activiteit->getLeden()->add($groepLid);
+
+		// Al aangemeld
+		$this->assertGeenToegang(
+			$token,
+			AbstractGroepVoter::AANMELDEN,
+			$activiteit
+		);
+	}
+}

--- a/tests/Voters/GroepVoterAfmeldenTest.php
+++ b/tests/Voters/GroepVoterAfmeldenTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Voters;
+
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
+use CsrDelft\DataFixtures\AccountFixtures;
+use CsrDelft\entity\groepen\Activiteit;
+use CsrDelft\entity\groepen\GroepLid;
+use CsrDelft\tests\AbstractVoterTestCase;
+
+class GroepVoterAfmeldenTest extends AbstractVoterTestCase
+{
+	public function testAfmelden()
+	{
+		$activiteit = new Activiteit();
+		$activiteit->setAanmeldenTot(date_create_immutable('+3 days'));
+		$activiteit->setAanmeldenVanaf(date_create_immutable('-2 days'));
+
+		$groepLid = new GroepLid();
+		$token = $this->getToken(AccountFixtures::UID_LID_MAN);
+		$groepLid->setProfiel($token->getUser()->profiel);
+		$activiteit->getLeden()->add($groepLid);
+
+		$this->assertToegang($token, AbstractGroepVoter::AFMELDEN, $activiteit);
+	}
+
+	public function testAfmelden_nietAangemeld()
+	{
+		$activiteit = new Activiteit();
+		$token = $this->getToken(AccountFixtures::UID_LID_MAN);
+
+		$this->assertGeenToegang($token, AbstractGroepVoter::AFMELDEN, $activiteit);
+	}
+
+	public function testAfmelden_afmeldenTot()
+	{
+		$activiteit = new Activiteit();
+		$activiteit->setAanmeldenTot(date_create_immutable('+3 days'));
+		$activiteit->setAanmeldenVanaf(date_create_immutable('-2 days'));
+
+		$activiteit->setAfmeldenTot(date_create_immutable('-1 days'));
+
+		$groepLid = new GroepLid();
+		$token = $this->getToken(AccountFixtures::UID_LID_MAN);
+		$groepLid->setProfiel($token->getUser()->profiel);
+		$activiteit->getLeden()->add($groepLid);
+
+		$this->assertGeenToegang($token, AbstractGroepVoter::AFMELDEN, $activiteit);
+
+		$activiteit->setAfmeldenTot(date_create_immutable('+1 days'));
+
+		$this->assertToegang($token, AbstractGroepVoter::AFMELDEN, $activiteit);
+	}
+
+	public function testAfmelden_aanmeldRechten()
+	{
+		$activiteit = new Activiteit();
+		$activiteit->setAanmeldenTot(date_create_immutable('+3 days'));
+		$activiteit->setAanmeldenVanaf(date_create_immutable('-2 days'));
+		$activiteit->setAanmeldRechten(AccountFixtures::UID_LID_VROUW);
+
+		$groepLid = new GroepLid();
+		$token = $this->getToken(AccountFixtures::UID_LID_MAN);
+		$groepLid->setProfiel($token->getUser()->profiel);
+		$activiteit->getLeden()->add($groepLid);
+
+		$this->assertGeenToegang($token, AbstractGroepVoter::AFMELDEN, $activiteit);
+	}
+}

--- a/tests/Voters/GroepVoterTest.php
+++ b/tests/Voters/GroepVoterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Voters;
+
+use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
+use CsrDelft\DataFixtures\AccountFixtures;
+use CsrDelft\entity\groepen\Commissie;
+use CsrDelft\tests\AbstractVoterTestCase;
+
+class GroepVoterTest extends AbstractVoterTestCase
+{
+	public function testCommissieAanmaken()
+	{
+		$commissie = new Commissie();
+		// Lid mag geen commissie maken
+		$this->assertGeenToegang(
+			$this->getToken(AccountFixtures::UID_LID_MAN),
+			AbstractGroepVoter::AANMAKEN,
+			$commissie
+		);
+		// Bestuur mag wel commissie maken
+		$this->assertToegang(
+			$this->getToken(AccountFixtures::UID_BESTUUR_FISCUS),
+			AbstractGroepVoter::AANMAKEN,
+			$commissie
+		);
+	}
+}

--- a/tests/lib/AbstractVoterTestCase.php
+++ b/tests/lib/AbstractVoterTestCase.php
@@ -39,14 +39,20 @@ abstract class AbstractVoterTestCase extends CsrTestCase
 		$this->adm = $this->getContainer()->get('security.access.decision_manager');
 	}
 
-	protected function assertToegang(UsernamePasswordToken $token, $permissie)
-	{
-		$this->assertTrue($this->adm->decide($token, [$permissie]));
+	protected function assertToegang(
+		UsernamePasswordToken $token,
+		$permissie,
+		$subject = null
+	) {
+		$this->assertTrue($this->adm->decide($token, [$permissie], $subject));
 	}
 
-	protected function assertGeenToegang(UsernamePasswordToken $token, $permissie)
-	{
-		$this->assertFalse($this->adm->decide($token, [$permissie]));
+	protected function assertGeenToegang(
+		UsernamePasswordToken $token,
+		$permissie,
+		$subject = null
+	) {
+		$this->assertFalse($this->adm->decide($token, [$permissie], $subject));
 	}
 
 	/**


### PR DESCRIPTION
Trek alle rechtenlogica uit de Groep gerelateerde entities en gebruik in plaats daarvan voters. Deze zijn makkelijker te gebruiken vanuit controllers.

## TODO

- [x] Oplossing verzinnen voor 'mag' check met soort
- [x] Oude logica eruit gooien
- [x] Testen