### PR TITLE
Draft: Voeg ondersteuning toe voor devenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
+
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,8 @@ package-lock.json
 /phpunit.xml
 ###< symfony/phpunit-bridge ###
 csrdelft.nl.code-workspace
+
+# Devenv
+.devenv*
+devenv.local.nix
+

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,210 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1683102061,
+        "narHash": "sha256-kOphT6V0uQUlFNBP3GBjs7DAU7fyZGGqCs9ue1gNY6E=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "ff1f29e41756553174d596cafe3a9fa77595100b",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1683020768,
+        "narHash": "sha256-ZyZl6k9NWS5QPwD3NoAVz/eSgodQDvl+y+fu8MVbrHc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "44f30edf5661d86fb3a95841c35127f3d0ea8b0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "phps": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1682836446,
+        "narHash": "sha256-DgOq31R6Av+maPcLRM+u7RYUvpVRw3P8J+QiMOFmHmg=",
+        "owner": "fossar",
+        "repo": "nix-phps",
+        "rev": "47a8dd00449947caafc166a77a8c7bbef4b1e64a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fossar",
+        "repo": "nix-phps",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1682596858,
+        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "fb58866e20af98779017134319b5663b8215d912",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "phps": "phps",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,78 @@
+{ pkgs, config, ... }:
+
+{
+  # https://devenv.sh/basics/
+
+  # https://devenv.sh/packages/
+  packages = [ pkgs.yarn ];
+
+  # https://devenv.sh/scripts/
+  scripts.setup-yarn.exec = ''
+        	  set -e
+    				trap "exit 0" SIGTERM;
+        		yarn install;
+        		yarn watch;
+        		'';
+
+  # enterShell = ''
+  # '';
+
+  # https://devenv.sh/languages/
+  languages.php = {
+    enable = true;
+    version = "7.4";
+    fpm.pools.web = {
+      settings = {
+        "pm" = "dynamic";
+        "pm.max_children" = 5;
+        "pm.start_servers" = 2;
+        "pm.min_spare_servers" = 1;
+        "pm.max_spare_servers" = 5;
+      };
+    };
+  };
+
+  languages.javascript.enable = true;
+
+  # https://devenv.sh/pre-commit-hooks/
+  # pre-commit.hooks.shellcheck.enable = true;
+
+  # https://devenv.sh/processes/
+  # processes.ping.exec = "ping example.com";
+  processes = {
+    yarn.exec = "setup-yarn";
+    # Sleep infinity to prevent shutting down other processes
+    composer.exec = "composer install --ignore-platform-reqs && sleep infinity";
+  };
+
+  services.mysql = {
+    enable = true;
+    ensureUsers = [
+      {
+        name = "csrdelft";
+        ensurePermissions = {
+          "csrdelft.*" = "ALL PRIVILEGES";
+        };
+      }
+    ];
+    initialDatabases = [
+      { name = "csrdelft"; }
+    ];
+  };
+  env.DATABASE_URL = "mysql://csrdelft:bl44t@localhost:3306/csrdelft";
+
+  services.memcached.enable = true;
+  services.caddy = {
+    enable = true;
+    config = ''{
+			http_port 8000
+		}'';
+    virtualHosts."localhost:8000" = {
+      extraConfig = ''
+        root * htdocs
+        php_fastcgi unix/${config.languages.php.fpm.pools.web.socket}
+        file_server'';
+    };
+  };
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,8 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+  phps:
+    url: github:fossar/nix-phps
+    inputs:
+      nixpkgs:
+        follows: nixpkgs


### PR DESCRIPTION
Devenv (https://devenv.sh) is een manier om software lokaal te draaien. Het werkt op Linux/MacOS/WSL2. Het voordeel is dat je één command draait (`devenv up`) en daarmee de hele stek in een keer draaiende hebt. Als je dan `devenv shell` draait (terwijl je `devenv up` in de achtergrond hebt draaien), kun je met de mysql client de database dumps importeren.

Devenv installeren: https://devenv.sh/getting-started/

Ik ben benieuwd wat jullie ervan vinden. Het configureren bracht wel wat koppijn met zich mee (nix is ingewikkeld), maar het is wel zeer flexibel. Het grote voordeel is vooral dat de software automatisch gedownload word door nix zodat je zelf niets meer hoeft te installeren.

Nog een paar kleine problemen:
- php 7 zit niet in de binary cache van nix, daarom bouwt hij hem helemaal zelf. Als je dit niet wilt, kun je `cachix use fossar` gebruiken om ze te cachen, maar voor mij werkte dit niet.
- Ik weet niet of ik de webserver configuratie helemaal goed heb, devenv ondersteunt alleen caddy en geen apache2, dus er zullen bepaalde dingen misschien niet werken
- Ik weet ook niet of alle nodige PHP extensions zijn ingeschakeld, daar heb ik nog niet naar gekeken

Nog een paar TODOtjes voor mezelf:

- [ ] Documentatie toevoegen in /docs
- [ ] Caddy configuratie verbeteren