### PR TITLE
Mogelijke fix voor http500 bij editen van cms-pagina's

### DIFF
--- a/lib/view/bbcode/prosemirror/NodeBb.php
+++ b/lib/view/bbcode/prosemirror/NodeBb.php
@@ -28,7 +28,7 @@ class NodeBb implements Node
 
 		$contentString = implode(
 			'',
-			array_map(fn(BbString $string) => $string->getContent(), $content)
+			array_map(fn(BbNode $string) => $string->getContent(), $content)
 		);
 
 		return [


### PR DESCRIPTION
Zat een type declaration in een lambda die iets te strikt was (moest parent class zijn). Fixt hopelijk de http 500 errors die je nu krijgt als je (sommige) CMS-pagina's probeert te editen.