### PR TITLE
Voer push naar productie alleen op master uit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     # Deze workflow gebruikt een geheime token: PRODUCTIE_KEY en kan niet van een fork gerund worden.
-    if: github.repository == 'csrdelft/csrdelft.nl'
+    if: github.repository == 'csrdelft/csrdelft.nl' && github.ref == 'refs/heads/master'
 
     steps:
       - uses: actions/checkout@v3
@@ -176,7 +176,7 @@ jobs:
           path: productie/htdocs/dist
 
       - name: 📩 Push naar productie
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' # dubbel check
         working-directory: productie
         run: |
           git config user.name "PubCie"


### PR DESCRIPTION
Zorgt er op dit moment alleen maar voor dat externe builds falen
