### PR TITLE
Fix de stormvloed aan deprecation errors

### DIFF
--- a/lib/view/Icon.php
+++ b/lib/view/Icon.php
@@ -119,17 +119,17 @@ class Icon
 		if (strpos($icon, 'fab fa-') !== false) {
 			return sprintf(
 				'<i class="%s %s %s" title="%s" aria-hidden="true"></i>',
-				htmlspecialchars($icon),
-				htmlspecialchars($hover),
-				htmlspecialchars($class),
+				htmlspecialchars($icon ?? ''),
+				htmlspecialchars($hover ?? ''),
+				htmlspecialchars($class ?? ''),
 				$titleSafe
 			);
 		} else {
 			return sprintf(
 				'<i class="fas fa-%s %s %s" title="%s" aria-hidden="true"></i>',
-				htmlspecialchars($icon),
-				htmlspecialchars($hover),
-				htmlspecialchars($class),
+				htmlspecialchars($icon ?? ''),
+				htmlspecialchars($hover ?? ''),
+				htmlspecialchars($class ?? ''),
 				$titleSafe
 			);
 		}


### PR DESCRIPTION
htmlspecialchars kan geen null meer aannemen, PHP 8 wordt super boos >:(
![image](https://github.com/csrdelft/csrdelft.nl/assets/36598276/eb55acb4-394b-4569-9206-e6944d42020f)

Elke request naar /corvee/beheer genereert 1MB aan logs