### PR TITLE
Herstructureer resized en thumbs

### DIFF
--- a/lib/defines.include.php
+++ b/lib/defines.include.php
@@ -34,6 +34,8 @@ define('VAR_PATH', BASE_PATH . 'var/');
 define('TMP_PATH', VAR_PATH . 'tmp/');
 define('PHOTOS_PATH', HTDOCS_PATH . 'plaetjes/');
 define('PHOTOALBUM_PATH', DATA_PATH . 'foto/fotoalbum/');
+define('RESIZED_PATH', DATA_PATH . 'foto/resized/');
+define('THUMBS_PATH', DATA_PATH . 'foto/thumbs/');
 define('PASFOTO_PATH', DATA_PATH . 'foto/pasfoto/');
 define('PLAATJES_PATH', DATA_PATH . 'plaatjes/');
 define('CONFIG_CACHE_PATH', VAR_PATH . 'config_cache/');

--- a/lib/entity/fotoalbum/Foto.php
+++ b/lib/entity/fotoalbum/Foto.php
@@ -91,9 +91,8 @@ class Foto extends Afbeelding
 	public function getThumbPath()
 	{
 		return PathUtil::join_paths(
-			PHOTOALBUM_PATH,
+			THUMBS_PATH,
 			$this->subdir,
-			self::THUMBS_DIR,
 			$this->filename
 		);
 	}
@@ -101,9 +100,8 @@ class Foto extends Afbeelding
 	public function getResizedPath()
 	{
 		return PathUtil::join_paths(
-			PHOTOALBUM_PATH,
+			RESIZED_PATH,
 			$this->subdir,
-			self::RESIZED_DIR,
 			$this->filename
 		);
 	}
@@ -164,9 +162,8 @@ class Foto extends Afbeelding
 	public function createThumb()
 	{
 		$path = PathUtil::join_paths(
-			PHOTOALBUM_PATH,
+			THUMBS_PATH,
 			$this->subdir,
-			self::THUMBS_DIR
 		);
 		if (!file_exists($path)) {
 			mkdir($path, 0755, true);
@@ -194,9 +191,8 @@ class Foto extends Afbeelding
 	public function createResized()
 	{
 		$path = PathUtil::join_paths(
-			PHOTOALBUM_PATH,
+			RESIZED_PATH,
 			$this->subdir,
-			self::RESIZED_DIR
 		);
 		if (!file_exists($path)) {
 			mkdir($path, 0755, true);


### PR DESCRIPTION
In plaats van resized en thumbs als een subfolder in het album op te slaan, doen we het nu in een kopie van de albumstructuur. Op dit moment werkt verwijderen/verplaatsen nog niet, maar dat wordt sowieso al handmatig gedaan. Fotoalbums moeten binnenkort toch helemaal gerefactord worden.

Deze structuur maakt het hosten van de volledige kwaliteit foto's op een network share van Confide mogelijk. Hiermee besparen we ontiegelijk veel opslag, de resized foto's nemen namelijk 20Gig op, terwijl het hele fotoalbum meer dan 300Gig is. Redelijk verschil dus