### PR TITLE
Fix: Agenda item toevoegen

### DIFF
--- a/lib/entity/agenda/AgendaItem.php
+++ b/lib/entity/agenda/AgendaItem.php
@@ -34,21 +34,21 @@ class AgendaItem implements Agendeerbaar
 	#[ORM\Id]
 	#[ORM\Column(type: 'integer')]
 	#[ORM\GeneratedValue]
-	public int $item_id;
+	public $item_id;
 	#[ORM\Column(type: 'string')]
-	public string $titel;
+	public $titel;
 	#[ORM\Column(type: 'text', nullable: true)]
-	public ?string $beschrijving;
+	public $beschrijving;
 	#[ORM\Column(type: 'datetime')]
-	public DateTimeImmutable $begin_moment;
+	public $begin_moment;
 	#[ORM\Column(type: 'datetime')]
-	public DateTimeImmutable $eind_moment;
+	public $eind_moment;
 	#[ORM\Column(type: 'string')]
-	public string $rechten_bekijken;
+	public $rechten_bekijken;
 	#[ORM\Column(type: 'string', nullable: true)]
-	public ?string $locatie;
+	public $locatie;
 	#[ORM\Column(type: 'string', nullable: true)]
-	public ?string $link;
+	public $link;
 
 	public function getBeginMoment(): DateTimeImmutable
 	{


### PR DESCRIPTION
Vanwege de ontzettend gebeunde structuur van formulieren moeten we deze types weghalen. Anders kunnen we geen nieuwe agenda-items aanmaken.

De propere manier om dit op te lossen is om DTOs te gebruiken voor forms, maar dan kunnen we net zo goed de boel herschrijven naar Symfony forms