### PR TITLE
Voorkom Gala DDOS met standaard groepentab list ipv pasfoto's

### DIFF
--- a/lib/view/groepen/GroepenView.php
+++ b/lib/view/groepen/GroepenView.php
@@ -5,11 +5,13 @@ namespace CsrDelft\view\groepen;
 use CsrDelft\common\ContainerFacade;
 use CsrDelft\common\Enum;
 use CsrDelft\common\Security\Voter\Entity\Groep\AbstractGroepVoter;
+use CsrDelft\entity\groepen\enum\ActiviteitSoort;
 use CsrDelft\entity\groepen\enum\GroepTab;
 use CsrDelft\entity\groepen\Groep;
 use CsrDelft\entity\groepen\interfaces\HeeftSoort;
 use CsrDelft\entity\security\enum\AccessAction;
 use CsrDelft\repository\CmsPaginaRepository;
+use CsrDelft\repository\groepen\ActiviteitenRepository;
 use CsrDelft\repository\groepen\BesturenRepository;
 use CsrDelft\repository\GroepRepository;
 use CsrDelft\view\cms\CmsPaginaView;
@@ -48,7 +50,9 @@ class GroepenView implements View
 		callable $urlGetter = null,
 		private $geschiedenis = false
 	) {
-		if ($this->model instanceof BesturenRepository) {
+		// HACK: Voorkom gala DDOS door dies-activiteiten standaard als lijst te laten zien ipv profielfoto's
+		if ($this->model instanceof BesturenRepository
+			|| ($this->model instanceof ActiviteitenRepository && $this->soort === ActiviteitSoort::Dies())) {
 			$this->tab = GroepTab::Lijst;
 		} else {
 			$this->tab = GroepTab::Pasfotos;


### PR DESCRIPTION
Het is weer die tijd van het jaar, honderden leden staan klaar om zich in te ketzen voor het illustere diesgala. Terwijl zij hun browsertabbladen verversen in verwachting, kreunt de stek. Zij moet namelijk duizenden profielfoto's serveren. Door deze grote lading aan data die allemaal naar buiten geschoven moet worden, ervaren onze dierbare leden vertraging met het inketzen voor de mooiste activiteit van het jaar. Dit is natuurlijk onacceptabel.

Helaesch heeft ook de PubCie een grote last te verduren: zij moet constant de decennia aan technische schuld van de stek op haar nemen. Daarom deze vieze hack. Het is misschien niet perfect, maar hopelijk werkt het goed genoeg.

P.S. Weet iemand waarvoor de originele uitzondering voor besturen was?
	Ik zou geen reden kunnen bedenken, maar misschien ben ik daar nu in de
	vroege ochtend nog te nuchter voor.